### PR TITLE
chore: remove unnecessary arc

### DIFF
--- a/core/src/routing/filter/impls/path.rs
+++ b/core/src/routing/filter/impls/path.rs
@@ -13,12 +13,10 @@ trait PathPart: Send + Sync + Debug {
     fn detect<'a>(&self, state: &mut PathState) -> bool;
 }
 
-type FnPartMap = Arc<
-    RwLock<
-        HashMap<
-            String,
-            Arc<Box<dyn Fn(&FnPart, &mut PathState) -> bool + Send + Sync + 'static>>,
-        >,
+type FnPartMap = RwLock<
+    HashMap<
+        String,
+        Arc<Box<dyn Fn(&FnPart, &mut PathState) -> bool + Send + Sync + 'static>>,
     >,
 >;
 static FN_PART_HANDLERS: Lazy<FnPartMap> = Lazy::new(|| {
@@ -28,7 +26,7 @@ static FN_PART_HANDLERS: Lazy<FnPartMap> = Lazy::new(|| {
     > = HashMap::with_capacity(8);
     map.insert("num".into(), Arc::new(Box::new(num_handler)));
     map.insert("nums".into(), Arc::new(Box::new(num_handler)));
-    Arc::new(RwLock::new(map))
+    RwLock::new(map)
 });
 
 fn num_handler(part: &FnPart, state: &mut PathState) -> bool {

--- a/examples/basic_auth.rs
+++ b/examples/basic_auth.rs
@@ -1,6 +1,6 @@
 use salvo::routing::Router;
 use salvo::Server;
-use salvo_extra::auth::basic::{BasicAuthConfig, BasicAuthHandler};
+use salvo_extra::basic_auth::{BasicAuthConfig, BasicAuthHandler};
 use salvo_extra::serve::StaticDir;
 
 #[tokio::main]

--- a/examples/sse_chat.rs
+++ b/examples/sse_chat.rs
@@ -7,7 +7,7 @@ use salvo::prelude::*;
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc, Mutex,
+    Mutex,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -23,7 +23,7 @@ static NEXT_USER_ID: AtomicUsize = AtomicUsize::new(1);
 ///
 /// - Key is their id
 /// - Value is a sender of `Message`
-type Users = Arc<Mutex<HashMap<usize, mpsc::UnboundedSender<Message>>>>;
+type Users = Mutex<HashMap<usize, mpsc::UnboundedSender<Message>>>;
 
 // Keep track of all connected users, key is usize, value
 // is an event stream sender.

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -119,15 +119,14 @@ pub async fn delete_todo(req: &mut Request, res: &mut Response) {
 
 mod models {
     use serde_derive::{Deserialize, Serialize};
-    use std::sync::Arc;
     use tokio::sync::Mutex;
 
     /// So we don't have to tackle how different database work, we'll just use
     /// a simple in-memory DB, a vector synchronized by a mutex.
-    pub type Db = Arc<Mutex<Vec<Todo>>>;
+    pub type Db = Mutex<Vec<Todo>>;
 
     pub fn blank_db() -> Db {
-        Arc::new(Mutex::new(Vec::new()))
+        Mutex::new(Vec::new())
     }
 
     #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
1. Global static variables do not need to be wrapped with Arc again
2. Fix module change cause ci fail

By the way, the project doesn’t seem to be formatted with [rustfmt](https://github.com/rust-lang/rustfmt), I’m not sure if you’re willing to do this, so I didn’t use it rashly either 