### PR TITLE
fix: allow single feature on extra

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 pub use salvo_core as core;
 pub use salvo_core::*;
 
-#[cfg(feature = "basic_auth")]
-#[cfg(feature = "jwt_auth")]
-#[cfg(feature = "compression")]
-#[cfg(feature = "proxy")]
-#[cfg(feature = "serve")]
-#[cfg(feature = "sse")]
-#[cfg(feature = "ws")]
-#[cfg(feature = "size_limiter")]
+#[cfg(any(
+    feature = "basic_auth",
+    feature = "jwt_auth",
+    feature = "compression",
+    feature = "proxy",
+    feature = "serve",
+    feature = "sse",
+    feature = "ws",
+    feature = "size_limiter"
+))]
 pub use salvo_extra as extra;


### PR DESCRIPTION
In the current code, if all features are not allowed, a single feature cannot be used