### PR TITLE
refactor: rewrite fs module on async way

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1"
 base64 = "0.13"
 bitflags = "1"
 bytes = "1"
-cookie = { version = "0.14", features = [ "percent-encode" ] }
+cookie = { version = "0.15", features = [ "percent-encode" ] }
 display_bytes = "0.2"
 double-checked-cell-async = "2"
 form_urlencoded = "1"
@@ -56,7 +56,7 @@ time = "0.2"
 tokio = { version = "1", features = [ "full" ] }
 tokio-rustls = { version = "0.22", optional = true }
 tracing = "0.1"
-tracing-futures= "0.2"
+tracing-futures = "0.2"
 twoway = "0.2"
 
 [dev-dependencies]

--- a/core/src/fs/mod.rs
+++ b/core/src/fs/mod.rs
@@ -1,13 +1,15 @@
 mod named_file;
 pub use named_file::*;
 
+use bytes::BytesMut;
 use futures::Stream;
-use hyper::body::Bytes;
-use std::fs::File;
-use std::io::{Read, Seek};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{cmp, io};
+use tokio::{
+    fs::File,
+    io::{AsyncRead, AsyncSeek},
+};
 
 pub struct FileChunk {
     chunk_size: u64,
@@ -16,33 +18,41 @@ pub struct FileChunk {
     offset: u64,
     file: File,
 }
+
 impl Stream for FileChunk {
-    type Item = Result<Bytes, io::Error>;
+    type Item = Result<BytesMut, io::Error>;
 
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let Self {
-            chunk_size,
-            ref mut read_size,
-            ref mut offset,
-            buffer_size,
-            ref mut file,
-        } = *self;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        if self.chunk_size == self.read_size {
+            return Poll::Ready(None);
+        }
 
-        if chunk_size == *read_size {
-            Poll::Ready(None)
-        } else {
-            let max_bytes: usize;
-            max_bytes = cmp::min(chunk_size.saturating_sub(*read_size), buffer_size) as usize;
-            let mut buf = Vec::with_capacity(max_bytes);
-            file.seek(io::SeekFrom::Start(*offset))?;
-            let nbytes = file.by_ref().take(max_bytes as u64).read_to_end(&mut buf)?;
-            if nbytes == 0 {
-                Poll::Ready(Some(Err(std::io::ErrorKind::UnexpectedEof.into())))
-            } else {
-                *offset += nbytes as u64;
-                *read_size += nbytes as u64;
-                Poll::Ready(Some(Ok(Bytes::from(buf))))
+        let max_bytes = cmp::min(self.chunk_size.saturating_sub(self.read_size), self.buffer_size) as usize;
+        let offset = self.offset;
+        Pin::new(&mut self.file).start_seek(io::SeekFrom::Start(offset))?;
+        let mut data = BytesMut::with_capacity(max_bytes);
+        // safety: it has max bytes capacity, and we don't read it
+        unsafe {
+            data.set_len(max_bytes);
+        }
+        // ReadBuf get a &mut [u8], so it cannot expand by itself, it can only read max_bytes at most
+        let mut buf = tokio::io::ReadBuf::new(data.as_mut());
+
+        match Pin::new(&mut self.file).poll_read(cx, &mut buf) {
+            Poll::Ready(Ok(())) => {
+                // we only read this size data from the file
+                let filled = max_bytes - buf.remaining();
+                if filled == max_bytes {
+                    Poll::Ready(Some(Err(std::io::ErrorKind::UnexpectedEof.into())))
+                } else {
+                    self.offset += filled as u64;
+                    self.read_size += filled as u64;
+                    data.truncate(filled);
+                    Poll::Ready(Some(Ok(data)))
+                }
             }
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
         }
     }
 }

--- a/extra/src/serve/dir.rs
+++ b/extra/src/serve/dir.rs
@@ -164,7 +164,7 @@ impl Handler for StaticDir {
                 for ifile in &self.options.defaults {
                     let ipath = path.join(ifile);
                     if ipath.exists() {
-                        if let Ok(named_file) = NamedFile::open(ipath) {
+                        if let Ok(named_file) = NamedFile::open(ipath).await {
                             named_file.write(req, depot, res).await;
                         } else {
                             res.set_http_error(InternalServerError().with_summary("file read error"));
@@ -190,7 +190,7 @@ impl Handler for StaticDir {
                     }
                 }
             } else if path.is_file() {
-                if let Ok(named_file) = NamedFile::open(path) {
+                if let Ok(named_file) = NamedFile::open(path).await {
                     named_file.write(req, depot, res).await;
                 } else {
                     res.set_http_error(InternalServerError().with_summary("file read error"));

--- a/extra/src/serve/fs.rs
+++ b/extra/src/serve/fs.rs
@@ -16,7 +16,7 @@ impl StaticFile {
 #[async_trait]
 impl Handler for StaticFile {
     async fn handle(&self, req: &mut Request, depot: &mut Depot, res: &mut Response) {
-        let named_file = NamedFile::open(self.0.clone().into());
+        let named_file = NamedFile::open(self.0.clone().into()).await;
         if named_file.is_err() {
             res.set_http_error(NotFound());
             return;


### PR DESCRIPTION
The previous fs used the sync method to operate in an async environment. During concurrent execution, it may be stuck in the executor thread and unable to respond to other requests. Now I rewrite all synchronous methods into asynchronous methods.

Sorry, API break on this PR.

Although tokio's fs relies on the blocking thread pool to perform tasks, this is the best solution at present. Regarding io_ring, firstly, it has too high requirements for the kernel version, and secondly, it is still under development. At present, [tokio-uring](https://github.com/tokio-rs/tokio-uring) is trying out, so we can keep paying attention.

If you need early access, you can take a look at this runtime: [glommio](https://github.com/DataDog/glommio)