### PR TITLE
chore: impl debug to depot

### DIFF
--- a/core/src/depot.rs
+++ b/core/src/depot.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt;
 
 pub struct Depot {
     data: HashMap<String, Box<dyn Any + Send>>,
@@ -84,5 +85,12 @@ impl Depot {
             data.insert(k, v);
         }
         Depot { data }
+    }
+}
+
+impl fmt::Debug for Depot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Depot")
+        .finish()
     }
 }


### PR DESCRIPTION
use `tracing::instrument` macro need all parameters can be debugged 

```
error[E0277]: `salvo::Depot` doesn't implement `std::fmt::Debug`
  --> src/web/visitor.rs:17:1
   |
17 | #[tracing::instrument]
   | ^^^^^^^^^^^^^^^^^^^^^^ `salvo::Depot` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
   |
   = help: the trait `std::fmt::Debug` is not implemented for `salvo::Depot`
   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&mut salvo::Depot`
   = note: 1 redundant requirements hidden
   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&&mut salvo::Depot`
   = note: required because of the requirements on the impl of `tracing::Value` for `tracing::field::DebugValue<&&mut salvo::Depot>`
   = note: required for the cast to the object type `dyn tracing::Value`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```