### PR TITLE
Avoid warning when errors

### DIFF
--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -176,7 +176,8 @@ impl HyperHandler {
                 if !is_allowed {
                     res.set_status_code(StatusCode::UNSUPPORTED_MEDIA_TYPE);
                 }
-            } else if req.body.is_none() { //avoid warning when errors (404 etc.)
+            } else if req.body.is_none() {
+                //avoid warning when errors (404 etc.)
                 tracing::warn!(
                     uri = ?req.uri(),
                     method = req.method().as_str(),

--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -176,7 +176,7 @@ impl HyperHandler {
                 if !is_allowed {
                     res.set_status_code(StatusCode::UNSUPPORTED_MEDIA_TYPE);
                 }
-            } else {
+            } else if req.body.is_none() { //avoid warning when errors (404 etc.)
                 tracing::warn!(
                     uri = ?req.uri(),
                     method = req.method().as_str(),


### PR DESCRIPTION
This warning is annoying when status code is error such as 404. And it cannot give correct information at that time.