### PR TITLE
chore: repalce tempdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![crates.io](https://img.shields.io/crates/v/salvo)](https://crates.io/crates/salvo)
 [![Documentation](https://docs.rs/salvo/badge.svg)](https://docs.rs/salvo)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
-[![Rust Version](https://img.shields.io/badge/rust-1.56%2B-blue)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![Rust Version](https://img.shields.io/badge/rust-1.59%2B-blue)](https://blog.rust-lang.org/2021/10/21/Rust-1.59.0.html)
 <br>
 [![codecov](https://codecov.io/gh/salvo-rs/salvo/branch/main/graph/badge.svg)](https://codecov.io/gh/salvo-rs/salvo)
 [![Download](https://img.shields.io/crates/d/salvo.svg)](https://crates.io/crates/salvo)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,7 +59,7 @@ rustls-pemfile = { version = "1.0", optional = true }
 salvo_macros = { version = "0.21", path = "../macros" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tempdir = "0.3"
+tempfile = "3"
 textnonce = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,7 +45,6 @@ mime = "0.3"
 mime_guess = "2"
 multer = "2"
 multimap = { version = "0.8", features = ["serde"] }
-num_cpus = "1"
 once_cell = "1"
 parking_lot = "0.12.0"
 percent-encoding = "2"

--- a/core/src/http/form.rs
+++ b/core/src/http/form.rs
@@ -4,7 +4,7 @@ use multer::{Field, Multipart};
 use multimap::MultiMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use tempfile::TempDir;
+use tempfile::Builder;
 use textnonce::TextNonce;
 use tokio::{fs::File, io::AsyncWriteExt};
 
@@ -91,7 +91,7 @@ impl FilePart {
     /// deleted once the FilePart object goes out of scope).
     pub async fn create(field: &mut Field<'_>) -> Result<FilePart, ParseError> {
         // Setup a file to capture the contents.
-        let mut path = tokio::task::spawn_blocking(|| TempDir::new_in("salvo_http_multipart"))
+        let mut path = tokio::task::spawn_blocking(|| Builder::new().prefix("salvo_http_multipart").tempdir())
             .await
             .expect("Runtime spawn blocking poll error")?
             .into_path();

--- a/core/src/http/form.rs
+++ b/core/src/http/form.rs
@@ -4,7 +4,7 @@ use multer::{Field, Multipart};
 use multimap::MultiMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use textnonce::TextNonce;
 use tokio::{fs::File, io::AsyncWriteExt};
 
@@ -91,7 +91,7 @@ impl FilePart {
     /// deleted once the FilePart object goes out of scope).
     pub async fn create(field: &mut Field<'_>) -> Result<FilePart, ParseError> {
         // Setup a file to capture the contents.
-        let mut path = tokio::task::spawn_blocking(|| TempDir::new("salvo_http_multipart"))
+        let mut path = tokio::task::spawn_blocking(|| TempDir::new_in("salvo_http_multipart"))
             .await
             .expect("Runtime spawn blocking poll error")?
             .into_path();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,7 +64,7 @@ pub mod prelude {
     pub use salvo_macros::fn_handler;
 }
 
-use std::future::Future;
+use std::{future::Future, thread::available_parallelism};
 use tokio::runtime::{self, Runtime};
 
 fn new_runtime(threads: usize) -> Runtime {
@@ -92,7 +92,7 @@ fn new_runtime(threads: usize) -> Runtime {
 /// }
 /// ```
 pub fn run<F: Future>(future: F) {
-    run_with_threads(future, num_cpus::get())
+    run_with_threads(future, available_parallelism().map(|n| n.get()).unwrap_or(1))
 }
 
 /// If you don't want to include tokio in your project directly,


### PR DESCRIPTION
`tempdir` is archived and merged into [tempfile](https://github.com/Stebalien/tempfile)

if rust minimum supported version upgrade to 1.59.0, we can use [available_parallelism](https://doc.rust-lang.org/nightly/std/thread/fn.available_parallelism.html) instead of `num_cpus` crate