### PR TITLE
FlowCtrl call logic error

### DIFF
--- a/core/src/routing/mod.rs
+++ b/core/src/routing/mod.rs
@@ -92,6 +92,9 @@ impl FlowCtrl {
         if let Some(handler) = self.handlers.get(self.cursor) {
             self.cursor += 1;
             handler.clone().handle(req, depot, res, self).await;
+            if self.has_next() {
+                self.call_next(req, depot, res).await;
+            }
             true
         } else {
             false

--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -200,11 +200,7 @@ impl HyperHandler {
             if let Some(dm) = router.detect(&mut req, &mut path_state) {
                 req.params = path_state.params;
                 let mut ctrl = FlowCtrl::new([&dm.hoops[..], &[dm.handler]].concat());
-                while ctrl.has_next() {
-                    if !ctrl.call_next(&mut req, &mut depot, &mut res).await {
-                        break;
-                    }
-                }
+                ctrl.call_next(&mut req, &mut depot, &mut res).await;
             } else {
                 res.set_status_code(StatusCode::NOT_FOUND);
             }

--- a/examples/middleware-add-header/src/main.rs
+++ b/examples/middleware-add-header/src/main.rs
@@ -7,7 +7,7 @@ async fn hello_world() -> &'static str {
 }
 
 #[fn_handler]
-async fn add_header(res: &mut Response, ctrl: &mut FlowCtrl) {
+async fn add_header(res: &mut Response) {
     res.headers_mut()
         .insert(header::SERVER, HeaderValue::from_static("Salvo"));
 }

--- a/examples/middleware-add-header/src/main.rs
+++ b/examples/middleware-add-header/src/main.rs
@@ -7,7 +7,7 @@ async fn hello_world() -> &'static str {
 }
 
 #[fn_handler]
-async fn add_header(res: &mut Response) {
+async fn add_header(res: &mut Response, ctrl: &mut FlowCtrl) {
     res.headers_mut()
         .insert(header::SERVER, HeaderValue::from_static("Salvo"));
 }


### PR DESCRIPTION
感觉这是一个比较隐晦的 bug, 比如说， 有一个计算执行用时的 middleware, 如果是之前的逻辑， 如果后续某个 middleware 没有调用 ctrl.call_next, 那计算耗时的这个 middleware 就会提前返回， 后续没被执行的 middleware 由 service 中的 ctrl.call_next 调用， 但是已经无法正确计算时间了。