### PR TITLE
Fix typo in doc

### DIFF
--- a/core/src/routing/filter/mod.rs
+++ b/core/src/routing/filter/mod.rs
@@ -126,7 +126,7 @@ pub fn options() -> MethodFilter {
 pub fn post() -> MethodFilter {
     MethodFilter(Method::POST)
 }
-/// Filter request, only allow path method.
+/// Filter request, only allow patch method.
 #[inline]
 pub fn patch() -> MethodFilter {
     MethodFilter(Method::PATCH)


### PR DESCRIPTION
- Change "allow path method" to "allow patch method" in `filter::patch` documentation