### PR TITLE
Remove parking_lot, use std::sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ native-tls = "0.2"
 once_cell = "1.17"
 openssl = "0.10"
 path-slash = "0.2"
-parking_lot = "0.12"
 percent-encoding = "2"
 pin-project = "1"
 quinn = { version = "0.8"}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,7 +54,6 @@ mime_guess.workspace = true
 multer.workspace = true
 multimap = { workspace = true, features = ["serde"] }
 once_cell.workspace = true
-parking_lot.workspace = true
 percent-encoding.workspace = true
 pin-project = { workspace = true }
 quinn = { workspace = true, optional = true, features = ["tls-rustls", "ring"] }

--- a/crates/core/src/conn/acme/config.rs
+++ b/crates/core/src/conn/acme/config.rs
@@ -2,11 +2,10 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{RwLock, Arc};
 use std::time::Duration;
 
 use http::Uri;
-use parking_lot::RwLock;
 
 use super::key_pair::KeyPair;
 use super::{ChallengeType, LETS_ENCRYPT_PRODUCTION};

--- a/crates/core/src/conn/acme/mod.rs
+++ b/crates/core/src/conn/acme/mod.rs
@@ -68,10 +68,9 @@ mod resolver;
 
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
+use std::sync::{RwLock, Arc};
 
 use client::AcmeClient;
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 use crate::http::StatusError;

--- a/crates/core/src/conn/acme/resolver.rs
+++ b/crates/core/src/conn/acme/resolver.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use parking_lot::RwLock;
 use tokio_rustls::rustls::server::{ClientHello, ResolvesServerCert};
 use tokio_rustls::rustls::sign::CertifiedKey;
 use x509_parser::prelude::{FromDer, X509Certificate};

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt::{self, Formatter};
+use std::sync::RwLock;
 
 #[cfg(feature = "cookie")]
 use cookie::{Cookie, CookieJar};
@@ -14,7 +15,6 @@ use http_body_util::{BodyExt, Limited};
 use mime;
 use multimap::MultiMap;
 use once_cell::sync::OnceCell;
-use parking_lot::RwLock;
 use serde::de::Deserialize;
 
 use crate::conn::SocketAddr;
@@ -29,12 +29,12 @@ static SECURE_MAX_SIZE: RwLock<usize> = RwLock::new(64 * 1024);
 
 /// Get default secure max size.
 pub fn secure_max_size() -> usize {
-    *SECURE_MAX_SIZE.read()
+    *SECURE_MAX_SIZE.read().unwrap()
 }
 
 /// Set default secure max size globally.
 pub fn set_secure_max_size(size: usize) {
-    let mut lock = SECURE_MAX_SIZE.write();
+    let mut lock = SECURE_MAX_SIZE.write().unwrap();
     *lock = size;
 }
 

--- a/crates/core/src/routing/filter/path.rs
+++ b/crates/core/src/routing/filter/path.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use std::fmt::{self, Formatter};
-use std::sync::Arc;
+use std::sync::{RwLock, Arc};
 
 use once_cell::sync::Lazy;
-use parking_lot::RwLock;
 use regex::Regex;
 
 use crate::http::Request;
@@ -522,7 +521,7 @@ impl PathParser {
                                 self.offset
                             ));
                         };
-                        let builders = WISP_BUILDERS.read();
+                        let builders = WISP_BUILDERS.read().unwrap();
                         let builder = builders
                             .get(&sign)
                             .ok_or_else(|| format!("WISP_BUILDERS does not contains fn part with sign {sign}"))?
@@ -654,13 +653,13 @@ impl PathFilter {
     where
         B: WispBuilder + 'static,
     {
-        let mut builders = WISP_BUILDERS.write();
+        let mut builders = WISP_BUILDERS.write().unwrap();
         builders.insert(name.into(), Arc::new(Box::new(builder)));
     }
     /// Register new path part regex.
     #[inline]
     pub fn register_wisp_regex(name: impl Into<String>, regex: Regex) {
-        let mut builders = WISP_BUILDERS.write();
+        let mut builders = WISP_BUILDERS.write().unwrap();
         builders.insert(name.into(), Arc::new(Box::new(RegexWispBuilder::new(regex))));
     }
     /// Detect is that path is match.

--- a/crates/core/src/routing/filter/path.rs
+++ b/crates/core/src/routing/filter/path.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::{self, Formatter};
-use std::sync::{RwLock, Arc};
+use std::sync::{Arc, RwLock};
 
 use once_cell::sync::Lazy;
 use regex::Regex;


### PR DESCRIPTION
`std::sync::RwLock` is more general and in most cases it not slow.
https://users.rust-lang.org/t/which-mutex-to-use-parking-lot-or-std-sync/85060/5