### PR TITLE
fix：repair openapi error description of attrs

### DIFF
--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -23,7 +23,7 @@ pub(crate) struct EndpointAttr<'p> {
 impl Parse for EndpointAttr<'_> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected identifier, expected any of: operation_id, request_body, responses, parameters, tag, security";
+            "unexpected identifier, expected any of: operation_id, request_body, responses, parameters, tags, security";
         let mut attr = EndpointAttr::default();
 
         while !input.is_empty() {


### PR DESCRIPTION
修复endpoint宏attr拼写错误后，报的提示中tag少加一个s