### PR TITLE
tests: add test case for openapi/tag and openapi/xml

### DIFF
--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -169,8 +169,7 @@ macro_rules! impl_to_schema_primitive {
 pub mod oapi {
     pub use super::*;
 }
-// Create `salvo-oapi` module so we can use `salvo-oapi-macros` directly
-// from `salvo-oapi` crate. ONLY FOR INTERNAL USE!
+
 #[doc(hidden)]
 pub mod __private {
     pub use inventory;

--- a/crates/oapi/src/openapi/tag.rs
+++ b/crates/oapi/src/openapi/tag.rs
@@ -84,3 +84,56 @@ impl Tag {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Tag;
+    use super::ExternalDocs;
+
+    #[test]
+    fn tag_new() {
+        let tag = Tag::new("tag name");
+        assert_eq!(tag.name, "tag name");
+        assert!(tag.description.is_none());
+        assert!(tag.external_docs.is_none());
+        assert!(tag.extensions.is_none());
+
+        let tag = tag.name("new tag name");
+        assert_eq!(tag.name, "new tag name");
+
+        let tag = tag.description("description");
+        assert!(tag.description.is_some());
+
+        let tag = tag.external_docs(ExternalDocs::new(""));
+        assert!(tag.external_docs.is_some());
+    }
+
+    #[test]
+    fn from_string() {
+        let name = "tag name".to_string();
+        let tag = Tag::from(name);
+        assert_eq!(tag.name, "tag name".to_string());
+    }
+
+    #[test]
+    fn from_string_ref() {
+        let name = "tag name".to_string();
+        let tag = Tag::from(&name);
+        assert_eq!(tag.name, "tag name".to_string());
+    }
+
+    #[test]
+    fn from_str() {
+        let name = "tag name";
+        let tag = Tag::from(name);
+        assert_eq!(tag.name, "tag name");
+    }
+
+    #[test]
+    fn cmp() {
+        let tag1 = Tag::new("a");
+        let tag2 = Tag::new("b");
+
+        assert!(tag1 < tag2);
+    }
+}

--- a/crates/oapi/src/openapi/xml.rs
+++ b/crates/oapi/src/openapi/xml.rs
@@ -95,12 +95,27 @@ mod tests {
 
     #[test]
     fn xml_new() {
-        let xml = Xml::new();
+        let mut xml = Xml::new();
 
         assert!(xml.name.is_none());
         assert!(xml.namespace.is_none());
         assert!(xml.prefix.is_none());
         assert!(xml.attribute.is_none());
         assert!(xml.wrapped.is_none());
+
+        xml = xml.name("name");
+        assert!(xml.name.is_some());
+
+        xml = xml.namespace("namespave");
+        assert!(xml.namespace.is_some());
+
+        xml = xml.prefix("prefix");
+        assert!(xml.prefix.is_some());
+
+        xml = xml.attribute(true);
+        assert!(xml.attribute.is_some());
+
+        xml = xml.wrapped(true);
+        assert!(xml.wrapped.is_some());
     }
 }


### PR DESCRIPTION
1. Remove duplicated comment.
2. Add test case for `openapi/tag.rs` and `openapi/xml.rs`