### PR TITLE
tests: add testcases for `openapi/response` && `openapi/request_body` && `openapi/example`

### DIFF
--- a/crates/oapi/src/openapi/example.rs
+++ b/crates/oapi/src/openapi/example.rs
@@ -76,3 +76,30 @@ impl Example {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_example() {
+        let example = Example::new();
+        assert!(example.summary.is_empty());
+        assert!(example.description.is_empty());
+        assert!(example.value.is_none());
+        assert!(example.external_value.is_empty());
+
+        let example = example.summary("summary");
+        assert!(example.summary == "summary");
+
+        let example = example.description("description");
+        assert!(example.description == "description");
+
+        let example = example.external_value("external_value");
+        assert!(example.external_value == "external_value");
+
+        let example = example.value(serde_json::Value::String("value".to_string()));
+        assert!(example.value.is_some());
+        assert!(example.value.unwrap() == serde_json::Value::String("value".to_string()));
+    }
+}

--- a/crates/oapi/src/openapi/request_body.rs
+++ b/crates/oapi/src/openapi/request_body.rs
@@ -93,8 +93,7 @@ mod tests {
                 "application/json",
                 Content::new(crate::Ref::from_schema_name("EmailPayload")),
             );
-        let serialized = serde_json::to_string_pretty(&request_body)?;
-        println!("serialized json:\n {serialized}");
+
         assert_json_eq!(
             request_body,
             json!({
@@ -110,5 +109,33 @@ mod tests {
             })
         );
         Ok(())
+    }
+
+    #[test]
+    fn request_body_merge() {
+        let mut request_body = RequestBody::new();
+        let other_request_body = RequestBody::new()
+            .description("Merged requestBody")
+            .required(Required::True)
+            .add_content(
+                "application/json",
+                Content::new(crate::Ref::from_schema_name("EmailPayload")),
+            );
+
+        request_body.merge(other_request_body);
+        assert_json_eq!(
+            request_body,
+            json!({
+              "description": "Merged requestBody",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EmailPayload"
+                  }
+                }
+              },
+              "required": true
+            })
+        );
     }
 }

--- a/crates/oapi/src/openapi/response.rs
+++ b/crates/oapi/src/openapi/response.rs
@@ -203,7 +203,7 @@ mod tests {
             .description("A sample response description")
             .add_content(
                 "application/json",
-                Content::new(crate::Ref::from_schema_name("MySchemaPayload")),
+                Content::new(Ref::from_schema_name("MySchemaPayload")),
             )
             .add_header("content-type", Header::default().description("application/json"));
 


### PR DESCRIPTION
1. `./crates/oapi/src/openapi/example.rs` 100%
2. `./crates/oapi/src/openapi/request_body.rs` 100%
3. `./crates/oapi/src/openapi/response.rs` 95.35% 