### PR TITLE
tests: add testcases for `openapi/content` && `openapi/encoding`

### DIFF
--- a/crates/oapi/src/openapi/content.rs
+++ b/crates/oapi/src/openapi/content.rs
@@ -101,3 +101,70 @@ impl From<RefOr<Schema>> for Content {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::{json, Map};
+
+    use super::*;
+
+    #[test]
+    fn test_build_content() {
+        let content = Content::new(RefOr::Ref(crate::Ref::from_schema_name("MySchema")))
+            .example(Value::Object(Map::from_iter([(
+                "schema".into(),
+                Value::String("MySchema".to_string()),
+            )])))
+            .encoding("schema".to_string(), Encoding::default().content_type("text/plain"));
+        assert_json_eq!(
+            content,
+            json!({
+              "schema": {
+                "$ref": "#/components/schemas/MySchema"
+              },
+              "example": {
+                "schema": "MySchema"
+              },
+              "encoding": {
+                  "schema": {
+                    "contentType": "text/plain"
+                  }
+              }
+            })
+        );
+
+        let content = content
+            .schema(RefOr::Ref(crate::Ref::from_schema_name("NewSchema")))
+            .extend_examples([(
+                "example1".to_string(),
+                Example::new().value(Value::Object(Map::from_iter([(
+                    "schema".into(),
+                    Value::String("MySchema".to_string()),
+                )]))),
+            )]);
+        assert_json_eq!(
+            content,
+            json!({
+              "schema": {
+                "$ref": "#/components/schemas/NewSchema"
+              },
+              "example": {
+                "schema": "MySchema"
+              },
+              "examples": {
+                "example1": {
+                  "value": {
+                    "schema": "MySchema"
+                  }
+                }
+              },
+              "encoding": {
+                  "schema": {
+                    "contentType": "text/plain"
+                  }
+              }
+            })
+        );
+    }
+}

--- a/crates/oapi/src/openapi/encoding.rs
+++ b/crates/oapi/src/openapi/encoding.rs
@@ -82,3 +82,43 @@ impl Encoding {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    #[test]
+    fn test_encoding_default() {
+        let encoding = Encoding::default();
+        assert_json_eq!(encoding, json!({}));
+    }
+
+    #[test]
+    fn test_build_encoding() {
+        let encoding = Encoding::default()
+            .content_type("application/json")
+            .header("header1", Header::default())
+            .style(ParameterStyle::Simple)
+            .explode(true)
+            .allow_reserved(false);
+
+        assert_json_eq!(
+            encoding,
+            json!({
+              "contentType": "application/json",
+              "headers": {
+                "header1": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              },
+              "style": "simple",
+              "explode": true,
+              "allowReserved": false
+            })
+        );
+    }
+}

--- a/crates/oapi/src/openapi/schema/mod.rs
+++ b/crates/oapi/src/openapi/schema/mod.rs
@@ -549,8 +549,10 @@ mod tests {
                         .required("name"),
                 ),
             )])
+            .response("204", Response::new("No Content"))
             .extend_responses(vec![("200", Response::new("Okay"))])
-            .add_security_scheme("TLS", SecurityScheme::MutualTls { description: None });
+            .add_security_scheme("TLS", SecurityScheme::MutualTls { description: None })
+            .extend_security_schemes(vec![("APIKey", SecurityScheme::Http(security::Http::default()))]);
 
         let serialized_components = serde_json::to_string(&components).unwrap();
 


### PR DESCRIPTION
1. `crates/oapi/src/openapi/content.rs` 94.44%
2. `crates/oapi/src/openapi/encoding.rs` 100.00%