### PR TITLE
tests: add testcases for openapi mods

### DIFF
--- a/crates/oapi/src/openapi/external_docs.rs
+++ b/crates/oapi/src/openapi/external_docs.rs
@@ -59,7 +59,9 @@ mod tests {
     #[test]
     fn test_build_external_docs() {
         let external_docs = ExternalDocs::default();
-        let external_docs_with_url = external_docs.url("https://pet-api.external.docs").description("description");
+        let external_docs_with_url = external_docs
+            .url("https://pet-api.external.docs")
+            .description("description");
 
         assert_eq!(external_docs_with_url.url, "https://pet-api.external.docs");
         assert_eq!(external_docs_with_url.description, Some("description".to_string()));

--- a/crates/oapi/src/openapi/external_docs.rs
+++ b/crates/oapi/src/openapi/external_docs.rs
@@ -44,3 +44,24 @@ impl ExternalDocs {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_external_docs() {
+        let external_docs = ExternalDocs::default();
+        assert_eq!(external_docs.url, "");
+        assert_eq!(external_docs.description, None);
+    }
+
+    #[test]
+    fn test_build_external_docs() {
+        let external_docs = ExternalDocs::default();
+        let external_docs_with_url = external_docs.url("https://pet-api.external.docs").description("description");
+
+        assert_eq!(external_docs_with_url.url, "https://pet-api.external.docs");
+        assert_eq!(external_docs_with_url.description, Some("description".to_string()));
+    }
+}

--- a/crates/oapi/src/openapi/header.rs
+++ b/crates/oapi/src/openapi/header.rs
@@ -64,3 +64,35 @@ impl Default for Header {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_build_header() {
+        let header = Header::new(Object::with_type(SchemaType::String));
+        assert_json_eq!(
+            header,
+            json!({
+                "schema": {
+                    "type": "string"
+                }
+            })
+        );
+
+        let header = header.description("test description").schema(Object::with_type(SchemaType::Number));
+        assert_json_eq!(
+            header,
+            json!({
+                "description": "test description",
+                "schema": {
+                    "type": "number"
+                }
+            })
+        );
+    }
+}

--- a/crates/oapi/src/openapi/header.rs
+++ b/crates/oapi/src/openapi/header.rs
@@ -84,7 +84,9 @@ mod tests {
             })
         );
 
-        let header = header.description("test description").schema(Object::with_type(SchemaType::Number));
+        let header = header
+            .description("test description")
+            .schema(Object::with_type(SchemaType::Number));
         assert_json_eq!(
             header,
             json!({

--- a/crates/oapi/src/openapi/info.rs
+++ b/crates/oapi/src/openapi/info.rs
@@ -219,7 +219,10 @@ mod tests {
         assert!(contact.url.is_none());
         assert!(contact.email.is_none());
 
-        let contact = contact.name("salvo api").url("https://github.com/salvo-rs/salvo").email("salvo.rs@some.mail.com");
+        let contact = contact
+            .name("salvo api")
+            .url("https://github.com/salvo-rs/salvo")
+            .email("salvo.rs@some.mail.com");
         assert_json_eq!(
             contact,
             json!({

--- a/crates/oapi/src/openapi/info.rs
+++ b/crates/oapi/src/openapi/info.rs
@@ -204,14 +204,38 @@ impl License {
 
 #[cfg(test)]
 mod tests {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    use crate::License;
+
     use super::Contact;
 
     #[test]
-    fn contact_new() {
+    fn build_contact() {
         let contact = Contact::new();
 
         assert!(contact.name.is_none());
         assert!(contact.url.is_none());
         assert!(contact.email.is_none());
+
+        let contact = contact.name("salvo api").url("https://github.com/salvo-rs/salvo").email("salvo.rs@some.mail.com");
+        assert_json_eq!(
+            contact,
+            json!({
+                "name": "salvo api",
+                "url": "https://github.com/salvo-rs/salvo",
+                "email": "salvo.rs@some.mail.com"
+            })
+        );
+    }
+
+    #[test]
+    fn test_license_set_name() {
+        let license = License::default();
+        assert!(license.name.is_empty());
+
+        let license = license.name("MIT");
+        assert_json_eq!(license, json!({ "name": "MIT" }));
     }
 }

--- a/crates/oapi/src/openapi/mod.rs
+++ b/crates/oapi/src/openapi/mod.rs
@@ -628,14 +628,20 @@ mod tests {
                 "name": "MIT",
                 "url": "http://mit.licence"
               },
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "contact": {},
+              "termsOfService": "terms of service"
             },
             "paths": {}
           }"#;
         let doc: OpenApi = OpenApi::with_info(
-            Info::new("My api", "1.0.0")
+            Info::default()
                 .description("My api description")
-                .license(License::new("MIT").url("http://mit.licence")),
+                .license(License::new("MIT").url("http://mit.licence"))
+                .title("My api")
+                .version("1.0.0")
+                .terms_of_service("terms of service")
+                .contact(Contact::default()),
         );
         let serialized = doc.to_json()?;
 


### PR DESCRIPTION
1. `openapi/external_docs.rs` 100%.
2. `openapi/header.rs` 100%.
3. `openapi/info.rs` 100%.