### PR TITLE
tests: add testcases for `openapi/mod.rs`

### DIFF
--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -577,7 +577,7 @@ impl Request {
         })
     }
     /// Get mutable queries reference.
-    pub fn queries_mut(&mut self) -> &MultiMap<String, String> {
+    pub fn queries_mut(&mut self) -> &mut MultiMap<String, String> {
         let _ = self.queries();
         self.queries.get_mut().unwrap()
     }


### PR DESCRIPTION
1. `crates/oapi/src/openapi/mod.rs` 95.54%.
2. Fix `Request::queries_mut()`returns an unmutable reference.