### PR TITLE
Add testcases for `crates/oapi/src/extract/parameter/*.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cobertura.xml
 debug.log
 **/temp
 tarpaulin-report.*
+*.profraw
 examples/*/.env.local
 examples/**/package-lock.json
 examples/**/pnpm-lock.yaml

--- a/crates/oapi/Cargo.toml
+++ b/crates/oapi/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = ["salvo-oapi-macros/indexmap"]
 yaml = ["dep:serde_yaml"]
 
 [dependencies]
-salvo_core = { workspace = true, default-features = false, features = ["cookie"] }
+salvo_core = { workspace = true, default-features = false, features = ["cookie", "test"] }
 salvo-oapi-macros = { workspace = true, default-features = false }
 base64 = { workspace = true }
 thiserror = { workspace = true }
@@ -46,6 +46,7 @@ serde_json = { workspace = true }
 regex = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+http = { workspace = true }
 
 # Feature optional dependencies
 chrono = { workspace = true, optional = true }

--- a/crates/oapi/src/extract/parameter/cookie.rs
+++ b/crates/oapi/src/extract/parameter/cookie.rs
@@ -140,6 +140,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use assert_json_diff::assert_json_eq;
+    use http::header::HeaderValue;
+    use salvo_core::test::TestClient;
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -161,19 +166,19 @@ mod tests {
     }
 
     #[test]
-    fn test_unrequired_cookie_param_into_inner() {
+    fn test_cookie_param_into_inner() {
         let param = CookieParam::<String, false>(Some("param".to_string()));
         assert_eq!(Some("param".to_string()), param.into_inner());
     }
 
     #[test]
-    fn test_unrequired_cookie_param_deref() {
+    fn test_cookie_param_deref() {
         let param = CookieParam::<String, false>(Some("param".to_string()));
         assert_eq!(&Some("param".to_string()), param.deref())
     }
 
     #[test]
-    fn test_unrequired_cookie_param_deref_mut() {
+    fn test_cookie_param_deref_mut() {
         let mut param = CookieParam::<String, false>(Some("param".to_string()));
         assert_eq!(&mut Some("param".to_string()), param.deref_mut())
     }
@@ -194,5 +199,98 @@ mod tests {
     fn test_cookie_param_display() {
         let param = CookieParam::<String, true>(Some("param".to_string()));
         assert_eq!(format!("{}", param), "param");
+    }
+
+    #[test]
+    fn test_required_cookie_param_metadata() {
+        let metadata = CookieParam::<String, true>::metadata();
+        assert_eq!("", metadata.name);
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_required_cookie_prarm_extract() {
+        let mut req = Request::new();
+        let _ = CookieParam::<String, true>::extract(&mut req).await;
+    }
+
+    #[tokio::test]
+    async fn test_required_cookie_prarm_extract_with_value() {
+        let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
+        req.headers_mut()
+            .append("cookie", HeaderValue::from_static("param=param"));
+        let schema = req.uri().scheme().cloned().unwrap();
+        let mut req = Request::from_hyper(req, schema);
+        let result = CookieParam::<String, true>::extract_with_arg(&mut req, "param").await;
+        assert_eq!(result.unwrap().0.unwrap(), "param");
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_required_cookie_prarm_extract_with_value_panic() {
+        let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
+        let schema = req.uri().scheme().cloned().unwrap();
+        let mut req = Request::from_hyper(req, schema);
+        let result = CookieParam::<String, true>::extract_with_arg(&mut req, "param").await;
+        assert_eq!(result.unwrap().0.unwrap(), "param");
+    }
+
+    #[test]
+    fn test_cookie_param_metadata() {
+        let metadata = CookieParam::<String, false>::metadata();
+        assert_eq!("", metadata.name);
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_cookie_prarm_extract() {
+        let mut req = Request::new();
+        let _ = CookieParam::<String, false>::extract(&mut req).await;
+    }
+
+    #[tokio::test]
+    async fn test_cookie_prarm_extract_with_value() {
+        let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
+        req.headers_mut()
+            .append("cookie", HeaderValue::from_static("param=param"));
+        let schema = req.uri().scheme().cloned().unwrap();
+        let mut req = Request::from_hyper(req, schema);
+        let result = CookieParam::<String, false>::extract_with_arg(&mut req, "param").await;
+        assert_eq!(result.unwrap().0.unwrap(), "param");
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_cookie_prarm_extract_with_value_panic() {
+        let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
+        let schema = req.uri().scheme().cloned().unwrap();
+        let mut req = Request::from_hyper(req, schema);
+        let result = CookieParam::<String, false>::extract_with_arg(&mut req, "param").await;
+        assert_eq!(result.unwrap().0.unwrap(), "param");
+    }
+
+    #[test]
+    fn test_cookie_param_register() {
+        let mut components = Components::new();
+        let mut operation = Operation::new();
+        CookieParam::<String, false>::register(&mut components, &mut operation, "arg");
+
+        assert_json_eq!(
+            operation,
+            json!({
+                "parameters": [
+                    {
+                        "name": "arg",
+                        "in": "cookie",
+                        "description": "Get parameter `arg` from request cookie.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {}
+            })
+        )
     }
 }

--- a/crates/oapi/src/extract/parameter/cookie.rs
+++ b/crates/oapi/src/extract/parameter/cookie.rs
@@ -137,3 +137,62 @@ where
         operation.parameters.insert(parameter);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_required_cookie_param_into_inner() {
+        let param = CookieParam::<String, true>(Some("param".to_string()));
+        assert_eq!("param".to_string(), param.into_inner());
+    }
+
+    #[test]
+    fn test_required_cookie_param_deref() {
+        let param = CookieParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&"param".to_string(), param.deref())
+    }
+
+    #[test]
+    fn test_required_cookie_param_deref_mut() {
+        let mut param = CookieParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&mut "param".to_string(), param.deref_mut())
+    }
+
+    #[test]
+    fn test_unrequired_cookie_param_into_inner() {
+        let param = CookieParam::<String, false>(Some("param".to_string()));
+        assert_eq!(Some("param".to_string()), param.into_inner());
+    }
+
+    #[test]
+    fn test_unrequired_cookie_param_deref() {
+        let param = CookieParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&Some("param".to_string()), param.deref())
+    }
+
+    #[test]
+    fn test_unrequired_cookie_param_deref_mut() {
+        let mut param = CookieParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&mut Some("param".to_string()), param.deref_mut())
+    }
+
+    #[test]
+    fn test_cookie_param_deserialize() {
+        let param = serde_json::from_str::<CookieParam<String, true>>(r#""param""#).unwrap();
+        assert_eq!(param.0.unwrap(), "param");
+    }
+
+    #[test]
+    fn test_cookie_param_debug() {
+        let param = CookieParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{:?}", param), r#"Some("param")"#);
+    }
+
+    #[test]
+    fn test_cookie_param_display() {
+        let param = CookieParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{}", param), "param");
+    }
+}

--- a/crates/oapi/src/extract/parameter/header.rs
+++ b/crates/oapi/src/extract/parameter/header.rs
@@ -141,3 +141,62 @@ where
         operation.parameters.insert(parameter);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_required_header_param_into_inner() {
+        let param = HeaderParam::<String, true>(Some("param".to_string()));
+        assert_eq!("param".to_string(), param.into_inner());
+    }
+
+    #[test]
+    fn test_required_header_param_deref() {
+        let param = HeaderParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&"param".to_string(), param.deref())
+    }
+
+    #[test]
+    fn test_required_header_param_deref_mut() {
+        let mut param = HeaderParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&mut "param".to_string(), param.deref_mut())
+    }
+
+    #[test]
+    fn test_unrequired_header_param_into_inner() {
+        let param = HeaderParam::<String, false>(Some("param".to_string()));
+        assert_eq!(Some("param".to_string()), param.into_inner());
+    }
+
+    #[test]
+    fn test_unrequired_header_param_deref() {
+        let param = HeaderParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&Some("param".to_string()), param.deref())
+    }
+
+    #[test]
+    fn test_unrequired_header_param_deref_mut() {
+        let mut param = HeaderParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&mut Some("param".to_string()), param.deref_mut())
+    }
+
+    #[test]
+    fn test_header_param_deserialize() {
+        let param = serde_json::from_str::<HeaderParam<String, true>>(r#""param""#).unwrap();
+        assert_eq!(param.0.unwrap(), "param");
+    }
+
+    #[test]
+    fn test_header_param_debug() {
+        let param = HeaderParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{:?}", param), r#"Some("param")"#);
+    }
+
+    #[test]
+    fn test_header_param_display() {
+        let param = HeaderParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{}", param), "param");
+    }
+}

--- a/crates/oapi/src/extract/parameter/path.rs
+++ b/crates/oapi/src/extract/parameter/path.rs
@@ -95,3 +95,44 @@ where
         operation.parameters.insert(parameter);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_param_into_inner() {
+        let param = PathParam::<String>("param".to_string());
+        assert_eq!("param".to_string(), param.into_inner());
+    }
+
+    #[test]
+    fn test_path_param_deref() {
+        let param = PathParam::<String>("param".to_string());
+        assert_eq!(&"param".to_string(), param.deref())
+    }
+
+    #[test]
+    fn test_path_param_deref_mut() {
+        let mut param = PathParam::<String>("param".to_string());
+        assert_eq!(&mut "param".to_string(), param.deref_mut())
+    }
+
+    #[test]
+    fn test_path_param_deserialize() {
+        let param = serde_json::from_str::<PathParam<String>>(r#""param""#).unwrap();
+        assert_eq!(param.0, "param");
+    }
+
+    #[test]
+    fn test_path_param_debug() {
+        let param = PathParam::<String>("param".to_string());
+        assert_eq!(format!("{:?}", param), r#""param""#);
+    }
+
+    #[test]
+    fn test_path_param_display() {
+        let param = PathParam::<String>("param".to_string());
+        assert_eq!(format!("{}", param), "param");
+    }
+}

--- a/crates/oapi/src/extract/parameter/query.rs
+++ b/crates/oapi/src/extract/parameter/query.rs
@@ -131,3 +131,62 @@ where
         operation.parameters.insert(parameter);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_required_query_param_into_inner() {
+        let param = QueryParam::<String, true>(Some("param".to_string()));
+        assert_eq!("param".to_string(), param.into_inner());
+    }
+
+    #[test]
+    fn test_required_query_param_deref() {
+        let param = QueryParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&"param".to_string(), param.deref())
+    }
+
+    #[test]
+    fn test_required_query_param_deref_mut() {
+        let mut param = QueryParam::<String, true>(Some("param".to_string()));
+        assert_eq!(&mut "param".to_string(), param.deref_mut())
+    }
+
+    #[test]
+    fn test_unrequired_query_param_into_inner() {
+        let param = QueryParam::<String, false>(Some("param".to_string()));
+        assert_eq!(Some("param".to_string()), param.into_inner());
+    }
+
+    #[test]
+    fn test_unrequired_query_param_deref() {
+        let param = QueryParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&Some("param".to_string()), param.deref())
+    }
+
+    #[test]
+    fn test_unrequired_query_param_deref_mut() {
+        let mut param = QueryParam::<String, false>(Some("param".to_string()));
+        assert_eq!(&mut Some("param".to_string()), param.deref_mut())
+    }
+
+    #[test]
+    fn test_query_param_deserialize() {
+        let param = serde_json::from_str::<QueryParam<String, true>>(r#""param""#).unwrap();
+        assert_eq!(param.0.unwrap(), "param");
+    }
+
+    #[test]
+    fn test_query_param_debug() {
+        let param = QueryParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{:?}", param), r#"Some("param")"#);
+    }
+
+    #[test]
+    fn test_query_param_display() {
+        let param = QueryParam::<String, true>(Some("param".to_string()));
+        assert_eq!(format!("{}", param), "param");
+    }
+}


### PR DESCRIPTION
1. In `salvo_oapi`, we enable `test` feature from `salvo_core`, in order to build `hyper::Request` with `TestClient`.
2. `crates/oapi/src/extract/parameter/cookie.rs` 97.67%.
3. `crates/oapi/src/extract/parameter/header.rs` 97.44%.
4. `crates/oapi/src/extract/parameter/path.rs` 96.30%.
5. `crates/oapi/src/extract/parameter/query.rs` 97.62%.
