### PR TITLE
Support ratelimit headers

### DIFF
--- a/crates/rate-limiter/src/fixed_guard.rs
+++ b/crates/rate-limiter/src/fixed_guard.rs
@@ -51,4 +51,16 @@ impl RateGuard for FixedGuard {
             false
         }
     }
+
+    async fn remaining(&self, quota: &Self::Quota) -> usize {
+        quota.limit - self.count
+    }
+
+    async fn reset(&self, _: &Self::Quota) -> i64 {
+        self.reset.unix_timestamp()
+    }
+
+    async fn limit(&self, quota: &Self::Quota) -> usize {
+        quota.limit
+    }
 }

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -63,7 +63,7 @@ impl RateGuard for SlidingGuard {
             self.cell_inst = OffsetDateTime::now_utc();
             return true;
         } else {
-            while delta > self.cell_span{
+            while delta > self.cell_span {
                 delta -= self.cell_span;
                 self.head = (self.head + 1) % self.counts.len();
                 self.counts[self.head] = 0;
@@ -73,5 +73,20 @@ impl RateGuard for SlidingGuard {
             self.cell_inst = OffsetDateTime::now_utc();
         }
         self.counts.iter().cloned().sum::<usize>() <= quota.limit
+    }
+
+    async fn remaining(&self, quota: &Self::Quota) -> usize {
+        quota
+            .limit
+            .checked_sub(self.counts.iter().cloned().sum::<usize>())
+            .unwrap_or_default()
+    }
+
+    async fn reset(&self, quota: &Self::Quota) -> i64 {
+        (self.cell_inst + quota.period).unix_timestamp()
+    }
+
+    async fn limit(&self, quota: &Self::Quota) -> usize {
+        quota.limit
     }
 }


### PR DESCRIPTION
resolve #626 

- Add `add_headers` field to the `RateLimiter` struct
- Add `add_headers` function to the `RateLimiter` struct
- Add `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers to the response if the `add_headers` is true

- Add `remaining`, `reset` and `limit` functions to the `RateGuard` trait, to get the infos