### PR TITLE
add: graceful shutdown example

### DIFF
--- a/examples/graceful-shutdown/Cargo.toml
+++ b/examples/graceful-shutdown/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-graceful-shutdown"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+salvo = { workspace = true }
+tokio = { workspace = true, features = ["macros", "signal"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/examples/graceful-shutdown/Cargo.toml
+++ b/examples/graceful-shutdown/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+
 [dependencies]
 salvo = { workspace = true }
 tokio = { workspace = true, features = ["macros", "signal"] }

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -1,0 +1,23 @@
+use salvo_core::prelude::*;
+use tokio::signal;
+
+#[tokio::main]
+async fn main() {
+    let acceptor = TcpListener::new("127.0.0.1:5800").bind().await;
+    let server = Server::new(acceptor);
+    let handle = server.handle();
+
+    // Listen Shutdown Signal
+    listen_shutdown_signal(handle);
+
+    server.serve(Router::new()).await;
+}
+
+async fn listen_shutdown_signal(handle: ServerHandle) {
+    // Wait Shutdown Signal
+    tokio::spawn(async move {
+        let _ = signal::ctrl_c().await;
+        // Graceful Shutdown Server
+        handle.stop_graceful(None);
+    })
+}


### PR DESCRIPTION
Add：shutdown_graceful_example.

The Salvo server will graceful shutdown when recv Ctrl+C.