### PR TITLE
Add cfg_attr(docsrs) to compression crate

### DIFF
--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -1,6 +1,9 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Compression middleware for for Savlo web server framework.
 //!
 //! Read more: <https://salvo.rs>
+
 use std::fmt::{self, Display};
 use std::str::FromStr;
 


### PR DESCRIPTION
The compression crate uses cfg_attr(docsrs) to use nightly docs features but does not actually declare those nightly features, breaking all downstream consumers of salvo.

This fixes that by enabling the appropriate nightly feature.