### PR TITLE
Fix host filter in http2

### DIFF
--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Formatter};
 
 use crate::http::uri::Scheme;
-use crate::http::{header, Method, Request};
+use crate::http::{Method, Request};
 use crate::routing::{Filter, PathState};
 
 /// Filter by request method
@@ -90,7 +90,7 @@ impl Filter for HostFilter {
         let host = req.uri().authority().map(|a| a.as_str());
         #[cfg(not(feature = "fix-http1-request-uri"))]
         let host = req.uri().authority().map(|a| a.as_str())
-            .or_else(|| req.headers().get(header::HOST).and_then(|h| h.to_str().ok()));
+            .or_else(|| req.headers().get(crate::http::header::HOST).and_then(|h| h.to_str().ok()));
         host.map(|h| {
                 if h.contains(':') {
                     h.rsplit_once(':')
@@ -141,7 +141,7 @@ impl Filter for PortFilter {
         let host = req.uri().authority().map(|a| a.as_str());
         #[cfg(not(feature = "fix-http1-request-uri"))]
         let host = req.uri().authority().map(|a| a.as_str())
-            .or_else(|| req.headers().get(header::HOST).and_then(|h| h.to_str().ok()));
+            .or_else(|| req.headers().get(crate::http::header::HOST).and_then(|h| h.to_str().ok()));
         host.map(|h| {
                 if h.contains(':') {
                     h.rsplit_once(':')

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -86,10 +86,12 @@ impl Filter for HostFilter {
     fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         // Http1, if `fix-http1-request-uri` feature is disabled, host is lack. so use header host instead.
         // https://github.com/hyperium/hyper/issues/1310
-        req.headers()
-            .get(header::HOST)
-            .and_then(|h| h.to_str().ok())
-            .map(|h| {
+        #[cfg(feature = "fix-http1-request-uri")]
+        let host = req.uri().authority().map(|a| a.as_str());
+        #[cfg(not(feature = "fix-http1-request-uri"))]
+        let host = req.uri().authority().map(|a| a.as_str())
+            .or_else(|| req.headers().get(header::HOST).and_then(|h| h.to_str().ok()));
+        host.map(|h| {
                 if h.contains(':') {
                     h.rsplit_once(':')
                         .expect("rsplit_once by ':' should not returns `None`")
@@ -135,10 +137,12 @@ impl Filter for PortFilter {
     fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         // Http1, if `fix-http1-request-uri` feature is disabled, port is lack. so use header host instead.
         // https://github.com/hyperium/hyper/issues/1310
-        req.headers()
-            .get(header::HOST)
-            .and_then(|h| h.to_str().ok())
-            .map(|h| {
+        #[cfg(feature = "fix-http1-request-uri")]
+        let host = req.uri().authority().map(|a| a.as_str());
+        #[cfg(not(feature = "fix-http1-request-uri"))]
+        let host = req.uri().authority().map(|a| a.as_str())
+            .or_else(|| req.headers().get(header::HOST).and_then(|h| h.to_str().ok()));
+        host.map(|h| {
                 if h.contains(':') {
                     h.rsplit_once(':')
                         .expect("rsplit_once by ':' should not returns `None`")


### PR DESCRIPTION
Requests that come from http2 use the :authority headers and might not include  the Host header, so they won't work with the host filter.

This PR makes the host filter check for both, first the :authority then the Host header. If the fix-http1-request-uri feature is enabled, then it only checks the authority.