### PR TITLE
fix: HTTP/1.1 Always has HTTP Scheme

### DIFF
--- a/crates/core/src/conn/acme/listener.rs
+++ b/crates/core/src/conn/acme/listener.rs
@@ -439,7 +439,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            ..
         } = self.inner.accept(fuse_factory).await?;
         let fusewire = conn.fusewire();
         Ok(Accepted {
@@ -447,7 +447,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            http_scheme: Scheme::HTTPS,
         })
     }
 }

--- a/crates/core/src/conn/native_tls/listener.rs
+++ b/crates/core/src/conn/native_tls/listener.rs
@@ -157,7 +157,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            ..
         } = self.inner.accept(fuse_factory.clone()).await?;
         let fusewire = conn.fusewire();
         let conn = async move {
@@ -171,7 +171,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            http_scheme: Scheme::HTTPS,
         })
     }
 }

--- a/crates/core/src/conn/openssl/listener.rs
+++ b/crates/core/src/conn/openssl/listener.rs
@@ -156,7 +156,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            ..
         } = self.inner.accept(fuse_factory).await?;
         let fusewire = conn.fusewire();
         let conn = async move {
@@ -176,7 +176,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            http_scheme: Scheme::HTTPS,
         })
     }
 }

--- a/crates/core/src/conn/rustls/listener.rs
+++ b/crates/core/src/conn/rustls/listener.rs
@@ -154,7 +154,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            ..
         } = self.inner.accept(fuse_factory).await?;
         let fusewire = conn.fusewire();
         Ok(Accepted {
@@ -162,7 +162,7 @@ where
             local_addr,
             remote_addr,
             http_version,
-            http_scheme,
+            http_scheme: Scheme::HTTPS,
         })
     }
 }

--- a/crates/core/src/conn/tcp.rs
+++ b/crates/core/src/conn/tcp.rs
@@ -89,7 +89,7 @@ impl<T: ToSocketAddrs + Send> TcpListener<T> {
         #[inline]
         pub fn acme(self) -> AcmeListener<Self>
         {
-            AcmeListener::new( self)
+            AcmeListener::new(self)
         }
     }
 }


### PR DESCRIPTION
Close https://github.com/salvo-rs/salvo/pull/702