### PR TITLE
Fixes redirect loop in serve-static.

### DIFF
--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) fn decode_url_path_safely(path: &str) -> String {
 
 #[inline]
 pub(crate) fn format_url_path_safely(path: &str) -> String {
+    let final_slash = if path.ends_with("/") { "/" } else { "" };
     let mut used_parts = Vec::with_capacity(8);
     for part in path.split(['/', '\\']) {
         if part.is_empty() || part == "." {
@@ -66,7 +67,7 @@ pub(crate) fn format_url_path_safely(path: &str) -> String {
             used_parts.push(part);
         }
     }
-    used_parts.join("/")
+    used_parts.join("/") + final_slash
 }
 
 pub(crate) fn redirect_to_dir_url(req_uri: &Uri, res: &mut Response) {


### PR DESCRIPTION
When using serve-static with static_embed and defaults:

  Router::with_path("<**>").get(static_embed::<Assets>().defaults("index.html"));

with a non-root folder with a default file ("index.html"):

  ├─ index.html
  └─ foo/
     └─ index.html

trying to GET the "/foo" path results in a redirect loop, with salvo adding an extra "/" after each iteration: "/foo//////////////////".

This is because of the code in embed.rs that tries to redirect from "/foo" to "/foo/":

  135 |     if embedded_file.is_some() && !req_path.ends_with('/') && !req_path.is_empty() {
  136 |         redirect_to_dir_url(req.uri(), res);
  137 |         return;
  138 |     }

where req_path was built with:

  123 |  let req_path = format_url_path_safely(&req_path);

but `format_url_path_safely()` always strips the final slash(es), which means the `!req_path.ends_with('/')` check always succeeds, and `redirect_to_dir_url()` is called on `req.uri()` (not `req_path`), which still has all its slashes.  `redirect_to_dir_url()` then unconditionally adds another slash, and the loop repeats.

This commit breaks the loop by having `format_url_path_safely()` keep one final slash if it was already present, so the check on line 135 now works as expected.