### PR TITLE
Adding EC private keys to rustls config

### DIFF
--- a/crates/core/src/conn/rustls/config.rs
+++ b/crates/core/src/conn/rustls/config.rs
@@ -92,7 +92,7 @@ impl Keycert {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|_| IoError::new(ErrorKind::Other, "failed to parse tls private keys"))?;
             if !ec.is_empty() {
-                PrivateKeyDer::Pkcs8(ec.remove(0))
+                PrivateKeyDer::Sec1(ec.remove(0))
             } else {
                 let mut pkcs8 = rustls_pemfile::pkcs8_private_keys(&mut self.key.as_ref())
                     .collect::<Result<Vec<_>, _>>()


### PR DESCRIPTION
Hello, 

I rely on Caddy to automatically generate and renew TLS certificates. By default, they use the ED25519 algorithm to generate a private key.
To make use of their certificates, I included the EC private keys in the rustls configuration.

Let me know if I forgot something or if I did something wrong.
Thank you for this amazing project!