### PR TITLE
fix: Respect schema names in short `FlexNamer`

### DIFF
--- a/crates/oapi/src/naming.rs
+++ b/crates/oapi/src/naming.rs
@@ -141,7 +141,7 @@ impl Namer for FlexNamer {
             NameRule::Force(force_name) => {
                 let mut base = if self.short_mode {
                     let re = Regex::new(r"([^<>]*::)+").expect("Invalid regex");
-                    re.replace_all(type_name, "").to_string()
+                    re.replace_all(force_name, "").to_string()
                 } else {
                     format! {"{}{}", force_name, type_generic_part(type_name).replace("::", ".")}
                 };


### PR DESCRIPTION
Fixes https://github.com/salvo-rs/salvo/issues/833

### Changes

In this PR, I addressed the issue where `FlexNamer` did not respect the schema
name when generating the short name. Previously, `FlexNamer` incorrectly used
the `type_name` parameter as the short name in the `Force` rule. This has been
corrected by using the `force_name` parameter as the short name in the `Force`
rule.

### Note
This fix only applies to the schema name itself and does not address cases where
the schema name is used as a generic type. Unfortunately, this limitation cannot
be resolved, so please avoid naming your schema if it is intended for use as a
generic type.