### PR TITLE
fix: server logs only show `HTTP/1.1` even when `HTTP/2.0` enabled

### DIFF
--- a/crates/core/src/conn/tcp.rs
+++ b/crates/core/src/conn/tcp.rs
@@ -187,9 +187,9 @@ impl TryFrom<TokioTcpListener> for TcpAcceptor {
     fn try_from(inner: TokioTcpListener) -> Result<Self, Self::Error> {
         let holdings = vec![Holding {
             local_addr: inner.local_addr()?.into(),
-            #[cfg(not(feature = "http2-cleartext"))]
+            #[cfg(not(feature = "http2"))]
             http_versions: vec![Version::HTTP_11],
-            #[cfg(feature = "http2-cleartext")]
+            #[cfg(feature = "http2")]
             http_versions: vec![Version::HTTP_11, Version::HTTP_2],
             http_scheme: Scheme::HTTP,
         }];

--- a/crates/core/src/conn/unix.rs
+++ b/crates/core/src/conn/unix.rs
@@ -107,9 +107,9 @@ where
 
         let holdings = vec![Holding {
             local_addr: inner.local_addr()?.into(),
-            #[cfg(not(feature = "http2-cleartext"))]
+            #[cfg(not(feature = "http2"))]
             http_versions: vec![Version::HTTP_11],
-            #[cfg(feature = "http2-cleartext")]
+            #[cfg(feature = "http2")]
             http_versions: vec![Version::HTTP_11, Version::HTTP_2],
             http_scheme: Scheme::HTTP,
         }];


### PR DESCRIPTION
Fixes: https://github.com/salvo-rs/salvo/issues/851