### PR TITLE
oapi: Migrate to OpenAPI spec 3.1.0

### DIFF
--- a/crates/oapi-macros/src/feature/macros.rs
+++ b/crates/oapi-macros/src/feature/macros.rs
@@ -35,6 +35,7 @@ macro_rules! is_validatable {
 is_validatable! {
     Default => false,
     Example => false,
+    Examples => false,
     XmlAttr => false,
     Format => false,
     WriteOnly => false,
@@ -74,6 +75,8 @@ is_validatable! {
     Required => false,
     SkipBound => false,
     Bound => false,
+    ContentEncoding => false,
+    ContentMediaType => false
 }
 
 macro_rules! parse_features {
@@ -163,6 +166,7 @@ macro_rules! impl_feature_into_inner {
 
 impl_feature_into_inner! {
     Example,
+    Examples,
     Default,
     Inline,
     XmlAttr,

--- a/crates/oapi-macros/src/feature/mod.rs
+++ b/crates/oapi-macros/src/feature/mod.rs
@@ -68,6 +68,7 @@ pub(crate) trait Parse {
 #[derive(Clone, Debug)]
 pub(crate) enum Feature {
     Example(Example),
+    Examples(Examples),
     Default(Default),
     Inline(Inline),
     XmlAttr(XmlAttr),
@@ -108,6 +109,8 @@ pub(crate) enum Feature {
     Required(Required),
     SkipBound(SkipBound),
     Bound(Bound),
+    ContentEncoding(ContentEncoding),
+    ContentMediaType(ContentMediaType),
 }
 
 impl Feature {
@@ -167,6 +170,7 @@ impl TryToTokens for Feature {
                 }
             }
             Feature::Example(example) => quote! { .example(#example) },
+            Feature::Examples(examples) => quote! { .examples(#examples) },
             Feature::XmlAttr(xml) => quote! { .xml(#xml) },
             Feature::Format(format) => {
                 let format = format.try_to_token_stream()?;
@@ -176,13 +180,20 @@ impl TryToTokens for Feature {
             Feature::ReadOnly(read_only) => quote! { .read_only(#read_only) },
             Feature::Name(name) => quote! { .name(#name) },
             Feature::Title(title) => quote! { .title(#title) },
-            Feature::Aliases(_) => quote! {
+            Feature::Aliases(_) => {
                 return Err(Diagnostic::spanned(
-                Span::call_site(),
-                DiagLevel::Error,
-                "Aliases feature does not support `TryToTokens`",
-            )); },
-            Feature::Nullable(nullable) => quote! { .nullable(#nullable) },
+                    Span::call_site(),
+                    DiagLevel::Error,
+                    "Aliases feature does not support `TryToTokens`",
+                ))
+            }
+            Feature::Nullable(_) => {
+                return Err(Diagnostic::spanned(
+                    Span::call_site(),
+                    DiagLevel::Error,
+                    "Nullable does not support `TryToTokens`",
+                ))
+            }
             Feature::Required(required) => quote! { .required(#required) },
             Feature::Rename(rename) => rename.to_token_stream(),
             Feature::Style(style) => quote! { .style(#style) },
@@ -220,6 +231,8 @@ impl TryToTokens for Feature {
             Feature::AdditionalProperties(additional_properties) => {
                 quote! { .additional_properties(#additional_properties) }
             }
+            Feature::ContentEncoding(content_encoding) => quote! { .content_encoding(#content_encoding) },
+            Feature::ContentMediaType(content_media_type) => quote! { .content_media_type(#content_media_type) },
             Feature::RenameAll(_) => {
                 return Err(Diagnostic::spanned(
                     Span::call_site(),
@@ -262,6 +275,7 @@ impl Display for Feature {
         match self {
             Feature::Default(default) => default.fmt(f),
             Feature::Example(example) => example.fmt(f),
+            Feature::Examples(examples) => examples.fmt(f),
             Feature::XmlAttr(xml) => xml.fmt(f),
             Feature::Format(format) => format.fmt(f),
             Feature::WriteOnly(write_only) => write_only.fmt(f),
@@ -301,6 +315,8 @@ impl Display for Feature {
             Feature::Required(required) => required.fmt(f),
             Feature::SkipBound(skip) => skip.fmt(f),
             Feature::Bound(bound) => bound.fmt(f),
+            Feature::ContentEncoding(content_encoding) => content_encoding.fmt(f),
+            Feature::ContentMediaType(content_media_type) => content_media_type.fmt(f),
         }
     }
 }
@@ -310,6 +326,7 @@ impl Validatable for Feature {
         match &self {
             Feature::Default(default) => default.is_validatable(),
             Feature::Example(example) => example.is_validatable(),
+            Feature::Examples(examples) => examples.is_validatable(),
             Feature::XmlAttr(xml) => xml.is_validatable(),
             Feature::Format(format) => format.is_validatable(),
             Feature::WriteOnly(write_only) => write_only.is_validatable(),
@@ -349,6 +366,8 @@ impl Validatable for Feature {
             Feature::Required(required) => required.is_validatable(),
             Feature::SkipBound(skip) => skip.is_validatable(),
             Feature::Bound(bound) => bound.is_validatable(),
+            Feature::ContentEncoding(content_encoding) => content_encoding.is_validatable(),
+            Feature::ContentMediaType(content_media_type) => content_media_type.is_validatable(),
         }
     }
 }

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -236,10 +236,10 @@ mod tests {
             ///
             /// This is user description.
             #[derive(ToSchema)]
-            struct User{
-                #[salvo(schema(example = "chris", min_length = 1, max_length = 100, required))]
+            struct User {
+                #[salvo(schema(examples("chris"), min_length = 1, max_length = 100, required))]
                 name: String,
-                #[salvo(schema(example = 16, default = 0, maximum=100, minimum=0,format = "int32"))]
+                #[salvo(schema(examples(16), default = 0, maximum=100, minimum=0,format = "int32"))]
                 age: i32,
                 #[deprecated = "There is deprecated"]
                 high: u32,
@@ -259,7 +259,7 @@ mod tests {
                                 .property(
                                     "name",
                                     salvo::oapi::Object::new()
-                                        .schema_type(salvo::oapi::SchemaType::String)
+                                        .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::String))
                                         .example(salvo::oapi::__private::serde_json::json!("chris"))
                                         .min_length(1usize)
                                         .max_length(100usize)
@@ -268,7 +268,7 @@ mod tests {
                                 .property(
                                     "age",
                                     salvo::oapi::Object::new()
-                                        .schema_type(salvo::oapi::SchemaType::Integer)
+                                        .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::Integer))
                                         .format(salvo::oapi::SchemaFormat::KnownFormat(salvo::oapi::KnownFormat::Int32))
                                         .example(salvo::oapi::__private::serde_json::json!(16))
                                         .default_value(salvo::oapi::__private::serde_json::json!(0))
@@ -280,7 +280,7 @@ mod tests {
                                 .property(
                                     "high",
                                     salvo::oapi::Object::new()
-                                        .schema_type(salvo::oapi::SchemaType::Integer)
+                                        .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::Integer))
                                         .format(salvo::oapi::SchemaFormat::KnownFormat(salvo::oapi::KnownFormat::Int32))
                                         .deprecated(salvo::oapi::Deprecated::True)
                                         .minimum(0f64)
@@ -366,7 +366,7 @@ mod tests {
                         if !components.schemas.contains_key(&name) {
                             components.schemas.insert(name.clone(), ref_or.clone());
                             let schema = salvo::oapi::Object::new()
-                                .schema_type(salvo::oapi::SchemaType::String)
+                                .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::String))
                                 .enum_values::<[&str; 2usize], &str>(["man", "woman",]);
                             components.schemas.insert(name, schema);
                         }
@@ -401,13 +401,13 @@ mod tests {
                                 salvo::oapi::Object::new()
                                     .property(
                                         "name",
-                                        salvo::oapi::Object::new().schema_type(salvo::oapi::SchemaType::String)
+                                        salvo::oapi::Object::new().schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::String))
                                     )
                                     .required("name")
                                     .property(
                                         "age",
                                         salvo::oapi::Object::new()
-                                            .schema_type(salvo::oapi::SchemaType::Integer)
+                                            .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::Integer))
                                             .format(salvo::oapi::SchemaFormat::KnownFormat(
                                                 salvo::oapi::KnownFormat::Int32
                                             ))
@@ -453,8 +453,7 @@ mod tests {
             }
         };
         assert_eq!(
-            response::to_responses(parse2(input).unwrap()).unwrap()
-                .to_string(),
+            response::to_responses(parse2(input).unwrap()).unwrap().to_string(),
             quote! {
                 impl salvo::oapi::ToResponses for UserResponses {
                     fn to_responses(components: &mut salvo::oapi::Components) -> salvo::oapi::response::Responses {
@@ -468,7 +467,7 @@ mod tests {
                                             salvo::oapi::Object::new()
                                                 .property(
                                                     "value",
-                                                    salvo::oapi::Object::new().schema_type(salvo::oapi::SchemaType::String)
+                                                    salvo::oapi::Object::new().schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::String))
                                                 )
                                                 .required("value")
                                                 .description("Success response description.")
@@ -518,7 +517,8 @@ mod tests {
                             .append(&mut <Self as salvo::oapi::ToResponses>::to_responses(components));
                     }
                 }
-            } .to_string()
+            }
+            .to_string()
         );
     }
 
@@ -548,19 +548,17 @@ mod tests {
                                     .required(salvo::oapi::Required::False)
                                     .schema(
                                         salvo::oapi::Object::new()
-                                            .schema_type(salvo::oapi::SchemaType::String)
-                                            .nullable(true)
+                                            .schema_type(salvo::oapi::schema::SchemaType::from_iter([salvo::oapi::schema::BasicType::String, salvo::oapi::schema::BasicType::Null]))
                                     ),
                                 salvo::oapi::parameter::Parameter::new("age")
                                     .description("Age of pet")
                                     .required(salvo::oapi::Required::False)
                                     .schema(
                                         salvo::oapi::Object::new()
-                                            .schema_type(salvo::oapi::SchemaType::Integer)
+                                            .schema_type(salvo::oapi::schema::SchemaType::from_iter([salvo::oapi::schema::BasicType::Integer, salvo::oapi::schema::BasicType::Null]))
                                             .format(salvo::oapi::SchemaFormat::KnownFormat(
                                                 salvo::oapi::KnownFormat::Int32
                                             ))
-                                            .nullable(true)
                                     ),
                                 salvo::oapi::parameter::Parameter::new("kind")
                                     .description("Kind of pet")

--- a/crates/oapi-macros/src/operation/example.rs
+++ b/crates/oapi-macros/src/operation/example.rs
@@ -75,7 +75,7 @@ impl Parse for Example {
 }
 
 impl ToTokens for Example {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
         let summary = self.summary.as_ref().map(|summary| quote!(.summary(#summary)));
         let description = self
@@ -88,7 +88,7 @@ impl ToTokens for Example {
             .as_ref()
             .map(|external_value| quote!(.external_value(#external_value)));
 
-        stream.extend(quote! {
+        tokens.extend(quote! {
             #oapi::oapi::Example::new()
                 #summary
                 #description

--- a/crates/oapi-macros/src/operation/mod.rs
+++ b/crates/oapi-macros/src/operation/mod.rs
@@ -351,8 +351,8 @@ impl PathTypeTree for TypeTree<'_> {
                 .map(|children| {
                     children
                         .iter()
-                        .flat_map(|child| &child.path)
-                        .any(|path| SchemaType(path).is_byte())
+                        .flat_map(|child| child.path.as_ref().zip(Some(child.is_option())))
+                        .any(|(path, nullable)| SchemaType { path, nullable }.is_byte())
                 })
                 .unwrap_or(false)
         {
@@ -360,7 +360,10 @@ impl PathTypeTree for TypeTree<'_> {
         } else if self
             .path
             .as_ref()
-            .map(|path| SchemaType(path.deref()))
+            .map(|path| SchemaType {
+                path: path.deref(),
+                nullable: self.is_option(),
+            })
             .map(|schema_type| schema_type.is_primitive())
             .unwrap_or(false)
         {

--- a/crates/oapi-macros/src/parameter/mod.rs
+++ b/crates/oapi-macros/src/parameter/mod.rs
@@ -347,9 +347,9 @@ impl Parse for ParameterIn {
 }
 
 impl ToTokens for ParameterIn {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
-        stream.extend(match self {
+        tokens.extend(match self {
             Self::Path => quote! { #oapi::oapi::parameter::ParameterIn::Path },
             Self::Query => quote! { #oapi::oapi::parameter::ParameterIn::Query },
             Self::Header => quote! { #oapi::oapi::parameter::ParameterIn::Header },
@@ -390,20 +390,20 @@ impl Parse for ParameterStyle {
 }
 
 impl ToTokens for ParameterStyle {
-    fn to_tokens(&self, stream: &mut proc_macro2::TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
         match self {
-            ParameterStyle::Matrix => stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Matrix }),
-            ParameterStyle::Label => stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Label }),
-            ParameterStyle::Form => stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Form }),
-            ParameterStyle::Simple => stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Simple }),
+            ParameterStyle::Matrix => tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Matrix }),
+            ParameterStyle::Label => tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Label }),
+            ParameterStyle::Form => tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Form }),
+            ParameterStyle::Simple => tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Simple }),
             ParameterStyle::SpaceDelimited => {
-                stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::SpaceDelimited })
+                tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::SpaceDelimited })
             }
             ParameterStyle::PipeDelimited => {
-                stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::PipeDelimited })
+                tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::PipeDelimited })
             }
-            ParameterStyle::DeepObject => stream.extend(quote! { #oapi::oapi::parameter::ParameterStyle::DeepObject }),
+            ParameterStyle::DeepObject => tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::DeepObject }),
         }
     }
 }

--- a/crates/oapi-macros/src/parse_utils.rs
+++ b/crates/oapi-macros/src/parse_utils.rs
@@ -44,10 +44,10 @@ impl Parse for Value {
 }
 
 impl ToTokens for Value {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Self::LitStr(str) => str.to_tokens(stream),
-            Self::Expr(expr) => expr.to_tokens(stream),
+            Self::LitStr(str) => str.to_tokens(tokens),
+            Self::Expr(expr) => expr.to_tokens(tokens),
         }
     }
 }

--- a/crates/oapi-macros/src/response/mod.rs
+++ b/crates/oapi-macros/src/response/mod.rs
@@ -642,8 +642,8 @@ impl Parse for ResponseStatusCode {
 }
 
 impl ToTokens for ResponseStatusCode {
-    fn to_tokens(&self, stream: &mut TokenStream) {
-        self.0.to_tokens(stream);
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
     }
 }
 

--- a/crates/oapi-macros/src/schema/enum_schemas.rs
+++ b/crates/oapi-macros/src/schema/enum_schemas.rs
@@ -61,6 +61,7 @@ impl<'e> EnumSchema<'e> {
                         let mut repr_enum_features = feature::parse_schema_features_with(attributes, |input| {
                             Ok(parse_features!(
                                 input as crate::feature::Example,
+                                crate::feature::Examples,
                                 crate::feature::Default,
                                 crate::feature::Name,
                                 crate::feature::Title,
@@ -767,7 +768,7 @@ impl ComplexEnum<'_> {
                                 #title
                                 .item(#unnamed_enum)
                                 .item(#oapi::oapi::schema::Object::new()
-                                    .schema_type(#oapi::oapi::schema::SchemaType::Object)
+                                    .schema_type(#oapi::oapi::schema::BasicType::Object)
                                     .property(#tag, #variant_name_tokens)
                                     .required(#tag)
                                 )
@@ -776,7 +777,7 @@ impl ComplexEnum<'_> {
                         Ok(Some(quote! {
                             #unnamed_enum
                                 #name
-                                .schema_type(#oapi::oapi::schema::SchemaType::Object)
+                                .schema_type(#oapi::oapi::schema::BasicType::Object)
                                 .property(#tag, #variant_name_tokens)
                                 .required(#tag)
                         }))
@@ -881,7 +882,7 @@ impl ComplexEnum<'_> {
                 Ok(Some(quote! {
                     #oapi::oapi::schema::Object::new()
                         #title
-                        .schema_type(#oapi::oapi::schema::SchemaType::Object)
+                        .schema_type(#oapi::oapi::schema::BasicType::Object)
                         .property(#tag, #variant_name_tokens)
                         .required(#tag)
                         .property(#content, #named_enum)
@@ -933,7 +934,7 @@ impl ComplexEnum<'_> {
                     Ok(Some(quote! {
                         #oapi::oapi::schema::Object::new()
                             #title
-                            .schema_type(#oapi::oapi::schema::SchemaType::Object)
+                            .schema_type(#oapi::oapi::schema::BasicType::Object)
                             .property(#tag, #variant_name_tokens)
                             .required(#tag)
                             .property(#content, #unnamed_enum)

--- a/crates/oapi-macros/src/schema/feature.rs
+++ b/crates/oapi-macros/src/schema/feature.rs
@@ -2,10 +2,11 @@ use syn::parse::{Parse, ParseBuffer, ParseStream};
 use syn::Attribute;
 
 use crate::feature::{
-    impl_into_inner, impl_merge, parse_features, AdditionalProperties, Aliases, Bound, Default, Deprecated,
-    Description, Example, ExclusiveMaximum, ExclusiveMinimum, Feature, Format, Inline, MaxItems, MaxLength,
-    MaxProperties, Maximum, Merge, MinItems, MinLength, MinProperties, Minimum, MultipleOf, Name, Nullable, Pattern,
-    ReadOnly, Rename, RenameAll, Required, SchemaWith, Skip, SkipBound, Title, ValueType, WriteOnly, XmlAttr,
+    impl_into_inner, impl_merge, parse_features, AdditionalProperties, Aliases, Bound, ContentEncoding,
+    ContentMediaType, Default, Deprecated, Description, Example, Examples, ExclusiveMaximum, ExclusiveMinimum, Feature,
+    Format, Inline, MaxItems, MaxLength, MaxProperties, Maximum, Merge, MinItems, MinLength, MinProperties, Minimum,
+    MultipleOf, Name, Nullable, Pattern, ReadOnly, Rename, RenameAll, Required, SchemaWith, Skip, SkipBound, Title,
+    ValueType, WriteOnly, XmlAttr,
 };
 use crate::{attribute, DiagResult, Diagnostic, IntoInner};
 
@@ -16,6 +17,7 @@ impl Parse for NamedFieldStructFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(NamedFieldStructFeatures(parse_features!(
             input as Example,
+            Examples,
             XmlAttr,
             Name,
             Title,
@@ -43,6 +45,7 @@ impl Parse for UnnamedFieldStructFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(UnnamedFieldStructFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Name,
             Title,
@@ -67,6 +70,7 @@ impl Parse for EnumFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Name,
             Title,
@@ -89,6 +93,7 @@ impl Parse for ComplexEnumFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(ComplexEnumFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             RenameAll,
             Name,
@@ -111,6 +116,7 @@ impl Parse for NamedFieldFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(NamedFieldFeatures(parse_features!(
             input as Example,
+            Examples,
             ValueType,
             Format,
             Default,
@@ -134,7 +140,9 @@ impl Parse for NamedFieldFeatures {
             AdditionalProperties,
             Required,
             Deprecated,
-            Skip
+            Skip,
+            ContentEncoding,
+            ContentMediaType
         )))
     }
 }
@@ -147,6 +155,7 @@ impl Parse for EnumNamedFieldVariantFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumNamedFieldVariantFeatures(parse_features!(
             input as Example,
+            Examples,
             XmlAttr,
             Title,
             Rename,
@@ -165,6 +174,7 @@ impl Parse for EnumUnnamedFieldVariantFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumUnnamedFieldVariantFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Title,
             Format,

--- a/crates/oapi-macros/src/schema/flattened_map_schema.rs
+++ b/crates/oapi-macros/src/schema/flattened_map_schema.rs
@@ -66,7 +66,7 @@ impl FlattenedMapSchema {
 }
 
 impl ToTokens for FlattenedMapSchema {
-    fn to_tokens(&self, stream: &mut TokenStream) {
-        self.tokens.to_tokens(stream);
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.tokens.to_tokens(tokens);
     }
 }

--- a/crates/oapi-macros/src/schema/mod.rs
+++ b/crates/oapi-macros/src/schema/mod.rs
@@ -328,9 +328,9 @@ impl TryToTokens for SchemaVariant<'_> {
 struct UnitStructVariant;
 
 impl ToTokens for UnitStructVariant {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
-        stream.extend(quote! {
+        tokens.extend(quote! {
             #oapi::oapi::schema::empty()
         });
     }

--- a/crates/oapi-macros/src/schema/xml.rs
+++ b/crates/oapi-macros/src/schema/xml.rs
@@ -76,44 +76,44 @@ impl Parse for XmlAttr {
 }
 
 impl ToTokens for XmlAttr {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
-        stream.extend(quote! {
+        tokens.extend(quote! {
             #oapi::oapi::Xml::new()
         });
 
         if let Some(ref name) = self.name {
-            stream.extend(quote! {
+            tokens.extend(quote! {
                 .name(#name)
             })
         }
 
         if let Some(ref namespace) = self.namespace {
-            stream.extend(quote! {
+            tokens.extend(quote! {
                 .namespace(#namespace)
             })
         }
 
         if let Some(ref prefix) = self.prefix {
-            stream.extend(quote! {
+            tokens.extend(quote! {
                 .prefix(#prefix)
             })
         }
 
         if self.is_attribute {
-            stream.extend(quote! {
+            tokens.extend(quote! {
                 .attribute(true)
             })
         }
 
         if self.is_wrapped.is_some() {
-            stream.extend(quote! {
+            tokens.extend(quote! {
                 .wrapped(true)
             });
 
             // if is wrapped and wrap name is defined use wrap name instead
             if let Some(ref wrap_name) = self.wrap_name {
-                stream.extend(quote! {
+                tokens.extend(quote! {
                     .name(#wrap_name)
                 })
             }

--- a/crates/oapi-macros/src/security_requirement.rs
+++ b/crates/oapi-macros/src/security_requirement.rs
@@ -46,9 +46,9 @@ impl Parse for SecurityRequirementsAttrItem {
 }
 
 impl ToTokens for SecurityRequirementsAttr {
-    fn to_tokens(&self, stream: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let oapi = crate::oapi_crate();
-        stream.extend(quote! {
+        tokens.extend(quote! {
             #oapi::oapi::security::SecurityRequirement::default()
         });
 
@@ -57,7 +57,7 @@ impl ToTokens for SecurityRequirementsAttr {
                 let scopes = scopes.iter().collect::<Array<&String>>();
                 let scopes_len = scopes.len();
 
-                stream.extend(quote! {
+                tokens.extend(quote! {
                     .add::<&str, [&str; #scopes_len], &str>(#name, #scopes)
                 });
             }

--- a/crates/oapi/docs/derive_to_parameters.md
+++ b/crates/oapi/docs/derive_to_parameters.md
@@ -272,7 +272,7 @@ _**Use `schema_with` to manually implement schema for a field.**_
 # use salvo_oapi::schema::Object;
 fn custom_type() -> Object {
     Object::new()
-        .schema_type(salvo_oapi::SchemaType::String)
+        .schema_type(salvo_oapi::BasicType::String)
         .format(salvo_oapi::SchemaFormat::Custom(
             "email".to_string(),
         ))

--- a/crates/oapi/docs/derive_to_schema.md
+++ b/crates/oapi/docs/derive_to_schema.md
@@ -498,7 +498,7 @@ _**Use `schema_with` to manually implement schema for a field.**_
 # use salvo_oapi::schema::Object;
 fn custom_type() -> Object {
     Object::new()
-        .schema_type(salvo_oapi::SchemaType::String)
+        .schema_type(salvo_oapi::BasicType::String)
         .format(salvo_oapi::SchemaFormat::Custom(
             "email".to_string(),
         ))

--- a/crates/oapi/src/extract/payload/file.rs
+++ b/crates/oapi/src/extract/payload/file.rs
@@ -8,9 +8,7 @@ use salvo_core::http::{HeaderMap, Mime, ParseError};
 use salvo_core::{async_trait, Request};
 
 use crate::endpoint::EndpointArgRegister;
-use crate::{
-    Array, Components, Content, KnownFormat, Object, Operation, RequestBody, Schema, SchemaFormat, SchemaType,
-};
+use crate::{Array, BasicType, Components, Content, KnownFormat, Object, Operation, RequestBody, Schema, SchemaFormat};
 
 /// Represents the upload file.
 #[derive(Clone, Debug)]
@@ -97,7 +95,7 @@ impl EndpointArgRegister for FormFile {
     fn register(_components: &mut Components, operation: &mut Operation, arg: &str) {
         let schema = Schema::from(Object::new().property(
             arg,
-            Object::with_type(SchemaType::String).format(SchemaFormat::KnownFormat(KnownFormat::Binary)),
+            Object::with_type(BasicType::String).format(SchemaFormat::KnownFormat(KnownFormat::Binary)),
         ));
 
         if let Some(request_body) = &mut operation.request_body {
@@ -168,8 +166,8 @@ impl EndpointArgRegister for FormFiles {
     fn register(_components: &mut Components, operation: &mut Operation, arg: &str) {
         let schema = Schema::from(Object::new().property(
             arg,
-            Array::new(Schema::from(
-                Object::with_type(SchemaType::String).format(SchemaFormat::KnownFormat(KnownFormat::Binary)),
+            Array::new().items(Schema::from(
+                Object::with_type(BasicType::String).format(SchemaFormat::KnownFormat(KnownFormat::Binary)),
             )),
         ));
         if let Some(request_body) = &mut operation.request_body {

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -83,7 +83,7 @@ extern crate self as salvo_oapi;
 ///
 /// Following manual implementation is equal to above derive one.
 /// ```
-/// use salvo_oapi::{Components, ToSchema, RefOr, Schema, SchemaFormat, SchemaType, KnownFormat, Object};
+/// use salvo_oapi::{Components, ToSchema, RefOr, Schema, SchemaFormat, BasicType, SchemaType, KnownFormat, Object};
 /// # struct Pet {
 /// #     id: u64,
 /// #     name: String,
@@ -96,7 +96,7 @@ extern crate self as salvo_oapi;
 ///             .property(
 ///                 "id",
 ///                 Object::new()
-///                     .schema_type(SchemaType::Integer)
+///                     .schema_type(BasicType::Integer)
 ///                     .format(SchemaFormat::KnownFormat(
 ///                         KnownFormat::Int64,
 ///                     )),
@@ -105,13 +105,13 @@ extern crate self as salvo_oapi;
 ///             .property(
 ///                 "name",
 ///                 Object::new()
-///                     .schema_type(SchemaType::String),
+///                     .schema_type(BasicType::String),
 ///             )
 ///             .required("name")
 ///             .property(
 ///                 "age",
 ///                 Object::new()
-///                     .schema_type(SchemaType::Integer)
+///                     .schema_type(BasicType::Integer)
 ///                     .format(SchemaFormat::KnownFormat(
 ///                         KnownFormat::Int32,
 ///                     )),
@@ -395,7 +395,7 @@ impl ToSchema for serde_json::Map<String, serde_json::Value> {
 ///                 .description("Id of pet")
 ///                 .schema(
 ///                     salvo_oapi::Object::new()
-///                         .schema_type(salvo_oapi::SchemaType::Integer)
+///                         .schema_type(salvo_oapi::schema::BasicType::Integer)
 ///                         .format(salvo_oapi::SchemaFormat::KnownFormat(salvo_oapi::schema::KnownFormat::Int64)),
 ///                 ),
 ///         ).parameter(
@@ -405,7 +405,7 @@ impl ToSchema for serde_json::Map<String, serde_json::Value> {
 ///                 .description("Name of pet")
 ///                 .schema(
 ///                     salvo_oapi::Object::new()
-///                         .schema_type(salvo_oapi::SchemaType::String),
+///                         .schema_type(salvo_oapi::schema::BasicType::String),
 ///                 ),
 ///         )
 ///     }

--- a/crates/oapi/src/openapi/components.rs
+++ b/crates/oapi/src/openapi/components.rs
@@ -89,14 +89,14 @@ impl Components {
     ///
     /// # Examples
     /// ```
-    /// # use salvo_oapi::{Components, Object, SchemaType, Schema};
+    /// # use salvo_oapi::{Components, Object, BasicType, Schema};
     /// Components::new().extend_schemas([(
     ///     "Pet",
     ///     Schema::from(
     ///         Object::new()
     ///             .property(
     ///                 "name",
-    ///                 Object::new().schema_type(SchemaType::String),
+    ///                 Object::new().schema_type(BasicType::String),
     ///             )
     ///             .required("name")
     ///     ),

--- a/crates/oapi/src/openapi/header.rs
+++ b/crates/oapi/src/openapi/header.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{Object, RefOr, Schema, SchemaType};
+use super::{BasicType, Object, RefOr, Schema};
 
 /// Implements [OpenAPI Header Object][header] for response headers.
 ///
@@ -28,8 +28,8 @@ impl Header {
     ///
     /// Create new [`Header`] with integer type.
     /// ```
-    /// # use salvo_oapi::{Header, Object, SchemaType};
-    /// let header = Header::new(Object::with_type(SchemaType::Integer));
+    /// # use salvo_oapi::{Header, Object, BasicType};
+    /// let header = Header::new(Object::with_type(BasicType::Integer));
     /// ```
     ///
     /// Create a new [`Header`] with default type `String`
@@ -60,7 +60,7 @@ impl Default for Header {
     fn default() -> Self {
         Self {
             description: Default::default(),
-            schema: Object::with_type(SchemaType::String).into(),
+            schema: Object::with_type(BasicType::String).into(),
         }
     }
 }
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_build_header() {
-        let header = Header::new(Object::with_type(SchemaType::String));
+        let header = Header::new(Object::with_type(BasicType::String));
         assert_json_eq!(
             header,
             json!({
@@ -86,7 +86,7 @@ mod tests {
 
         let header = header
             .description("test description")
-            .schema(Object::with_type(SchemaType::Number));
+            .schema(Object::with_type(BasicType::Number));
         assert_json_eq!(
             header,
             json!({

--- a/crates/oapi/src/openapi/schema/all_of.rs
+++ b/crates/oapi/src/openapi/schema/all_of.rs
@@ -29,8 +29,8 @@ pub struct AllOf {
     pub default_value: Option<Value>,
 
     /// Example shown in UI of the value for richer documentation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub examples: Vec<Value>,
 
     /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
     /// specific schema.
@@ -97,9 +97,9 @@ impl AllOf {
         self
     }
 
-    /// Add or change example shown in UI of the value for richer documentation.
-    pub fn example(mut self, example: Value) -> Self {
-        self.example = Some(example);
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, example: I) -> Self {
+        self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/oapi/src/openapi/schema/any_of.rs
+++ b/crates/oapi/src/openapi/schema/any_of.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::SchemaType;
 use crate::{Discriminator, PropMap, RefOr, Schema};
 
 /// AnyOf [Composite Object][allof] component holds
@@ -10,11 +11,22 @@ use crate::{Discriminator, PropMap, RefOr, Schema};
 ///
 /// [allof]: https://spec.openapis.org/oas/latest.html#components-object
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AnyOf {
     /// Components of _AnyOf_ component.
     #[serde(rename = "anyOf")]
     pub items: Vec<RefOr<Schema>>,
+
+    /// Type of [`AnyOf`] e.g. `SchemaType::basic(BasicType::Object)` for `object`.
+    ///
+    /// By default this is [`SchemaType::AnyValue`] as the type is defined by items
+    /// themselves.
+    #[serde(
+        rename = "type",
+        default = "SchemaType::any",
+        skip_serializing_if = "SchemaType::is_any_value"
+    )]
+    pub schema_type: SchemaType,
 
     /// Changes the [`AnyOf`] title.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,13 +49,24 @@ pub struct AnyOf {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<Discriminator>,
 
-    /// Set `true` to allow `"null"` to be used as value for given type.
-    #[serde(default, skip_serializing_if = "super::is_false")]
-    pub nullable: bool,
-
     /// Optional extensions `x-something`.
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub extensions: Option<PropMap<String, serde_json::Value>>,
+}
+
+impl Default for AnyOf {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            schema_type: SchemaType::AnyValue,
+            title: None,
+            description: Default::default(),
+            default_value: Default::default(),
+            examples: Default::default(),
+            discriminator: Default::default(),
+            extensions: Default::default(),
+        }
+    }
 }
 
 impl AnyOf {
@@ -75,7 +98,13 @@ impl AnyOf {
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object
     pub fn item<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
         self.items.push(component.into());
+        self
+    }
 
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        self.schema_type = schema_type.into();
         self
     }
 
@@ -97,6 +126,15 @@ impl AnyOf {
         self
     }
 
+    /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`AnyOf::examples`] instead**
+    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
+    pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
+        self.examples.push(example.into());
+        self
+    }
+
     /// Add or change examples shown in UI of the value for richer documentation.
     pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
         self.examples = examples.into_iter().map(Into::into).collect();
@@ -106,12 +144,6 @@ impl AnyOf {
     /// Add or change discriminator field of the composite [`AnyOf`] type.
     pub fn discriminator(mut self, discriminator: Discriminator) -> Self {
         self.discriminator = Some(discriminator);
-        self
-    }
-
-    /// Add or change nullable flag for [Object][crate::Object].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        self.nullable = nullable;
         self
     }
 
@@ -147,9 +179,11 @@ mod tests {
             .title("title")
             .description("description")
             .default_value(Value::String("default".to_string()))
-            .example(Value::String("example".to_string()))
-            .discriminator(Discriminator::new("discriminator".to_string()))
-            .nullable(true);
+            .examples([
+                Value::String("example1".to_string()),
+                Value::String("example2".to_string()),
+            ])
+            .discriminator(Discriminator::new("discriminator".to_string()));
 
         assert_eq!(any_of.items.len(), 0);
         assert_eq!(any_of.items.capacity(), 5);
@@ -160,11 +194,10 @@ mod tests {
                 "title": "title",
                 "description": "description",
                 "default": "default",
-                "example": "example",
+                "examples": ["example1", "example2"],
                 "discriminator": {
                     "propertyName": "discriminator"
-                },
-                "nullable": true
+                }
             })
         )
     }

--- a/crates/oapi/src/openapi/schema/any_of.rs
+++ b/crates/oapi/src/openapi/schema/any_of.rs
@@ -28,9 +28,9 @@ pub struct AnyOf {
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     pub default_value: Option<Value>,
 
-    /// Example shown in UI of the value for richer documentation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<Value>,
+    /// Examples shown in UI of the value for richer documentation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub examples: Vec<Value>,
 
     /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
     /// specific schema.
@@ -97,9 +97,9 @@ impl AnyOf {
         self
     }
 
-    /// Add or change example shown in UI of the value for richer documentation.
-    pub fn example(mut self, example: Value) -> Self {
-        self.example = Some(example);
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/oapi/src/openapi/schema/array.rs
+++ b/crates/oapi/src/openapi/schema/array.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::schema::BasicType;
 use crate::{Deprecated, PropMap, RefOr, Schema, SchemaType, Xml};
 
 /// Array represents [`Vec`] or [`slice`] type  of items.
@@ -54,10 +55,6 @@ pub struct Array {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub xml: Option<Xml>,
 
-    /// Set `true` to allow `"null"` to be used as value for given type.
-    #[serde(default, skip_serializing_if = "super::is_false")]
-    pub nullable: bool,
-
     /// Optional extensions `x-something`.
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub extensions: Option<PropMap<String, serde_json::Value>>,
@@ -67,17 +64,16 @@ impl Default for Array {
     fn default() -> Self {
         Self {
             title: Default::default(),
-            schema_type: SchemaType::Array,
+            schema_type: BasicType::Array.into(),
             unique_items: bool::default(),
             items: Default::default(),
             description: Default::default(),
             deprecated: Default::default(),
-            example: Default::default(),
+            examples: Default::default(),
             default_value: Default::default(),
             max_items: Default::default(),
             min_items: Default::default(),
             xml: Default::default(),
-            nullable: Default::default(),
             extensions: Default::default(),
         }
     }
@@ -88,20 +84,34 @@ impl Array {
     ///
     /// # Examples
     ///
-    /// Create a `String` array component.
+    /// _**Create a `String` array component.**_
     /// ```
-    /// # use salvo_oapi::schema::{Schema, Array, SchemaType, Object};
-    /// let string_array = Array::new(Object::with_type(SchemaType::String));
+    /// # use salvo_oapi::schema::{Schema, Array, SchemaType, BasicType, Object};
+    /// let string_array = Array::new().items(Object::with_type(BasicType::String));
     /// ```
-    pub fn new<I: Into<RefOr<Schema>>>(items: I) -> Self {
-        Self {
-            items: Box::new(items.into()),
-            ..Default::default()
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
     /// Set [`Schema`] type for the [`Array`].
-    pub fn items<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
-        self.items = Box::new(component.into());
+    pub fn items<I: Into<RefOr<Schema>>>(mut self, items: I) -> Self {
+        self.items = Box::new(items.into());
+        self
+    }
+
+    /// Change type of the array e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    ///
+    /// # Examples
+    ///
+    /// _**Make nullable string array.**_
+    /// ```rust
+    /// # use salvo_oapi::schema::{Array, BasicType, SchemaType, Object};
+    /// let _ = Array::new()
+    ///     .schema_type(SchemaType::from_iter([BasicType::Array, BasicType::Null]))
+    ///     .items(Object::with_type(BasicType::String));
+    /// ```
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        self.schema_type = schema_type.into();
         self
     }
 
@@ -124,11 +134,20 @@ impl Array {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`Array::examples`] instead**
+    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
+    pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
+        self.examples.push(example.into());
+        self
+    }
+
+    /// Add or change example shown in UI of the value for richer documentation.
     pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
         self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
-    
+
     /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
     pub fn default_value(mut self, default: Value) -> Self {
         self.default_value = Some(default);
@@ -156,12 +175,6 @@ impl Array {
     /// Set [`Xml`] formatting for [`Array`].
     pub fn xml(mut self, xml: Xml) -> Self {
         self.xml = Some(xml);
-        self
-    }
-
-    /// Add or change nullable flag for [Object][crate::Object].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        self.nullable = nullable;
         self
     }
 
@@ -194,7 +207,7 @@ where
 {
     /// Convert a type to [`Array`].
     fn to_array(self) -> Array {
-        Array::new(self)
+        Array::new().items(self)
     }
 }
 
@@ -208,18 +221,20 @@ mod tests {
 
     #[test]
     fn test_build_array() {
-        let array = Array::new(Object::with_type(SchemaType::Object))
-            .items(Object::with_type(SchemaType::String))
+        let array = Array::new()
+            .items(Object::with_type(BasicType::String))
             .title("title")
             .description("description")
             .deprecated(Deprecated::False)
-            .example(Value::String("example".to_string()))
+            .examples([
+                Value::String("example1".to_string()),
+                Value::String("example2".to_string()),
+            ])
             .default_value(Value::String("default".to_string()))
             .max_items(10)
             .min_items(1)
             .unique_items(true)
-            .xml(Xml::new())
-            .nullable(false);
+            .xml(Xml::new());
 
         assert_json_eq!(
             array,
@@ -231,7 +246,7 @@ mod tests {
                 "title": "title",
                 "description": "description",
                 "deprecated": false,
-                "example": "example",
+                "examples": ["example1", "example2"],
                 "default": "default",
                 "maxItems": 10,
                 "minItems": 1,

--- a/crates/oapi/src/openapi/schema/array.rs
+++ b/crates/oapi/src/openapi/schema/array.rs
@@ -29,9 +29,9 @@ pub struct Array {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<Deprecated>,
 
-    /// Example shown in UI of the value for richer documentation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<Value>,
+    /// Examples shown in UI of the value for richer documentation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub examples: Vec<Value>,
 
     /// Default value which is provided when user has not provided the input in Swagger UI.
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
@@ -124,11 +124,11 @@ impl Array {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    pub fn example(mut self, example: Value) -> Self {
-        self.example = Some(example);
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
-
+    
     /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
     pub fn default_value(mut self, default: Value) -> Self {
         self.default_value = Some(default);

--- a/crates/oapi/src/openapi/schema/object.rs
+++ b/crates/oapi/src/openapi/schema/object.rs
@@ -65,9 +65,9 @@ pub struct Object {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<Deprecated>,
 
-    /// Example shown in UI of the value for richer documentation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<Value>,
+    /// Examples shown in UI of the value for richer documentation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub examples: Vec<Value>,
 
     /// Write only property will be only sent in _write_ requests like _POST, PUT_.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -227,9 +227,9 @@ impl Object {
         self
     }
 
-    /// Add or change example shown in UI of the value for richer documentation.
-    pub fn example(mut self, example: Value) -> Self {
-        self.example = Some(example);
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/oapi/src/openapi/schema/one_of.rs
+++ b/crates/oapi/src/openapi/schema/one_of.rs
@@ -28,9 +28,9 @@ pub struct OneOf {
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     pub default_value: Option<Value>,
 
-    /// Example shown in UI of the value for richer documentation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<Value>,
+    /// Examples shown in UI of the value for richer documentation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub examples: Vec<Value>,
 
     /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
     /// specific schema.
@@ -97,9 +97,9 @@ impl OneOf {
         self
     }
 
-    /// Add or change example shown in UI of the value for richer documentation.
-    pub fn example(mut self, example: Value) -> Self {
-        self.example = Some(example);
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        self.examples = examples.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/oapi/src/openapi/schema/one_of.rs
+++ b/crates/oapi/src/openapi/schema/one_of.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{Discriminator, PropMap, RefOr, Schema};
+use crate::{Discriminator, PropMap, RefOr, Schema, SchemaType};
 
 /// OneOf [Composite Object][oneof] component holds
 /// multiple components together where API endpoint could return any of them.
@@ -10,11 +10,22 @@ use crate::{Discriminator, PropMap, RefOr, Schema};
 ///
 /// [oneof]: https://spec.openapis.org/oas/latest.html#components-object
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct OneOf {
     /// Components of _OneOf_ component.
     #[serde(rename = "oneOf")]
     pub items: Vec<RefOr<Schema>>,
+
+    /// Type of [`OneOf`] e.g. `SchemaType::basic(BasicType::Object)` for `object`.
+    ///
+    /// By default this is [`SchemaType::AnyValue`] as the type is defined by items
+    /// themselves.
+    #[serde(
+        rename = "type",
+        default = "SchemaType::any",
+        skip_serializing_if = "SchemaType::is_any_value"
+    )]
+    pub schema_type: SchemaType,
 
     /// Changes the [`OneOf`] title.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,13 +48,24 @@ pub struct OneOf {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<Discriminator>,
 
-    /// Set `true` to allow `"null"` to be used as value for given type.
-    #[serde(default, skip_serializing_if = "super::is_false")]
-    pub nullable: bool,
-
     /// Optional extensions `x-something`.
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub extensions: Option<PropMap<String, serde_json::Value>>,
+}
+
+impl Default for OneOf {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            schema_type: SchemaType::AnyValue,
+            title: Default::default(),
+            description: Default::default(),
+            default_value: Default::default(),
+            examples: Default::default(),
+            discriminator: Default::default(),
+            extensions: Default::default(),
+        }
+    }
 }
 
 impl OneOf {
@@ -79,6 +101,13 @@ impl OneOf {
         self
     }
 
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        self.schema_type = schema_type.into();
+        self
+    }
+
     /// Add or change the title of the [`OneOf`].
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
@@ -97,6 +126,15 @@ impl OneOf {
         self
     }
 
+    /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`OneOf::examples`] instead**
+    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
+    pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
+        self.examples.push(example.into());
+        self
+    }
+
     /// Add or change examples shown in UI of the value for richer documentation.
     pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
         self.examples = examples.into_iter().map(Into::into).collect();
@@ -106,12 +144,6 @@ impl OneOf {
     /// Add or change discriminator field of the composite [`OneOf`] type.
     pub fn discriminator(mut self, discriminator: Discriminator) -> Self {
         self.discriminator = Some(discriminator);
-        self
-    }
-
-    /// Add or change nullable flag for [Object][crate::Object].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        self.nullable = nullable;
         self
     }
 
@@ -147,9 +179,11 @@ mod tests {
             .title("title")
             .description("description")
             .default_value(Value::String("default".to_string()))
-            .example(Value::String("example".to_string()))
-            .discriminator(Discriminator::new("discriminator".to_string()))
-            .nullable(true);
+            .examples([
+                Value::String("example1".to_string()),
+                Value::String("example2".to_string()),
+            ])
+            .discriminator(Discriminator::new("discriminator".to_string()));
 
         assert_eq!(one_of.items.len(), 0);
         assert_eq!(one_of.items.capacity(), 5);
@@ -160,11 +194,10 @@ mod tests {
                 "title": "title",
                 "description": "description",
                 "default": "default",
-                "example": "example",
+                "examples": ["example1", "example2"],
                 "discriminator": {
                     "propertyName": "discriminator"
-                },
-                "nullable": true
+                }
             })
         )
     }


### PR DESCRIPTION
Add support for deriving `content_encoding` and `content_media_type` on
struct named fields.

In OpenAPI 3.0 the request body and response body with type `string` and
format `binary`, `byte`, `base64` was considered a
`application/octet-stream`. However the OpenAPI 3.1 does not require
such and and the schema can be completely ignored in such cases.

This commit will remove the old behaviour where [u8] was rendered as
`type: string` `format: binary` for recognizing
`application/octet-stream`. From now on the content schema will be
resolved as is which means that [u8] will be rendered as `type: array`
of `items: int32`.

Update documentation and add more known formats according to the https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.3