### PR TITLE
Fix respect required attribute

### DIFF
--- a/crates/oapi-macros/src/schema/struct_schemas.rs
+++ b/crates/oapi-macros/src/schema/struct_schemas.rs
@@ -194,12 +194,13 @@ impl TryToTokens for NamedStructSchema<'_> {
                 .property(#name, #property)
             });
 
-            if (!is_option && crate::is_required(field_rule.as_ref(), container_rules.as_ref()))
-                || required
-                    .as_ref()
-                    .map(crate::feature::Required::is_true)
-                    .unwrap_or(false)
-            {
+            let component_required = !is_option && crate::is_required(field_rule.as_ref(), container_rules.as_ref());
+            let required = match (required, component_required) {
+                (Some(required), _) => required.is_true(),
+                (None, component_required) => component_required,
+            };
+
+            if required {
                 object_tokens.extend(quote! {
                     .required(#name)
                 })

--- a/crates/oapi/src/openapi/schema/all_of.rs
+++ b/crates/oapi/src/openapi/schema/all_of.rs
@@ -127,9 +127,6 @@ impl AllOf {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    ///
-    /// **Deprecated since 3.0.x. Prefer [`AllOf::examples`] instead**
-    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
     pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
         self.examples.push(example.into());
         self

--- a/crates/oapi/src/openapi/schema/any_of.rs
+++ b/crates/oapi/src/openapi/schema/any_of.rs
@@ -127,9 +127,6 @@ impl AnyOf {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    ///
-    /// **Deprecated since 3.0.x. Prefer [`AnyOf::examples`] instead**
-    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
     pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
         self.examples.push(example.into());
         self

--- a/crates/oapi/src/openapi/schema/array.rs
+++ b/crates/oapi/src/openapi/schema/array.rs
@@ -134,9 +134,6 @@ impl Array {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    ///
-    /// **Deprecated since 3.0.x. Prefer [`Array::examples`] instead**
-    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
     pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
         self.examples.push(example.into());
         self

--- a/crates/oapi/src/openapi/schema/object.rs
+++ b/crates/oapi/src/openapi/schema/object.rs
@@ -241,9 +241,6 @@ impl Object {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    ///
-    /// **Deprecated since 3.0.x. Prefer [`Object::examples`] instead**
-    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
     pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
         self.examples.push(example.into());
         self

--- a/crates/oapi/src/openapi/schema/one_of.rs
+++ b/crates/oapi/src/openapi/schema/one_of.rs
@@ -127,9 +127,6 @@ impl OneOf {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
-    ///
-    /// **Deprecated since 3.0.x. Prefer [`OneOf::examples`] instead**
-    #[deprecated = "Since OpenAPI 3.1 prefer using `examples`"]
     pub fn example<V: Into<Value>>(mut self, example: V) -> Self {
         self.examples.push(example.into());
         self


### PR DESCRIPTION
Merge from utoipa: https://github.com/juhaku/utoipa/pull/990

Prior to this PR the required attribute was not correctly respected in
all cases. This was due to the fact that the required attribute had the
same weight with the default rule that is checked from the option and some
other serde attributes. Even this works in most cases but lacks control
over explicitly defining required to false when type is not
optional.

This PR fixes this by making clear separation between the default rule
and the manual required attribute with preference on the manually
defined required attribute.