### PR TITLE
Added middleware method to service.rs

### DIFF
--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -86,6 +86,13 @@ impl Service {
         self
     }
 
+     /// An alternative to hoop. Add a handler as middleware, it will run the handler when request received.
+    #[inline]
+    pub fn middleware<H: Handler>(mut self, handler: H) -> Self {
+        self.hoops.push(Arc::new(handler));
+        self
+    }
+
     /// Add a handler as middleware, it will run the handler when request received.
     ///
     /// This middleware only effective when the filter return true.


### PR DESCRIPTION
#867
Added an implementation method for Service in service.rs that serves as an alternative to the hoop method.