### PR TITLE
fix: Derive ToSchema not work for unit enum variants

### DIFF
--- a/crates/oapi-macros/src/schema/enum_variant.rs
+++ b/crates/oapi-macros/src/schema/enum_variant.rs
@@ -274,7 +274,7 @@ impl TryToTokens for UntaggedEnum {
 
         tokens.extend(quote! {
             #oapi::oapi::schema::Object::new()
-                 .schema_type(#oapi::oapi::openapi::schema::BasicType::Null)
+                 .schema_type(#oapi::oapi::schema::BasicType::Null)
                 .default_value(#oapi::oapi::__private::serde_json::Value::Null)
                 #title
         });


### PR DESCRIPTION
Close #874