### PR TITLE
display actual number of connections; don't wait if stop_forcible

### DIFF
--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -335,7 +335,7 @@ impl<A: Acceptor + Send> Server<A> {
                 }
             }
 
-            if alive_connections.load(Ordering::Acquire) > 0 {
+            if !force_stop_token.is_cancelled() && alive_connections.load(Ordering::Acquire) > 0 {
                 tracing::info!("wait for all connections to close.");
                 notify.notified().await;
             }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -336,7 +336,7 @@ impl<A: Acceptor + Send> Server<A> {
             }
 
             if !force_stop_token.is_cancelled() && alive_connections.load(Ordering::Acquire) > 0 {
-                tracing::info!("wait for all connections to close.");
+                tracing::info!("wait for {} connections to close.",alive_connections.load(Ordering::Acquire));
                 notify.notified().await;
             }
 


### PR DESCRIPTION
#923 The graceful shutdown function causes the process to hang when exiting.

stop_forcible should be respected and we should not wait for connections.  display the number of connections instead of saying all.  I need to test graceful behavior more but this allows my program to exit when I stop_forible.