### PR TITLE
fix: correct typos and update URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<p><img alt="Savlo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
+<p><img alt="Salvo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
 <p>
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.md">English</a>&nbsp;&nbsp;
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.zh-hans.md">简体中文</a>&nbsp;&nbsp;
@@ -48,11 +48,13 @@ Salvo is an extremely simple and powerful Rust web backend framework. Only basic
 - Support Tower Service and Layer;
 
 ## ⚡️ Quick Start
+
 You can view samples [here](https://github.com/salvo-rs/salvo/tree/main/examples), or view [official website](https://salvo.rs).
 
 ### Hello World with ACME and HTTP3
 
-**It only takes a few lines of code to implement a server that supports ACME to automatically obtain certificates and supports HTTP1, HTTP2, and HTTP3 protocols.**
+**It only takes a few lines of code to implement a server that supports ACME to automatically obtain certificates and
+supports HTTP1, HTTP2, and HTTP3 protocols.**
 
 ```rust
 use salvo::prelude::*;
@@ -76,7 +78,8 @@ async fn main() {
 
 ### Middleware
 
-There is no difference between Handler and Middleware, Middleware is just Handler. **So you can write middlewares without to know concepts like associated type, generic type. You can write middleware if you can write function!!!**
+There is no difference between Handler and Middleware, Middleware is just Handler. **So you can write middlewares
+without to know concepts like associated type, generic type. You can write middleware if you can write function!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -95,61 +98,67 @@ Then add it to router:
 Router::new().hoop(add_header).get(hello)
 ```
 
-This is a very simple middleware, it adds `Header` to `Response`, view [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
+This is a very simple middleware, it adds `Header` to
+`Response`, view [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### Chainable tree routing system
 
-Normally we write routing like this：
+Normally we write routing like this:
 
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-    .get(show_article)
-    .patch(edit_article)
-    .delete(delete_article);
+.get(show_article)
+.patch(edit_article)
+.delete(delete_article);
 ```
 
 Often viewing articles and article lists does not require user login, but creating, editing, deleting articles, etc. require user login authentication permissions. The tree-like routing system in Salvo can meet this demand. We can write routers without user login together:
 
 ```rust
 Router::with_path("articles")
-    .get(list_articles)
-    .push(Router::with_path("<id>").get(show_article));
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article));
 ```
 
 Then write the routers that require the user to login together, and use the corresponding middleware to verify whether the user is logged in:
+
 ```rust
 Router::with_path("articles")
-    .hoop(auth_check)
-    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
-Although these two routes have the same `path("articles")`, they can still be added to the same parent route at the same time, so the final route looks like this:
+Although these two routes have the same
+`path("articles")`, they can still be added to the same parent route at the same time, so the final route looks like this:
 
 ```rust
 Router::new()
-    .push(
-        Router::with_path("articles")
-            .get(list_articles)
-            .push(Router::with_path("<id>").get(show_article)),
-    )
-    .push(
-        Router::with_path("articles")
-            .hoop(auth_check)
-            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-    );
+.push(
+Router::with_path("articles")
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article)),
+)
+.push(
+Router::with_path("articles")
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+);
 ```
 
-`<id>` matches a fragment in the path, under normal circumstances, the article `id` is just a number, which we can use regular expressions to restrict `id` matching rules, `r"<id:/\d+/>"`.
+`<id>` matches a fragment in the path, under normal circumstances, the article
+`id` is just a number, which we can use regular expressions to restrict `id` matching rules, `r"<id:/\d+/>"`.
 
-You can also use `<**>`,  `<*+>` or `<*?>` to match all remaining path fragments. In order to make the code more readable, you can also add appropriate name to make the path semantics more clear, for example: `<**file_path>`.
+You can also use `<**>`,  `<*+>` or
+`<*?>` to match all remaining path fragments. In order to make the code more readable, you can also add appropriate name to make the path semantics more clear, for example:
+`<**file_path>`.
 
 Some regular expressions for matching paths need to be used frequently, and it can be registered in advance, such as GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-    "guid",
-    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+"guid",
+Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
@@ -265,16 +274,22 @@ async fn main() {
 ```
 
 ### 🛠️ Salvo CLI
+
 Salvo CLI is a command-line tool that simplifies the creation of new Salvo projects, supporting templates for web APIs, websites, databases (including SQLite, PostgreSQL, and MySQL via SQLx, SeaORM, Diesel, Rbatis), and basic middleware.
 You can use [salvo-cli](https://github.com/salvo-rs/salvo-cli) to create a new Salvo project:
+
 #### install
+
 ```bash
 cargo install salvo-cli
 ```
+
 #### create a new salvo project
+
 ```bash
 salvo new project_name
 ```
+
 ___
 
 ### More Examples
@@ -304,7 +319,8 @@ Benchmark testing result can be found from here:
 
 ## ☕ Donate
 
-Salvo is an open source project. If you want to support Salvo, you can ☕ [**buy me a coffee here**](https://ko-fi.com/chrislearn).
+Salvo is an open source project. If you want to support Salvo, you can ☕ [**buy me a coffee here
+**](https://ko-fi.com/chrislearn).
 
 ## ⚠️ License
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ Then add it to router:
 Router::new().hoop(add_header).get(hello)
 ```
 
-This is a very simple middleware, it adds `Header` to
-`Response`, view [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
+This is a very simple middleware, it adds `Header` to `Response`, view [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### Chainable tree routing system
 
@@ -108,25 +107,25 @@ Normally we write routing like this:
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-.get(show_article)
-.patch(edit_article)
-.delete(delete_article);
+    .get(show_article)
+    .patch(edit_article)
+    .delete(delete_article);
 ```
 
 Often viewing articles and article lists does not require user login, but creating, editing, deleting articles, etc. require user login authentication permissions. The tree-like routing system in Salvo can meet this demand. We can write routers without user login together:
 
 ```rust
 Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article));
+    .get(list_articles)
+    .push(Router::with_path("<id>").get(show_article));
 ```
 
 Then write the routers that require the user to login together, and use the corresponding middleware to verify whether the user is logged in:
 
 ```rust
 Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+    .hoop(auth_check)
+    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
 Although these two routes have the same
@@ -134,31 +133,29 @@ Although these two routes have the same
 
 ```rust
 Router::new()
-.push(
-Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article)),
-)
-.push(
-Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-);
+    .push(
+        Router::with_path("articles")
+            .get(list_articles)
+            .push(Router::with_path("<id>").get(show_article)),
+    )
+    .push(
+        Router::with_path("articles")
+            .hoop(auth_check)
+            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+    );
 ```
 
-`<id>` matches a fragment in the path, under normal circumstances, the article
-`id` is just a number, which we can use regular expressions to restrict `id` matching rules, `r"<id:/\d+/>"`.
+`<id>` matches a fragment in the path, under normal circumstances, the article`id` is just a number, which we can use regular expressions to restrict `id` matching rules, `r"<id:/\d+/>"`.
 
-You can also use `<**>`,  `<*+>` or
-`<*?>` to match all remaining path fragments. In order to make the code more readable, you can also add appropriate name to make the path semantics more clear, for example:
-`<**file_path>`.
+You can also use `<**>`,  `<*+>` or`<*?>` to match all remaining path fragments.
+In order to make the code more readable, you can also add appropriate name to make the path semantics more clear, for example: `<**file_path>`.
 
 Some regular expressions for matching paths need to be used frequently, and it can be registered in advance, such as GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-"guid",
-Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+    "guid",
+    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 

--- a/README.osc.md
+++ b/README.osc.md
@@ -47,7 +47,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架。�
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
 - 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/)获取 TLS 证书。
-- 支持 Tower Serivce 和 Layer.
+- 支持 Tower Service 和 Layer.
 
 ## ⚡️ 快速开始
 

--- a/README.osc.md
+++ b/README.osc.md
@@ -33,9 +33,9 @@
 </p>
 </div>
 
-Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅仅需要基础 Rust 知识即可开发后端服务.
+Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架。仅仅需要基础 Rust 知识即可开发后端服务。
 
-> 中国用户可以添加我微信(chrislearn), 拉微信讨论群或者直接加入QQ群：823441777.
+> 中国用户可以添加我微信 (chrislearn), 拉微信讨论群或者直接加入 QQ 群：823441777.
 
 ## 🎯 功能特色
 
@@ -46,7 +46,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 - 集成 Multipart 表单处理;
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
-- 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/) 获取 TLS 证书.
+- 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/)获取 TLS 证书。
 - 支持 Tower Serivce 和 Layer.
 
 ## ⚡️ 快速开始
@@ -55,7 +55,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 
 ### 支持 ACME 自动获取证书和 HTTP3 的 Hello World
 
-**只需要几行代码就可以实现一个同时支持 ACME 自动获取证书以及支持 HTTP1，HTTP2， HTTP3 协议的服务器.**
+**只需要几行代码就可以实现一个同时支持 ACME 自动获取证书以及支持 HTTP1，HTTP2，HTTP3 协议的服务器。**
 
 ```rust
 use salvo::prelude::*;
@@ -70,7 +70,7 @@ async fn main() {
     let mut router = Router::new().get(hello);
     let listener = TcpListener::new("0.0.0.0:443")
         .acme()
-        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名.
+        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名
         .http01_challenge(&mut router).quinn("0.0.0.0:443");
     let acceptor = listener.join(TcpListener::new("0.0.0.0:80")).bind().await;
     Server::new(acceptor).serve(router).await;
@@ -79,8 +79,8 @@ async fn main() {
 
 ### 中间件
 
-Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识.
-只要你会写函数就会写中间件, 就是这么简单!!!**
+Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处。**所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识。
+只要你会写函数就会写中间件，就是这么简单!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -93,14 +93,13 @@ async fn add_header(res: &mut Response) {
 }
 ```
 
-然后将它添加到路由中:
+然后将它添加到路由中：
 
 ```rust
 Router::new().hoop(add_header).get(hello)
 ```
 
-这就是一个简单的中间件, 它向 `Response` 的头部添加了
-`Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
+这就是一个简单的中间件，它向 `Response` 的头部添加了 `Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可链式书写的树状路由系统
 
@@ -109,59 +108,57 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-.get(show_article)
-.patch(edit_article)
-.delete(delete_article);
+    .get(show_article)
+    .patch(edit_article)
+    .delete(delete_article);
 ```
 
-往往查看文章和文章列表是不需要用户登录的, 但是创建, 编辑, 删除文章等需要用户登录认证权限才可以. Salvo 中支持嵌套的路由系统可以很好地满足这种需求. 我们可以把不需要用户登录的路由写到一起：
+往往查看文章和文章列表是不需要用户登录的，但是创建，编辑，删除文章等需要用户登录认证权限才可以。Salvo 中支持嵌套的路由系统可以很好地满足这种需求。我们可以把不需要用户登录的路由写到一起：
 
 ```rust
 Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article));
+    .get(list_articles)
+    .push(Router::with_path("<id>").get(show_article));
 ```
 
-然后把需要用户登录的路由写到一起， 并且使用相应的中间件验证用户是否登录：
+然后把需要用户登录的路由写到一起，并且使用相应的中间件验证用户是否登录：
 
 ```rust
 Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+    .hoop(auth_check)
+    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
-虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由, 所以最后的路由长成了这个样子:
+虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由，所以最后的路由长成了这个样子：
 
 ```rust
 Router::new()
-.push(
-Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article)),
-)
-.push(
-Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-);
+    .push(
+        Router::with_path("articles")
+            .get(list_articles)
+            .push(Router::with_path("<id>").get(show_article)),
+    )
+    .push(
+        Router::with_path("articles")
+            .hoop(auth_check)
+            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+    );
 ```
 
-`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则,
-`r"<id:/\d+/>"`.
+`<id>`匹配了路径中的一个片段，正常情况下文章的的 `id`只是一个数字，这是我们可以使用正则表达式限制制 `id`的匹配规则，`r"<id:/\d+/>"`.
 
-还可以通过 `<**>`, `<*+>` 或者
-`<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
+还可以通过 `<**>`, `<*+>` 或者 `<*?>`匹配所有剩余的路径片段。为了代码易读性性强些，也可以添加适合的名字，让路径语义更清晰，比如：: `<**file_path>`.
 
-有些用于匹配路径的正则表达式需要经常被使用, 可以将它事先注册, 比如 GUID:
+有些用于匹配路径的正则表达式需要经常被使用，可以将它事先注册，比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-"guid",
-Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+    "guid",
+    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
-这样在需要路径匹配时就变得更简洁:
+这样在需要路径匹配时就变得更简洁：
 
 ```rust
 Router::with_path("<id:guid>").get(index)
@@ -171,7 +168,7 @@ Router::with_path("<id:guid>").get(index)
 
 ### 文件上传
 
-可以通过 `Request` 中的 `file` 异步获取上传的文件:
+可以通过 `Request` 中的 `file`异步获取上传的文件：
 
 ```rust
 #[handler]
@@ -192,7 +189,7 @@ async fn upload(req: &mut Request, res: &mut Response) {
 
 ### 提取请求数据
 
-可以轻松地从多个不同数据源获取数据, 并且组装为你想要的类型. 可以先定义一个自定义的类型, 比如:
+可以轻松地从多个不同数据源获取数据，并且组装为你想要的类型。可以先定义一个自定义的类型，比如：
 
 ```rust
 #[derive(Serialize, Deserialize, Extractible, Debug)]
@@ -209,7 +206,7 @@ struct GoodMan<'a> {
 }
 ```
 
-然后在 `Handler` 中可以这样获取数据:
+然后在 `Handler`中可以这样获取数据：
 
 ```rust
 #[handler]
@@ -218,7 +215,7 @@ async fn edit(req: &mut Request) {
 }
 ```
 
-甚至于可以直接把类型作为参数传入函数, 像这样:
+甚至于可以直接把类型作为参数传入函数，像这样：
 
 ```rust
 #[handler]
@@ -274,8 +271,8 @@ async fn main() {
 
 ### 🛠️ Salvo CLI
 
-Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程，支持Web API、网站、数据库（包括通过SQLx、SeaORM、Diesel、Rbatis支持的SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
-你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来创建一个新的 Salvo 项目:
+Salvo CLI 是一个命令行工具，可以简化创建新的 Salvo 项目的过程，支持 Web API、网站、数据库（包括通过 SQLx、SeaORM、Diesel、Rbatis 支持的 SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
+你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli)来创建一个新的 Salvo 项目：
 
 #### 安装
 
@@ -283,7 +280,7 @@ Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程
 cargo install salvo-cli
 ```
 
-#### 创建一个salvo项目
+#### 创建一个 Salvo 项目
 
 ```bash
 salvo new project_name
@@ -293,7 +290,7 @@ ___
 
 ### 更多示例
 
-您可以从 [examples](./examples/) 文件夹下查看更多示例代码, 您可以通过以下命令运行这些示例：
+您可以从 [examples](./examples/)文件夹下查看更多示例代码，您可以通过以下命令运行这些示例：
 
 ```bash
 cd examples
@@ -304,7 +301,7 @@ cargo run --bin example-basic-auth
 
 ## 🚀 性能
 
-Benchmark 测试结果可以从这里查看:
+Benchmark 测试结果可以从这里查看：
 
 [https://web-frameworks-benchmark.netlify.app/result?l=rust](https://web-frameworks-benchmark.netlify.app/result?l=rust)
 
@@ -318,14 +315,14 @@ Benchmark 测试结果可以从这里查看:
 
 ## ☕ 捐助
 
-`Salvo`是一个开源项目, 如果想支持本项目, 可以 ☕ [**请我喝杯咖啡**](https://ko-fi.com/chrislearn).
+`Salvo`是一个开源项目，如果想支持本项目，可以 ☕ [**请我喝杯咖啡**](https://ko-fi.com/chrislearn).
 <p style="text-align: center;">
 <img src="https://salvo.rs/images/alipay.png" alt="Alipay" width="180"/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://salvo.rs/images/weixin.png" alt="Weixin" width="180"/>
 </p>
 
 ## ⚠️ 开源协议
 
-Salvo 项目采用以下开源协议:
+Salvo 项目采用以下开源协议：
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
 

--- a/README.osc.md
+++ b/README.osc.md
@@ -1,5 +1,5 @@
 <div align="center">
-<p><img alt="Savlo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
+<p><img alt="Salvo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
 <p>
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.md">English</a>&nbsp;&nbsp;
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.zh-hans.md">简体中文</a>&nbsp;&nbsp;
@@ -51,7 +51,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 
 ## ⚡️ 快速开始
 
-你可以查看[实例代码](https://github.com/salvo-rs/salvo/tree/main/examples),  或者访问[官网](https://salvo.rs).
+你可以查看[实例代码](https://github.com/salvo-rs/salvo/tree/main/examples), 或者访问[官网](https://salvo.rs).
 
 ### 支持 ACME 自动获取证书和 HTTP3 的 Hello World
 
@@ -79,7 +79,8 @@ async fn main() {
 
 ### 中间件
 
-Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识. 只要你会写函数就会写中间件, 就是这么简单!!!**
+Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识.
+只要你会写函数就会写中间件, 就是这么简单!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -98,8 +99,8 @@ async fn add_header(res: &mut Response) {
 Router::new().hoop(add_header).get(hello)
 ```
 
-这就是一个简单的中间件, 它向 `Response` 的头部添加了 `Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
-
+这就是一个简单的中间件, 它向 `Response` 的头部添加了
+`Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可链式书写的树状路由系统
 
@@ -108,53 +109,55 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-    .get(show_article)
-    .patch(edit_article)
-    .delete(delete_article);
+.get(show_article)
+.patch(edit_article)
+.delete(delete_article);
 ```
 
 往往查看文章和文章列表是不需要用户登录的, 但是创建, 编辑, 删除文章等需要用户登录认证权限才可以. Salvo 中支持嵌套的路由系统可以很好地满足这种需求. 我们可以把不需要用户登录的路由写到一起：
 
 ```rust
 Router::with_path("articles")
-    .get(list_articles)
-    .push(Router::with_path("<id>").get(show_article));
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article));
 ```
 
 然后把需要用户登录的路由写到一起， 并且使用相应的中间件验证用户是否登录：
 
 ```rust
 Router::with_path("articles")
-    .hoop(auth_check)
-    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
 虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由, 所以最后的路由长成了这个样子:
 
 ```rust
 Router::new()
-    .push(
-        Router::with_path("articles")
-            .get(list_articles)
-            .push(Router::with_path("<id>").get(show_article)),
-    )
-    .push(
-        Router::with_path("articles")
-            .hoop(auth_check)
-            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-    );
+.push(
+Router::with_path("articles")
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article)),
+)
+.push(
+Router::with_path("articles")
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+);
 ```
 
-`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则, `r"<id:/\d+/>"`.
+`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则,
+`r"<id:/\d+/>"`.
 
-还可以通过 `<**>`, `<*+>` 或者 `<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
+还可以通过 `<**>`, `<*+>` 或者
+`<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
 
 有些用于匹配路径的正则表达式需要经常被使用, 可以将它事先注册, 比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-    "guid",
-    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+"guid",
+Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
@@ -217,7 +220,6 @@ async fn edit(req: &mut Request) {
 
 甚至于可以直接把类型作为参数传入函数, 像这样:
 
-
 ```rust
 #[handler]
 async fn edit<'a>(good_man: GoodMan<'a>) {
@@ -226,7 +228,6 @@ async fn edit<'a>(good_man: GoodMan<'a>) {
 ```
 
 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs)
-
 
 ### OpenAPI 支持
 
@@ -272,16 +273,22 @@ async fn main() {
 ```
 
 ### 🛠️ Salvo CLI
+
 Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程，支持Web API、网站、数据库（包括通过SQLx、SeaORM、Diesel、Rbatis支持的SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
 你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来创建一个新的 Salvo 项目:
+
 #### 安装
+
 ```bash
 cargo install salvo-cli
 ```
+
 #### 创建一个salvo项目
+
 ```bash
 salvo new project_name
 ```
+
 ___
 
 ### 更多示例

--- a/README.zh-hans.md
+++ b/README.zh-hans.md
@@ -1,5 +1,5 @@
 <div align="center">
-<p><img alt="Savlo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
+<p><img alt="Salvo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
 <p>
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.md">English</a>&nbsp;&nbsp;
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.zh-hans.md">简体中文</a>&nbsp;&nbsp;
@@ -51,7 +51,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 
 ## ⚡️ 快速开始
 
-你可以查看[实例代码](https://github.com/salvo-rs/salvo/tree/main/examples),  或者访问[官网](https://salvo.rs).
+你可以查看[实例代码](https://github.com/salvo-rs/salvo/tree/main/examples), 或者访问[官网](https://salvo.rs).
 
 ### 支持 ACME 自动获取证书和 HTTP3 的 Hello World
 
@@ -79,7 +79,8 @@ async fn main() {
 
 ### 中间件
 
-Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识. 只要你会写函数就会写中间件, 就是这么简单!!!**
+Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识.
+只要你会写函数就会写中间件, 就是这么简单!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -98,8 +99,8 @@ async fn add_header(res: &mut Response) {
 Router::new().hoop(add_header).get(hello)
 ```
 
-这就是一个简单的中间件, 它向 `Response` 的头部添加了 `Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
-
+这就是一个简单的中间件, 它向 `Response` 的头部添加了
+`Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可链式书写的树状路由系统
 
@@ -108,53 +109,55 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-    .get(show_article)
-    .patch(edit_article)
-    .delete(delete_article);
+.get(show_article)
+.patch(edit_article)
+.delete(delete_article);
 ```
 
 往往查看文章和文章列表是不需要用户登录的, 但是创建, 编辑, 删除文章等需要用户登录认证权限才可以. Salvo 中支持嵌套的路由系统可以很好地满足这种需求. 我们可以把不需要用户登录的路由写到一起：
 
 ```rust
 Router::with_path("articles")
-    .get(list_articles)
-    .push(Router::with_path("<id>").get(show_article));
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article));
 ```
 
 然后把需要用户登录的路由写到一起， 并且使用相应的中间件验证用户是否登录：
 
 ```rust
 Router::with_path("articles")
-    .hoop(auth_check)
-    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
 虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由, 所以最后的路由长成了这个样子:
 
 ```rust
 Router::new()
-    .push(
-        Router::with_path("articles")
-            .get(list_articles)
-            .push(Router::with_path("<id>").get(show_article)),
-    )
-    .push(
-        Router::with_path("articles")
-            .hoop(auth_check)
-            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-    );
+.push(
+Router::with_path("articles")
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article)),
+)
+.push(
+Router::with_path("articles")
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+);
 ```
 
-`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则, `r"<id:/\d+/>"`.
+`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则,
+`r"<id:/\d+/>"`.
 
-还可以通过 `<**>`, `<*+>` 或者 `<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
+还可以通过 `<**>`, `<*+>` 或者
+`<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
 
 有些用于匹配路径的正则表达式需要经常被使用, 可以将它事先注册, 比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-    "guid",
-    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+"guid",
+Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
@@ -217,7 +220,6 @@ async fn edit(req: &mut Request) {
 
 甚至于可以直接把类型作为参数传入函数, 像这样:
 
-
 ```rust
 #[handler]
 async fn edit<'a>(good_man: GoodMan<'a>) {
@@ -226,7 +228,6 @@ async fn edit<'a>(good_man: GoodMan<'a>) {
 ```
 
 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs)
-
 
 ### OpenAPI 支持
 
@@ -272,18 +273,23 @@ async fn main() {
 ```
 
 ### 🛠️ Salvo CLI
+
 Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程，支持Web API、网站、数据库（包括通过SQLx、SeaORM、Diesel、Rbatis支持的SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
 你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来创建一个新的 Salvo 项目:
+
 #### 安装
+
 ```bash
 cargo install salvo-cli
 ```
+
 #### 创建一个salvo项目
+
 ```bash
 salvo new project_name
 ```
-___
 
+___
 
 ### 更多示例
 

--- a/README.zh-hans.md
+++ b/README.zh-hans.md
@@ -47,7 +47,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架。�
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
 - 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/)获取 TLS 证书。.
-- 支持 Tower Serivce 和 Layer.
+- 支持 Tower Service 和 Layer.
 
 ## ⚡️ 快速开始
 
@@ -108,41 +108,41 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-.get(show_article)
-.patch(edit_article)
-.delete(delete_article);
+    .get(show_article)
+    .patch(edit_article)
+    .delete(delete_article);
 ```
 
 往往查看文章和文章列表是不需要用户登录的，但是创建，编辑，删除文章等需要用户登录认证权限才可以。Salvo 中支持嵌套的路由系统可以很好地满足这种需求。我们可以把不需要用户登录的路由写到一起：
 
 ```rust
 Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article));
+    .get(list_articles)
+    .push(Router::with_path("<id>").get(show_article));
 ```
 
 然后把需要用户登录的路由写到一起，并且使用相应的中间件验证用户是否登录：
 
 ```rust
 Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+    .hoop(auth_check)
+    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
 虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由，所以最后的路由长成了这个样子：
 
 ```rust
 Router::new()
-.push(
-Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article)),
-)
-.push(
-Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-);
+    .push(
+        Router::with_path("articles")
+            .get(list_articles)
+            .push(Router::with_path("<id>").get(show_article)),
+    )
+    .push(
+        Router::with_path("articles")
+            .hoop(auth_check)
+            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+    );
 ```
 
 `<id>`匹配了路径中的一个片段，正常情况下文章的的 `id`只是一个数字，这是我们可以使用正则表达式限制制 `id`的匹配规则，`r"<id:/\d+/>"`.
@@ -153,8 +153,8 @@ Router::with_path("articles")
 
 ```rust
 PathFilter::register_wisp_regex(
-"guid",
-Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+    "guid",
+    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 

--- a/README.zh-hans.md
+++ b/README.zh-hans.md
@@ -33,9 +33,9 @@
 </p>
 </div>
 
-Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅仅需要基础 Rust 知识即可开发后端服务.
+Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架。仅仅需要基础 Rust 知识即可开发后端服务。
 
-> 中国用户可以添加我微信(chrislearn), 拉微信讨论群或者直接加入QQ群：823441777.
+> 中国用户可以添加我微信 (chrislearn), 拉微信讨论群或者直接加入 QQ 群：823441777.
 
 ## 🎯 功能特色
 
@@ -46,7 +46,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 - 集成 Multipart 表单处理;
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
-- 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/) 获取 TLS 证书.
+- 支持 Acme, 自动从 [let's encrypt](https://letsencrypt.org/)获取 TLS 证书。.
 - 支持 Tower Serivce 和 Layer.
 
 ## ⚡️ 快速开始
@@ -55,7 +55,7 @@ Salvo(赛风) 是一个极其简单且功能强大的 Rust Web 后端框架. 仅
 
 ### 支持 ACME 自动获取证书和 HTTP3 的 Hello World
 
-**只需要几行代码就可以实现一个同时支持 ACME 自动获取证书以及支持 HTTP1，HTTP2， HTTP3 协议的服务器.**
+**只需要几行代码就可以实现一个同时支持 ACME 自动获取证书以及支持 HTTP1，HTTP2，HTTP3 协议的服务器。**
 
 ```rust
 use salvo::prelude::*;
@@ -70,7 +70,7 @@ async fn main() {
     let mut router = Router::new().get(hello);
     let listener = TcpListener::new("0.0.0.0:443")
         .acme()
-        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名.
+        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名
         .http01_challenge(&mut router).quinn("0.0.0.0:443");
     let acceptor = listener.join(TcpListener::new("0.0.0.0:80")).bind().await;
     Server::new(acceptor).serve(router).await;
@@ -79,8 +79,8 @@ async fn main() {
 
 ### 中间件
 
-Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处. **所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识.
-只要你会写函数就会写中间件, 就是这么简单!!!**
+Salvo 中的中间件其实就是 Handler, 没有其他任何特别之处。**所以书写中间件并不需要像其他某些框架需要掌握泛型关联类型等知识。
+只要你会写函数就会写中间件，就是这么简单!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -93,14 +93,13 @@ async fn add_header(res: &mut Response) {
 }
 ```
 
-然后将它添加到路由中:
+然后将它添加到路由中：
 
 ```rust
 Router::new().hoop(add_header).get(hello)
 ```
 
-这就是一个简单的中间件, 它向 `Response` 的头部添加了
-`Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
+这就是一个简单的中间件，它向 `Response` 的头部添加了 `Header`, 查看[完整源码](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可链式书写的树状路由系统
 
@@ -114,7 +113,7 @@ Router::with_path("articles/<id>")
 .delete(delete_article);
 ```
 
-往往查看文章和文章列表是不需要用户登录的, 但是创建, 编辑, 删除文章等需要用户登录认证权限才可以. Salvo 中支持嵌套的路由系统可以很好地满足这种需求. 我们可以把不需要用户登录的路由写到一起：
+往往查看文章和文章列表是不需要用户登录的，但是创建，编辑，删除文章等需要用户登录认证权限才可以。Salvo 中支持嵌套的路由系统可以很好地满足这种需求。我们可以把不需要用户登录的路由写到一起：
 
 ```rust
 Router::with_path("articles")
@@ -122,7 +121,7 @@ Router::with_path("articles")
 .push(Router::with_path("<id>").get(show_article));
 ```
 
-然后把需要用户登录的路由写到一起， 并且使用相应的中间件验证用户是否登录：
+然后把需要用户登录的路由写到一起，并且使用相应的中间件验证用户是否登录：
 
 ```rust
 Router::with_path("articles")
@@ -130,7 +129,7 @@ Router::with_path("articles")
 .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
-虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由, 所以最后的路由长成了这个样子:
+虽然这两个路由都有这同样的 `path("articles")`, 然而它们依然可以被同时添加到同一个父路由，所以最后的路由长成了这个样子：
 
 ```rust
 Router::new()
@@ -146,13 +145,11 @@ Router::with_path("articles")
 );
 ```
 
-`<id>` 匹配了路径中的一个片段, 正常情况下文章的 `id` 只是一个数字, 这是我们可以使用正则表达式限制 `id` 的匹配规则,
-`r"<id:/\d+/>"`.
+`<id>`匹配了路径中的一个片段，正常情况下文章的的 `id`只是一个数字，这是我们可以使用正则表达式限制制 `id`的匹配规则，`r"<id:/\d+/>"`.
 
-还可以通过 `<**>`, `<*+>` 或者
-`<*?>` 匹配所有剩余的路径片段. 为了代码易读性性强些, 也可以添加适合的名字, 让路径语义更清晰, 比如: `<**file_path>`.
+还可以通过 `<**>`, `<*+>` 或者 `<*?>`匹配所有剩余的路径片段。为了代码易读性性强些，也可以添加适合的名字，让路径语义更清晰，比如：: `<**file_path>`.
 
-有些用于匹配路径的正则表达式需要经常被使用, 可以将它事先注册, 比如 GUID:
+有些用于匹配路径的正则表达式需要经常被使用，可以将它事先注册，比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
@@ -161,7 +158,7 @@ Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
-这样在需要路径匹配时就变得更简洁:
+这样在需要路径匹配时就变得更简洁：
 
 ```rust
 Router::with_path("<id:guid>").get(index)
@@ -171,7 +168,7 @@ Router::with_path("<id:guid>").get(index)
 
 ### 文件上传
 
-可以通过 `Request` 中的 `file` 异步获取上传的文件:
+可以通过 `Request` 中的 `file`异步获取上传的文件：:
 
 ```rust
 #[handler]
@@ -192,7 +189,7 @@ async fn upload(req: &mut Request, res: &mut Response) {
 
 ### 提取请求数据
 
-可以轻松地从多个不同数据源获取数据, 并且组装为你想要的类型. 可以先定义一个自定义的类型, 比如:
+可以轻松地从多个不同数据源获取数据，并且组装为你想要的类型。可以先定义一个自定义的类型，比如：
 
 ```rust
 #[derive(Serialize, Deserialize, Extractible, Debug)]
@@ -209,7 +206,7 @@ struct GoodMan<'a> {
 }
 ```
 
-然后在 `Handler` 中可以这样获取数据:
+然后在 `Handler`中可以这样获取数据：
 
 ```rust
 #[handler]
@@ -218,7 +215,7 @@ async fn edit(req: &mut Request) {
 }
 ```
 
-甚至于可以直接把类型作为参数传入函数, 像这样:
+甚至于可以直接把类型作为参数传入函数，像这样：
 
 ```rust
 #[handler]
@@ -274,8 +271,8 @@ async fn main() {
 
 ### 🛠️ Salvo CLI
 
-Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程，支持Web API、网站、数据库（包括通过SQLx、SeaORM、Diesel、Rbatis支持的SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
-你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来创建一个新的 Salvo 项目:
+Salvo CLI 是一个命令行工具，可以简化创建新的 Salvo 项目的过程，支持 Web API、网站、数据库（包括通过 SQLx、SeaORM、Diesel、Rbatis 支持的 SQLite、PostgreSQL、MySQL）和基本的中间件的模板。
+你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli)来创建一个新的 Salvo 项目：
 
 #### 安装
 
@@ -283,7 +280,7 @@ Salvo CLI是一个命令行工具，可以简化创建新的Salvo项目的过程
 cargo install salvo-cli
 ```
 
-#### 创建一个salvo项目
+#### 创建一个 salvo 项目
 
 ```bash
 salvo new project_name
@@ -293,7 +290,7 @@ ___
 
 ### 更多示例
 
-您可以从 [examples](./examples/) 文件夹下查看更多示例代码, 您可以通过以下命令运行这些示例：
+您可以从 [examples](./examples/)文件夹下查看更多示例代码，您可以通过以下命令运行这些示例：
 
 ```bash
 cd examples
@@ -304,7 +301,7 @@ cargo run --bin example-basic-auth
 
 ## 🚀 性能
 
-Benchmark 测试结果可以从这里查看:
+Benchmark 测试结果可以从这里查看：
 
 [https://web-frameworks-benchmark.netlify.app/result?l=rust](https://web-frameworks-benchmark.netlify.app/result?l=rust)
 
@@ -318,14 +315,14 @@ Benchmark 测试结果可以从这里查看:
 
 ## ☕ 捐助
 
-`Salvo`是一个开源项目, 如果想支持本项目, 可以 ☕ [**请我喝杯咖啡**](https://ko-fi.com/chrislearn).
+`Salvo`是一个开源项目，如果想支持本项目，可以 ☕ [**请我喝杯咖啡**](https://ko-fi.com/chrislearn).
 <p style="text-align: center;">
 <img src="https://salvo.rs/images/alipay.png" alt="Alipay" width="180"/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://salvo.rs/images/weixin.png" alt="Weixin" width="180"/>
 </p>
 
 ## ⚠️ 开源协议
 
-Salvo 项目采用以下开源协议:
+Salvo 项目采用以下开源协议：
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -47,7 +47,7 @@ Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架。�
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
 - 支持 Acme, 自動從 [let's encrypt](https://letsencrypt.org/)獲取 TLS 證書。
-- 支持 Tower Serivce 和 Layer.
+- 支持 Tower Service 和 Layer.
 
 ## ⚡️ 快速開始
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -33,9 +33,9 @@
 </p>
 </div>
 
-Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架. 僅僅需要基礎 Rust 知識即可開發後端服務.
+Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架。僅僅需要基礎 Rust 知識即可開發後端服務。
 
-> 中国用户可以添加我微信(chrislearn), 拉微信討論群或者直接加入QQ群：823441777.
+> 中国用户可以添加我微信 (chrislearn), 拉微信討論群或者直接加入 QQ 群：823441777.
 
 ## 🎯 功能特色
 
@@ -46,7 +46,7 @@ Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架. 僅
 - 集成 Multipart 錶單處理;
 - 支持 WebSocket, WebTransport;
 - 支持 OpenAPI;
-- 支持 Acme, 自動從 [let's encrypt](https://letsencrypt.org/) 獲取 TLS 證書.
+- 支持 Acme, 自動從 [let's encrypt](https://letsencrypt.org/)獲取 TLS 證書。
 - 支持 Tower Serivce 和 Layer.
 
 ## ⚡️ 快速開始
@@ -55,7 +55,7 @@ Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架. 僅
 
 ### 支持 ACME 自動獲取證書和 HTTP3 的 Hello World
 
-**隻需要幾行代碼就可以實現一個同時支持 ACME 自動獲取證書以及支持 HTTP1，HTTP2， HTTP3 協議的伺服器.**
+**隻需要幾行代碼就可以實現一個同時支持 ACME 自動獲取證書以及支持 HTTP1，HTTP2，HTTP3 協議的伺服器。**
 
 ```rust
 use salvo::prelude::*;
@@ -70,7 +70,7 @@ async fn main() {
     let mut router = Router::new().get(hello);
     let listener = TcpListener::new("0.0.0.0:443")
         .acme()
-        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名.
+        .add_domain("test.salvo.rs") // 用你自己的域名替换此域名
         .http01_challenge(&mut router).quinn("0.0.0.0:443");
     let acceptor = listener.join(TcpListener::new("0.0.0.0:80")).bind().await;
     Server::new(acceptor).serve(router).await;
@@ -79,8 +79,8 @@ async fn main() {
 
 ### 中間件
 
-Salvo 中的中間件其實就是 Handler, 冇有其他任何特別之處. **所以書寫中間件並不需要像其他某些框架需要掌握泛型關聯類型等知識.
-隻要你會寫函數就會寫中間件, 就是這麼簡單!!!**
+Salvo 中的中間件其實就是 Handler, 冇有其他任何特別之處。**所以書寫中間件並不需要像其他某些框架需要掌握泛型關聯類型等知識。
+隻要你會寫函數就會寫中間件，就是這麼簡單!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -93,14 +93,13 @@ async fn add_header(res: &mut Response) {
 }
 ```
 
-然後將它添加到路由中:
+然後將它添加到路由中：
 
 ```rust
 Router::new().hoop(add_header).get(hello)
 ```
 
-這就是一個簡單的中間件, 它嚮 `Response` 的頭部添加了
-`Header`, 查看[完整源碼](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
+這就是一個簡單的中間件，它嚮 `Response` 的頭部添加了 `Header`, 查看[完整源碼](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可鏈式書寫的樹狀路由係統
 
@@ -109,59 +108,57 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-.get(show_article)
-.patch(edit_article)
-.delete(delete_article);
+    .get(show_article)
+    .patch(edit_article)
+    .delete(delete_article);
 ```
 
-往往查看文章和文章列錶是不需要用戶登錄的, 但是創建, 編輯, 刪除文章等需要用戶登錄認證權限才可以. Salvo 中支持嵌套的路由係統可以很好地滿足這種需求. 我們可以把不需要用戶登錄的路由寫到一起：
+往往查看文章和文章列錶是不需要用戶登錄的，但是創建，編輯，刪除文章等需要用戶登錄認證權限才可以。Salvo 中支持嵌套的路由係統可以很好地滿足這種需求。我們可以把不需要用戶登錄的路由寫到一起：
 
 ```rust
 Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article));
+    .get(list_articles)
+    .push(Router::with_path("<id>").get(show_article));
 ```
 
-然後把需要用戶登錄的路由寫到一起， 並且使用相應的中間件驗證用戶是否登錄：
+然後把需要用戶登錄的路由寫到一起，並且使用相應的中間件驗證用戶是否登錄：
 
 ```rust
 Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+    .hoop(auth_check)
+    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
-雖然這兩個路由都有這同樣的 `path("articles")`, 然而它們依然可以被同時添加到同一個父路由, 所以最後的路由長成了這個樣子:
+雖然這兩個路由都有這同樣的 `path("articles")`, 然而它們依然可以被同時添加到同一個父路由，所以最後的路由長成了這個樣子：
 
 ```rust
 Router::new()
-.push(
-Router::with_path("articles")
-.get(list_articles)
-.push(Router::with_path("<id>").get(show_article)),
-)
-.push(
-Router::with_path("articles")
-.hoop(auth_check)
-.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-);
+    .push(
+        Router::with_path("articles")
+            .get(list_articles)
+            .push(Router::with_path("<id>").get(show_article)),
+    )
+    .push(
+        Router::with_path("articles")
+            .hoop(auth_check)
+            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+    );
 ```
 
-`<id>` 匹配了路徑中的一個片段, 正常情況下文章的 `id` 隻是一個數字, 這是我們可以使用正則錶達式限製 `id` 的匹配規則,
-`r"<id:/\d+/>"`.
+`<id>`匹配了路徑中的一個片段，正常情況下文章的的 `id`隻是一個數字，這是我們可以使用正則錶達式限製製 `id`的匹配規則，`r"<id:/\d+/>"`.
 
-還可以通過 `<**>`, `<*+>` 或者
-`<*?>` 匹配所有剩餘的路徑片段. 為了代碼易讀性性強些, 也可以添加適合的名字, 讓路徑語義更清晰, 比如: `<**file_path>`.
+還可以通過 `<**>`, `<*+>` 或者 `<*?>`匹配所有剩餘的路徑片段。為了代碼易讀性性強些，也可以添加適合的名字，讓路徑語義更清晰，比如：: `<**file_path>`.
 
-有些用於匹配路徑的正則錶達式需要經常被使用, 可以將它事先註冊, 比如 GUID:
+有些用於匹配路徑的正則錶達式需要經常被使用，可以將它事先註冊，比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-"guid",
-Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+    "guid",
+    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
-這樣在需要路徑匹配時就變得更簡潔:
+這樣在需要路徑匹配時就變得更簡潔：
 
 ```rust
 Router::with_path("<id:guid>").get(index)
@@ -171,7 +168,7 @@ Router::with_path("<id:guid>").get(index)
 
 ### 文件上傳
 
-可以通過 `Request` 中的 `file` 異步獲取上傳的文件:
+可以通過 `Request` 中的 `file`異步獲取上傳的文件：
 
 ```rust
 #[handler]
@@ -192,7 +189,7 @@ async fn upload(req: &mut Request, res: &mut Response) {
 
 ### 提取請求數據
 
-可以輕鬆地從多個不同數據源獲取數據, 並且組裝為你想要的類型. 可以先定義一個自定義的類型, 比如:
+可以輕鬆地從多個不同數據源獲取數據，並且組裝為你想要的類型。可以先定義一個自定義的類型，比如：
 
 ```rust
 #[derive(Serialize, Deserialize, Extractible, Debug)]
@@ -209,7 +206,7 @@ struct GoodMan<'a> {
 }
 ```
 
-然後在 `Handler` 中可以這樣獲取數據:
+然後在 `Handler`中可以這樣獲取數據：
 
 ```rust
 #[handler]
@@ -218,7 +215,7 @@ async fn edit(req: &mut Request) {
 }
 ```
 
-甚至於可以直接把類型作為參數傳入函數, 像這樣:
+甚至於可以直接把類型作為參數傳入函數，像這樣：
 
 ```rust
 #[handler]
@@ -274,8 +271,8 @@ async fn main() {
 
 ### 🛠️ Salvo CLI
 
-Salvo CLI是一個命令行工具，可以簡化創建新的Salvo項目的過程，支援Web API、網站、資料庫（包括透過SQLx、SeaORM、Diesel、Rbatis支援的SQLite、PostgreSQL、MySQL）和基本的中介軟體的模板。
-你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来來創建一個新的 Salvo 項目:
+Salvo CLI 是一個命令行工具，可以簡化創建新的 Salvo 項目的過程，支援 Web API、網站、資料庫（包括透過 SQLx、SeaORM、Diesel、Rbatis 支援的 SQLite、PostgreSQL、MySQL）和基本的中介軟體的模板。
+你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli)来來創建一個新的 Salvo 項目：
 
 #### 安裝
 
@@ -283,7 +280,7 @@ Salvo CLI是一個命令行工具，可以簡化創建新的Salvo項目的過程
 cargo install salvo-cli
 ```
 
-#### 創建一個新的salvo項目
+#### 創建一個新的 salvo 項目
 
 ```bash
 salvo new project_name
@@ -293,7 +290,7 @@ ___
 
 ### 更多示例
 
-您可以從 [examples](./examples/) 文件夾下查看更多示例代碼, 您可以通過以下命令運行這些示例：
+您可以從 [examples](./examples/)文件夾下查看更多示例代碼，您可以通過以下命令運行這些示例：：
 
 ```bash
 cd examples
@@ -304,7 +301,7 @@ cargo run --bin example-basic-auth
 
 ## 🚀 性能
 
-Benchmark 測試結果可以從這裏查看:
+Benchmark 測試結果可以從這裏查看：
 
 [https://web-frameworks-benchmark.netlify.app/result?l=rust](https://web-frameworks-benchmark.netlify.app/result?l=rust)
 
@@ -318,14 +315,14 @@ Benchmark 測試結果可以從這裏查看:
 
 ## ☕ 捐助
 
-`Salvo`是一個開源項目, 如果想支持本項目, 可以 ☕ [**請我喝杯咖啡**](https://ko-fi.com/chrislearn).
+`Salvo`是一個開源項目，如果想支持本項目，可以 ☕ [**請我喝杯咖啡**](https://ko-fi.com/chrislearn).
 <p style="text-align: center;">
 <img src="https://salvo.rs/images/alipay.png" alt="Alipay" width="180"/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://salvo.rs/images/weixin.png" alt="Weixin" width="180"/>
 </p>
 
 ## ⚠️ 開源協議
 
-Salvo 項目採用以下開源協議:
+Salvo 項目採用以下開源協議：
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -1,5 +1,5 @@
 <div align="center">
-<p><img alt="Savlo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
+<p><img alt="Salvo" width="132" style="max-width:40%;min-width:60px;" src="https://salvo.rs/images/logo-text.svg" /></p>
 <p>
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.md">English</a>&nbsp;&nbsp;
     <a href="https://github.com/salvo-rs/salvo/blob/main/README.zh-hans.md">简体中文</a>&nbsp;&nbsp;
@@ -51,7 +51,7 @@ Salvo(賽風) 是一個極其簡單且功能強大的 Rust Web 後端框架. 僅
 
 ## ⚡️ 快速開始
 
-你可以查看[實例代碼](https://github.com/salvo-rs/salvo/tree/main/examples),  或者訪問[官網](https://salvo.rs).
+你可以查看[實例代碼](https://github.com/salvo-rs/salvo/tree/main/examples), 或者訪問[官網](https://salvo.rs).
 
 ### 支持 ACME 自動獲取證書和 HTTP3 的 Hello World
 
@@ -79,7 +79,8 @@ async fn main() {
 
 ### 中間件
 
-Salvo 中的中間件其實就是 Handler, 冇有其他任何特別之處. **所以書寫中間件並不需要像其他某些框架需要掌握泛型關聯類型等知識. 隻要你會寫函數就會寫中間件, 就是這麼簡單!!!**
+Salvo 中的中間件其實就是 Handler, 冇有其他任何特別之處. **所以書寫中間件並不需要像其他某些框架需要掌握泛型關聯類型等知識.
+隻要你會寫函數就會寫中間件, 就是這麼簡單!!!**
 
 ```rust
 use salvo::http::header::{self, HeaderValue};
@@ -98,8 +99,8 @@ async fn add_header(res: &mut Response) {
 Router::new().hoop(add_header).get(hello)
 ```
 
-這就是一個簡單的中間件, 它嚮 `Response` 的頭部添加了 `Header`, 查看[完整源碼](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
-
+這就是一個簡單的中間件, 它嚮 `Response` 的頭部添加了
+`Header`, 查看[完整源碼](https://github.com/salvo-rs/salvo/blob/main/examples/middleware-add-header/src/main.rs).
 
 ### 可鏈式書寫的樹狀路由係統
 
@@ -108,53 +109,55 @@ Router::new().hoop(add_header).get(hello)
 ```rust
 Router::with_path("articles").get(list_articles).post(create_article);
 Router::with_path("articles/<id>")
-    .get(show_article)
-    .patch(edit_article)
-    .delete(delete_article);
+.get(show_article)
+.patch(edit_article)
+.delete(delete_article);
 ```
 
 往往查看文章和文章列錶是不需要用戶登錄的, 但是創建, 編輯, 刪除文章等需要用戶登錄認證權限才可以. Salvo 中支持嵌套的路由係統可以很好地滿足這種需求. 我們可以把不需要用戶登錄的路由寫到一起：
 
 ```rust
 Router::with_path("articles")
-    .get(list_articles)
-    .push(Router::with_path("<id>").get(show_article));
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article));
 ```
 
 然後把需要用戶登錄的路由寫到一起， 並且使用相應的中間件驗證用戶是否登錄：
 
 ```rust
 Router::with_path("articles")
-    .hoop(auth_check)
-    .push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article));
 ```
 
 雖然這兩個路由都有這同樣的 `path("articles")`, 然而它們依然可以被同時添加到同一個父路由, 所以最後的路由長成了這個樣子:
 
 ```rust
 Router::new()
-    .push(
-        Router::with_path("articles")
-            .get(list_articles)
-            .push(Router::with_path("<id>").get(show_article)),
-    )
-    .push(
-        Router::with_path("articles")
-            .hoop(auth_check)
-            .push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
-    );
+.push(
+Router::with_path("articles")
+.get(list_articles)
+.push(Router::with_path("<id>").get(show_article)),
+)
+.push(
+Router::with_path("articles")
+.hoop(auth_check)
+.push(Router::with_path("<id>").patch(edit_article).delete(delete_article)),
+);
 ```
 
-`<id>` 匹配了路徑中的一個片段, 正常情況下文章的 `id` 隻是一個數字, 這是我們可以使用正則錶達式限製 `id` 的匹配規則, `r"<id:/\d+/>"`.
+`<id>` 匹配了路徑中的一個片段, 正常情況下文章的 `id` 隻是一個數字, 這是我們可以使用正則錶達式限製 `id` 的匹配規則,
+`r"<id:/\d+/>"`.
 
-還可以通過 `<**>`, `<*+>` 或者 `<*?>` 匹配所有剩餘的路徑片段. 為了代碼易讀性性強些, 也可以添加適合的名字, 讓路徑語義更清晰, 比如: `<**file_path>`.
+還可以通過 `<**>`, `<*+>` 或者
+`<*?>` 匹配所有剩餘的路徑片段. 為了代碼易讀性性強些, 也可以添加適合的名字, 讓路徑語義更清晰, 比如: `<**file_path>`.
 
 有些用於匹配路徑的正則錶達式需要經常被使用, 可以將它事先註冊, 比如 GUID:
 
 ```rust
 PathFilter::register_wisp_regex(
-    "guid",
-    Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
+"guid",
+Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
 );
 ```
 
@@ -217,7 +220,6 @@ async fn edit(req: &mut Request) {
 
 甚至於可以直接把類型作為參數傳入函數, 像這樣:
 
-
 ```rust
 #[handler]
 async fn edit<'a>(good_man: GoodMan<'a>) {
@@ -271,17 +273,22 @@ async fn main() {
 ```
 
 ### 🛠️ Salvo CLI
+
 Salvo CLI是一個命令行工具，可以簡化創建新的Salvo項目的過程，支援Web API、網站、資料庫（包括透過SQLx、SeaORM、Diesel、Rbatis支援的SQLite、PostgreSQL、MySQL）和基本的中介軟體的模板。
 你可以使用 [salvo-cli](https://github.com/salvo-rs/salvo-cli) 来來創建一個新的 Salvo 項目:
+
 #### 安裝
+
 ```bash
 cargo install salvo-cli
 ```
 
 #### 創建一個新的salvo項目
+
 ```bash
 salvo new project_name
 ```
+
 ___
 
 ### 更多示例

--- a/crates/cache/README.md
+++ b/crates/cache/README.md
@@ -1,11 +1,11 @@
 # salvo-cache
 
-## Cache middleware for Savlo.
+## Cache middleware for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["cache"] }
+salvo = { version = "*", features = ["cache"] }
 ```
 
 [![Docs](https://docs.rs/salvo-cors/badge.svg)](https://docs.rs/salvo-cache)

--- a/crates/compression/README.md
+++ b/crates/compression/README.md
@@ -2,10 +2,10 @@
 
 ## Compression middleware for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["compression"] }
+salvo = { version = "*", features = ["compression"] }
 ```
 
 ## Documentation & Resources

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-//! Compression middleware for for Savlo web framework.
+//! Compression middleware for for Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-//! The core crate of Savlo web framework.
+//! The core crate of Salvo web framework.
 //!
 //! `salvo_core` uses a set of [feature flags] to reduce the amount of compiled and
 //! optional dependencies.

--- a/crates/cors/README.md
+++ b/crates/cors/README.md
@@ -2,10 +2,10 @@
 
 ## Library adds CORS protection for Salvo web framework.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["cors"] }
+salvo = { version = "*", features = ["cors"] }
 ```
 
 [![Docs](https://docs.rs/salvo-cors/badge.svg)](https://docs.rs/salvo-cors)

--- a/crates/csrf/README.md
+++ b/crates/csrf/README.md
@@ -2,10 +2,10 @@
 
 ## CSRF (Cross-Site Request Forgery) middleware for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["csrf"] }
+salvo = { version = "*", features = ["csrf"] }
 ```
 
 [![Docs](https://docs.rs/salvo-csrf/badge.svg)](https://docs.rs/salvo-csrf)

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -1,4 +1,4 @@
-//! CSRF middleware for Savlo web framework.
+//! CSRF middleware for Salvo web framework.
 //!
 //! CSRF middleware for Salvo that provides CSRF (Cross-Site Request Forgery) protection.
 //!

--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -1,4 +1,4 @@
-//! Extra features for Savlo web framework.
+//! Extra features for Salvo web framework.
 //!
 //! This library provides some common web features.
 //!

--- a/crates/flash/README.md
+++ b/crates/flash/README.md
@@ -2,13 +2,13 @@
 
 ## Flash message for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["flash"] }
+salvo = { version = "*", features = ["flash"] }
 ```
 
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-flash)
-- [Example Projects](https://github.com/salvo-rs/salvo/examples/)
+- [Example Projects](https://github.com/salvo-rs/salvo/tree/main/examples)

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -1,4 +1,4 @@
-//! The flash message lib for Savlo web framework.
+//! The flash message lib for Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -2,13 +2,13 @@
 
 ## Jwt auth middleware for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["jwt-auth"] }
+salvo = { version = "*", features = ["jwt-auth"] }
 ```
 
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-jwt-auth)
-- [Example Projects](https://github.com/salvo-rs/salvo/examples/)
+- [Example Projects](https://github.com/salvo-rs/salvo/tree/main/examples)

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -1,4 +1,4 @@
-//! Provide JWT authentication support for Savlo web framework.
+//! Provide JWT authentication support for Salvo web framework.
 //!
 //! Example:
 //!

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,4 +1,4 @@
-//! The macros lib of Savlo web framework.
+//! The macros lib of Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]

--- a/crates/oapi/README.md
+++ b/crates/oapi/README.md
@@ -2,10 +2,10 @@
 
 ## Library to Provide a OpenAPI supports for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["oapi"] }
+salvo = { version = "*", features = ["oapi"] }
 ```
 
 [![Docs](https://docs.rs/salvo-oapi/badge.svg)](https://docs.rs/salvo-oapi)

--- a/crates/otel/README.md
+++ b/crates/otel/README.md
@@ -2,10 +2,10 @@
 
 ## OpenTelemetry support for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["otel"] }
+salvo = { version = "*", features = ["otel"] }
 ```
 
 ## Documentation & Resources

--- a/crates/otel/src/lib.rs
+++ b/crates/otel/src/lib.rs
@@ -1,4 +1,4 @@
-//! OpenTelemetry support for Savlo web framework.
+//! OpenTelemetry support for Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]

--- a/crates/proxy/README.md
+++ b/crates/proxy/README.md
@@ -2,10 +2,10 @@
 
 ## Proxy for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["proxy"] }
+salvo = { version = "*", features = ["proxy"] }
 ```
 
 [![Docs](https://docs.rs/salvo-proxy/badge.svg)](https://docs.rs/salvo-proxy)

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -1,4 +1,4 @@
-//! Provide proxy support for Savlo web framework.
+//! Provide proxy support for Salvo web framework.
 //!
 //! # Example
 //!

--- a/crates/rate-limiter/README.md
+++ b/crates/rate-limiter/README.md
@@ -2,13 +2,13 @@
 
 ## Rate limit for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["rate-limiter"] }
+salvo = { version = "*", features = ["rate-limiter"] }
 ```
 
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-rate-limiter)
-- [Example Projects](https://github.com/salvo-rs/salvo/examples/)
+- [Example Projects](hhttps://github.com/salvo-rs/salvo/tree/main/examples)

--- a/crates/serve-static/README.md
+++ b/crates/serve-static/README.md
@@ -1,15 +1,14 @@
 # salvo-serve-static
 
-
 ## Serve static assets for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["serve-static"] }
+salvo = { version = "*", features = ["serve-static"] }
 ```
 
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-serve-static)
-- [Example Projects](https://github.com/salvo-rs/salvo/examples/)
+- [Example Projects](https://github.com/salvo-rs/salvo/tree/main/examples)

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -1,4 +1,4 @@
-//! serve static dir and file middleware for Savlo web framework.
+//! serve static dir and file middleware for Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]

--- a/crates/session/README.md
+++ b/crates/session/README.md
@@ -2,13 +2,13 @@
 
 ## Session management for Salvo.
 
-This is offical crate, so you can enable it in `Cargo.toml` like this:
+This is an official crate, so you can enable it in `Cargo.toml` like this:
 
 ```toml
-salvo = { version = "*", features=["session"] }
+salvo = { version = "*", features = ["session"] }
 ```
 
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-session)
-- [Example Projects](https://github.com/salvo-rs/salvo/examples/)
+- [Example Projects](https://github.com/salvo-rs/salvo/tree/main/examples)


### PR DESCRIPTION
- Corrected "Savlo" to "Salvo"
- Changed "offical" to "official"
- Updated the URL for Example Projects
- Improved the sentence "This is official crate" to "This is an official crate"