### PR TITLE
feat: impl ToSchema for Ipv4Addr, Ipv6Addr, IpAddr

### DIFF
--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -193,6 +193,8 @@ fn is_primitive(name: &str) -> bool {
             | "i128"
             | "f32"
             | "f64"
+            | "Ipv4Addr"
+            | "Ipv6Addr"
     )
 }
 
@@ -258,6 +260,9 @@ impl TryToTokens for SchemaType<'_> {
             "Uuid" => schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable),
             #[cfg(feature = "time")]
             "PrimitiveDateTime" | "OffsetDateTime" => {
+                schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable)
+            }
+            "Ipv4Addr" | "Ipv6Addr" | "IpAddr" => {
                 schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable)
             }
             _ => schema_type_tokens(tokens, oapi, SchemaTypeInner::Object, self.nullable),
@@ -385,7 +390,7 @@ impl Type<'_> {
 fn is_known_format(name: &str) -> bool {
     matches!(
         name,
-        "i8" | "i16" | "i32" | "u8" | "u16" | "u32" | "i64" | "u64" | "f32" | "f64"
+        "i8" | "i16" | "i32" | "u8" | "u16" | "u32" | "i64" | "u64" | "f32" | "f64" | "Ipv4Addr" | "Ipv6Addr"
     )
 }
 
@@ -456,6 +461,12 @@ impl TryToTokens for Type<'_> {
             #[cfg(feature = "time")]
             "PrimitiveDateTime" | "OffsetDateTime" => {
                 tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::DateTime) })
+            },
+            "Ipv4Addr" => {
+                tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::Ipv4) })
+            },
+            "Ipv6Addr" => {
+                tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::Ipv6) })
             }
             _ => (),
         };

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -191,6 +191,19 @@ impl_to_schema_primitive!(
 );
 impl_to_schema!(&str);
 
+impl_to_schema!(std::net::Ipv4Addr);
+impl_to_schema!(std::net::Ipv6Addr);
+
+impl ToSchema for std::net::IpAddr {
+    fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
+        crate::RefOr::Type(Schema::OneOf(
+            OneOf::default()
+                .item(std::net::Ipv4Addr::to_schema(components))
+                .item(std::net::Ipv6Addr::to_schema(components)),
+        ))
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl_to_schema_primitive!(chrono::NaiveDate, chrono::Duration, chrono::NaiveDateTime);
 #[cfg(feature = "chrono")]


### PR DESCRIPTION
- I noticed that ToSchema was missing for these types from std::net.
- This was needed for the [Shuttlings Christmas Code Hunt 2024](https://www.shuttle.dev/cch) (challenge 2).
- I'm not sure about the implementation for `IpAddr` enum. Let me know how it can be improved.