### PR TITLE
fix: conflict with serde deny_unknown_fields attr

### DIFF
--- a/crates/oapi-macros/src/schema/struct_schemas.rs
+++ b/crates/oapi-macros/src/schema/struct_schemas.rs
@@ -309,7 +309,7 @@ impl TryToTokens for NamedStructSchema<'_> {
                 .unwrap_or(false)
         {
             tokens.extend(quote! {
-                .additional_properties(Some(#oapi::schema::AdditionalProperties::FreeForm(false)))
+                .additional_properties(Some(#oapi::oapi::schema::AdditionalProperties::FreeForm(false)))
             });
         }
 

--- a/crates/oapi-macros/src/schema/struct_schemas.rs
+++ b/crates/oapi-macros/src/schema/struct_schemas.rs
@@ -309,7 +309,7 @@ impl TryToTokens for NamedStructSchema<'_> {
                 .unwrap_or(false)
         {
             tokens.extend(quote! {
-                .additional_properties(Some(#oapi::oapi::schema::AdditionalProperties::FreeForm(false)))
+                .additional_properties(#oapi::oapi::schema::AdditionalProperties::FreeForm(false))
             });
         }
 


### PR DESCRIPTION
When `#[serde(deny_unknown_fields)]` was used, the compilation failed with:
```
64 | #[derive(Debug, Serialize, Deserialize, ToSchema)]
   |                                         ^^^^^^^^ could not find `schema` in `salvo`
   |
   = note: this error originates in the derive macro `ToSchema` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Do we need to add a test for this?