### PR TITLE
feat: add matched-path features in Cargo.toml

### DIFF
--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["cookie", "fix-http1-request-uri", "server", "server-handle", "http1", "http2", "ring"]
-full = ["cookie", "fix-http1-request-uri", "server", "server-handle", "http1", "http2", "http2-cleartext", "quinn", "rustls", "native-tls", "openssl", "unix", "acme", "socket2", "tower-compat", "anyhow", "eyre", "test", "affix-state", "basic-auth", "craft", "force-https", "jwt-auth", "catch-panic", "compression", "logging", "proxy", "concurrency-limiter", "rate-limiter", "sse", "trailing-slash", "timeout", "websocket", "request-id", "caching-headers", "cache", "cors", "csrf", "flash", "rate-limiter", "session", "serve-static", "otel", "oapi", "ring"]
+full = ["cookie", "fix-http1-request-uri", "server", "server-handle", "http1", "http2", "http2-cleartext", "quinn", "rustls", "native-tls", "openssl", "unix", "acme", "socket2", "tower-compat", "anyhow", "eyre", "test", "affix-state", "basic-auth", "craft", "force-https", "jwt-auth", "catch-panic", "compression", "logging", "proxy", "concurrency-limiter", "rate-limiter", "sse", "trailing-slash", "timeout", "websocket", "request-id", "caching-headers", "cache", "cors", "csrf", "flash", "rate-limiter", "session", "serve-static", "otel", "oapi", "ring", "matched-path"]
 cookie = ["salvo_core/cookie"]
 fix-http1-request-uri = ["salvo_core/fix-http1-request-uri"]
 server = ["salvo_core/server"]
@@ -73,6 +73,7 @@ otel = ["dep:salvo-otel"]
 oapi = ["dep:salvo-oapi"]
 # aws-lc-rs = ["salvo_core/aws-lc-rs", "salvo-jwt-auth?/aws-lc-rs", "salvo-proxy?/aws-lc-rs"]
 ring = ["salvo_core/ring", "salvo-jwt-auth?/ring", "salvo-proxy?/ring"]
+matched-path = ["salvo_core/matched-path"]
 
 [dependencies]
 salvo_core = { workspace = true }


### PR DESCRIPTION
只有`salvo-core`中有，`salvo`中没有`matched-path`