### PR TITLE
feat: support compact_str for oapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ ulid = { version = "1", default-features = false }
 url = "2"
 uuid = "1"
 x509-parser = "0.16"
+compact_str = { version = "0.7", features = ["serde"] }
 
 # Compress
 brotli = { version = "7", default-features = false }

--- a/crates/oapi-macros/Cargo.toml
+++ b/crates/oapi-macros/Cargo.toml
@@ -29,6 +29,7 @@ smallvec = []
 repr = []
 indexmap = []
 non-strict-integers = []
+compact_str = []
 
 [dependencies]
 proc-macro2 = { workspace = true }
@@ -49,6 +50,7 @@ assert-json-diff = { workspace = true }
 time = { workspace = true, features = ["serde-human-readable"] }
 serde_with = { workspace = true }
 paste = { workspace = true }
+compact_str = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -78,6 +78,7 @@ impl SchemaType<'_> {
             feature = "ulid",
             feature = "uuid",
             feature = "time",
+            feature = "compact_str"
         )))]
         {
             is_primitive(name)
@@ -91,6 +92,7 @@ impl SchemaType<'_> {
             feature = "ulid",
             feature = "uuid",
             feature = "time",
+            feature = "compact_str"
         ))]
         {
             let mut primitive = is_primitive(name);
@@ -124,6 +126,10 @@ impl SchemaType<'_> {
                     name,
                     "Date" | "PrimitiveDateTime" | "OffsetDateTime" | "Duration"
                 );
+            }
+            #[cfg(feature = "compact_str")]
+            if !primitive {
+                primitive = matches!(name, "CompactString");
             }
 
             primitive
@@ -246,6 +252,10 @@ impl TryToTokens for SchemaType<'_> {
             "Date" | "Duration" => {
                 schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable)
             }
+            #[cfg(feature = "compact_str")]
+            "CompactString" => {
+                schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable)
+            }
             #[cfg(all(feature = "decimal", feature = "decimal-float"))]
             "Decimal" => schema_type_tokens(tokens, oapi, SchemaTypeInner::String, self.nullable),
             #[cfg(all(feature = "decimal", not(feature = "decimal-float")))]
@@ -333,7 +343,8 @@ impl Type<'_> {
             feature = "url",
             feature = "ulid",
             feature = "uuid",
-            feature = "time"
+            feature = "time",
+            feature = "compact_str"
         )))]
         {
             is_known_format(name)
@@ -346,7 +357,8 @@ impl Type<'_> {
             feature = "url",
             feature = "ulid",
             feature = "uuid",
-            feature = "time"
+            feature = "time",
+            feature = "compact_str"
         ))]
         {
             let mut known_format = is_known_format(name);
@@ -379,6 +391,11 @@ impl Type<'_> {
             #[cfg(feature = "time")]
             if !known_format {
                 known_format = matches!(name, "Date" | "PrimitiveDateTime" | "OffsetDateTime");
+            }
+
+            #[cfg(feature = "compact_str")]
+            if !known_format {
+                known_format = matches!(name, "CompactString");
             }
 
             known_format
@@ -459,6 +476,10 @@ impl TryToTokens for Type<'_> {
             #[cfg(feature = "chrono")]
             "NaiveDateTime" => {
                 tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::DateTime) })
+            }
+            #[cfg(feature = "compact_str")]
+            "CompactString" => {
+                tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::String) })
             }
             #[cfg(feature = "time")]
             "Date" => tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::Date) }),

--- a/crates/oapi/Cargo.toml
+++ b/crates/oapi/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>", "Chrislearn Young <chris@a
 
 [features]
 default = []
-full = ["swagger-ui", "scalar", "rapidoc", "redoc", "chrono", "decimal", "url", "ulid", "uuid", "time", "smallvec", "indexmap", "yaml", "non-strict-integers"]
+full = ["swagger-ui", "scalar", "rapidoc", "redoc", "chrono", "decimal", "url", "ulid", "uuid", "time", "smallvec", "indexmap", "yaml", "non-strict-integers", "compact_str"]
 swagger-ui = ["dep:rust-embed"]
 scalar = []
 rapidoc = []
@@ -34,6 +34,7 @@ yaml = ["dep:serde_yaml"]
 preserve-order = ["preserve-path-order", "preserve-prop-order"]
 preserve-path-order = []
 preserve-prop-order = []
+compact_str = ["salvo-oapi-macros/compact_str", "dep:compact_str"]
 
 [dependencies]
 salvo_core = { workspace = true, default-features = false, features = ["cookie"] }
@@ -63,6 +64,7 @@ time = { workspace = true, optional = true }
 ulid = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
+compact_str = { workspace = true, optional = true }
 
 [build-dependencies]
 regex = { workspace = true }
@@ -80,6 +82,7 @@ smallvec = { workspace = true, features = ["serde"] }
 rust_decimal = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 time = { workspace = true, features = ["serde-human-readable"] }
+compact_str = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -194,6 +194,7 @@ impl_to_schema!(&str);
 impl_to_schema!(std::net::Ipv4Addr);
 impl_to_schema!(std::net::Ipv6Addr);
 
+
 impl ToSchema for std::net::IpAddr {
     fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
         crate::RefOr::Type(Schema::OneOf(
@@ -212,6 +213,8 @@ impl<T: chrono::TimeZone> ToSchema for chrono::DateTime<T> {
         schema!(#[inline] DateTime<T>).into()
     }
 }
+#[cfg(feature = "compact_str")]
+impl_to_schema_primitive!(compact_str::CompactString);
 #[cfg(any(feature = "decimal", feature = "decimal-float"))]
 impl_to_schema!(rust_decimal::Decimal);
 #[cfg(feature = "url")]

--- a/crates/oapi/src/openapi/schema/mod.rs
+++ b/crates/oapi/src/openapi/schema/mod.rs
@@ -512,6 +512,8 @@ pub enum KnownFormat {
     Duration,
     /// Hint to UI to obscure input.
     Password,
+    /// Use for compact string
+    String,
     /// Used with [`String`] values to indicate value is in decimal format.
     ///
     /// **decimal** feature need to be enabled.

--- a/examples/oapi-todos/Cargo.toml
+++ b/examples/oapi-todos/Cargo.toml
@@ -10,5 +10,6 @@ salvo = { workspace = true, features = ["oapi"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1"
 tokio = { workspace = true, features = ["macros"] }
+compact_str = { version = "0.7", features = ["serde"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION
## Description

This pull request introduces support for the [compact_str](https://docs.rs/compact_str/) crate in the salvo web framework’s OpenAPI integration. The use of compact_str provides an efficient and lightweight alternative to String, particularly beneficial for scenarios involving small strings, reducing memory overhead without sacrificing usability.

## Key Changes
 - Implemented support for compact_str in relevant OpenAPI structures and code paths.
 - Ensured compatibility with existing String behavior, maintaining seamless integration for developers.

## Why This is Needed
The compact_str crate offers significant performance and memory usage advantages for string-heavy applications. This addition makes salvo more flexible and optimized for use cases where efficient memory utilization is critical, aligning with modern Rust best practices.


