### PR TITLE
fix: bug with colliding headers in `salvo-proxy`

### DIFF
--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -320,11 +320,13 @@ where
                             body,
                         ) = response.into_parts();
                         res.status_code(status);
+                        tracing::warn!("{:?}", headers);
                         for (name, value) in headers {
                             if let Some(name) = name {
                                 res.headers.insert(name, value);
                             }
                         }
+                        tracing::warn!("{:?}", res.headers());
                         res.body(body);
                     }
                     Err(e) => {

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -319,14 +319,12 @@ where
                             },
                             body,
                         ) = response.into_parts();
-                        tracing::warn!("{:?}", headers);
                         res.status_code(status);
                         for name in headers.keys() {
                             for value in headers.get_all(name) {
                                 res.headers.append(name, value.to_owned());
                             }
                         }
-                        tracing::warn!("{:?}", res.headers);
                         res.body(body);
                     }
                     Err(e) => {

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -321,9 +321,9 @@ where
                         ) = response.into_parts();
                         tracing::warn!("{:?}", headers);
                         res.status_code(status);
-                        for (name, value) in headers {
-                            if let Some(name) = name {
-                                res.headers.append(name, value);
+                        for name in headers.keys() {
+                            for value in headers.get_all(name) {
+                                res.headers.append(name, value.to_owned());
                             }
                         }
                         tracing::warn!("{:?}", res.headers);

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -320,13 +320,11 @@ where
                             body,
                         ) = response.into_parts();
                         res.status_code(status);
-                        tracing::warn!("{:?}", headers);
                         for (name, value) in headers {
                             if let Some(name) = name {
-                                res.headers.insert(name, value);
+                                res.headers.append(name, value);
                             }
                         }
-                        tracing::warn!("{:?}", res.headers());
                         res.body(body);
                     }
                     Err(e) => {

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -319,12 +319,14 @@ where
                             },
                             body,
                         ) = response.into_parts();
+                        tracing::warn!("{:?}", headers);
                         res.status_code(status);
                         for (name, value) in headers {
                             if let Some(name) = name {
                                 res.headers.append(name, value);
                             }
                         }
+                        tracing::warn!("{:?}", res.headers);
                         res.body(body);
                     }
                     Err(e) => {


### PR DESCRIPTION
I have a Flask service that inserts three `Set-Cookie` headers during the authentication process. But `salvo-proxy` returns only one of these headers for now. So, I think, we need to make this correction.