### PR TITLE
fix incorrect comment

### DIFF
--- a/examples/proxy-simple/src/main.rs
+++ b/examples/proxy-simple/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
 
     // In this example, if the requested URL begins with <http://127.0.0.1:5800/>, the proxy goes to
     // <https://www.rust-lang.org>; if the requested URL begins with <http://localhost:5800/>, the proxy
-    // goes to <https://www.rust-lang.org>.
+    // goes to <https://crates.io>.
     let router = Router::new()
         .push(
             Router::new()


### PR DESCRIPTION
I found an incorrect comment in a file that might mislead developers. I have corrected it to provide the accurate description.
Changes made:
- Fixed the comment in `salvo\examples\proxy-simple\src\main.rs`

This is my first attempt to contribute to an open-source project, so please let me know if there is anything I can improve. Thank you for reviewing!