### PR TITLE
set listener.set_nonblock to true in listenfd sample

### DIFF
--- a/examples/with-listenfd/src/main.rs
+++ b/examples/with-listenfd/src/main.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), salvo::Error> {
 
     let mut listenfd = ListenFd::from_env();
     let (addr, listener) = if let Some(listener) = listenfd.take_tcp_listener(0)? {
+        listener.set_nonblocking(true)?;
         (
             listener.local_addr()?,
             tokio::net::TcpListener::from_std(listener).unwrap(),


### PR DESCRIPTION
required due to latest version of tokio panicking if not set. https://github.com/tokio-rs/tokio/pull/7166