### PR TITLE
Update mod.rs. Spell mistake.

### DIFF
--- a/crates/core/src/fs/mod.rs
+++ b/crates/core/src/fs/mod.rs
@@ -101,8 +101,8 @@ mod test {
 
         let mut result = BytesMut::with_capacity(SIZE as usize);
 
-        while let Some(Ok(read_chunck)) = chunk.next().await {
-            result.extend_from_slice(&read_chunck)
+        while let Some(Ok(read_chunk)) = chunk.next().await {
+            result.extend_from_slice(&read_chunk)
         }
 
         assert_eq!(mock.into_inner(), result)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a spelling mistake in variable name `read_chunck` to `read_chunk`.

- Improved code readability and correctness in `mod.rs`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Fixed spelling mistake in variable name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/fs/mod.rs

<li>Corrected a spelling mistake in the variable name <code>read_chunck</code> to <br><code>read_chunk</code>.<br> <li> Ensured consistency in variable naming within the test code.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1094/files#diff-ad8248f330dfa557fa9ebe7137c7e01fb8fd57f77742a6a5655310fd4e038bb8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>