### PR TITLE
Update depot.rs. Spell mistake.

### DIFF
--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -152,7 +152,7 @@ impl Depot {
             if value.downcast_mut::<V>().is_some() {
                 Ok(value
                     .downcast_mut::<V>()
-                    .expect("downcast_mut shuold not be failed"))
+                    .expect("downcast_mut should not be failed"))
             } else {
                 Err(Some(value))
             }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a spelling mistake in an error message.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>depot.rs</strong><dd><code>Fix spelling mistake in error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/depot.rs

<li>Corrected a spelling mistake in an error message.<br> <li> Updated the text from <code>shuold</code> to <code>should</code>.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1095/files#diff-9970b52a3e12eeedcb056402009765ce8195f70387c78c233e3e2e7aacb28744">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>