### PR TITLE
Update handler.rs. Spell mistake.

### DIFF
--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -98,7 +98,7 @@
 //!
 //! ## Implement Handler trait directly
 //!
-//! Under certain circumstances, We need to implment `Handler` direclty.
+//! Under certain circumstances, We need to implement `Handler` directly.
 //!
 //! ```
 //! use salvo_core::prelude::*;
@@ -220,7 +220,7 @@ impl Handler for EmptyHandler {
 
 /// This is a empty implement for `Handler`.
 ///
-/// `EmptyHandler` does nothing except set [`Response`]'s satus as [`StatusCode::OK`], it just marker a router exits.
+/// `EmptyHandler` does nothing except set [`Response`]'s status as [`StatusCode::OK`], it just marker a router exits.
 pub fn empty() -> EmptyHandler {
     EmptyHandler
 }
@@ -271,7 +271,7 @@ where
     }
 }
 
-/// Handler that wrap [`Handler`] to let it use middlwares.
+/// Handler that wrap [`Handler`] to let it use middlewares.
 #[non_exhaustive]
 pub struct HoopedHandler {
     inner: Arc<dyn Handler>,


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fixed spelling mistakes in documentation comments.

- Improved clarity and accuracy of comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handler.rs</strong><dd><code>Fix spelling and clarity in documentation comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/handler.rs

<li>Corrected spelling errors in comments (e.g., "implment" to <br>"implement").<br> <li> Improved phrasing for better clarity (e.g., "satus" to "status").<br> <li> Adjusted terminology for accuracy (e.g., "middlwares" to <br>"middlewares").


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1096/files#diff-a64e35c7751020ee01d2a10ecbed04fc576bed552cec7e4f571f98818ac44181">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>