### PR TITLE
Update path.rs. Spell mistake.

### DIFF
--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -202,9 +202,9 @@ impl WispBuilder for CharsWispBuilder {
                 if max.is_empty() {
                     (min, None)
                 } else {
-                    let trimed_max = max.trim_start_matches('=');
-                    let max = if trimed_max == max {
-                        let max = trimed_max
+                    let trimmed_max = max.trim_start_matches('=');
+                    let max = if trimmed_max == max {
+                        let max = trimmed_max
                             .parse::<usize>()
                             .map_err(|_| format!("parse range for {name} failed"))?;
                         if max <= 1 {
@@ -212,7 +212,7 @@ impl WispBuilder for CharsWispBuilder {
                         }
                         max - 1
                     } else {
-                        let max = trimed_max
+                        let max = trimmed_max
                             .parse::<usize>()
                             .map_err(|_| format!("parse range for {name} failed"))?;
                         if max < 1 {
@@ -695,7 +695,7 @@ impl PathParser {
         let mut ident = "".to_owned();
         let mut ch = self
             .curr()
-            .ok_or_else(|| "current postion is out of index when scan ident".to_owned())?;
+            .ok_or_else(|| "current position is out of index when scan ident".to_owned())?;
         while !['/', ':', '|', '{', '}', '<', '>', '[', ']', '(', ')'].contains(&ch) {
             ident.push(ch);
             if let Some(c) = self.next(false) {
@@ -715,7 +715,7 @@ impl PathParser {
         let mut regex = "".to_owned();
         let mut ch = self
             .curr()
-            .ok_or_else(|| "current postion is out of index when scan regex".to_owned())?;
+            .ok_or_else(|| "current position is out of index when scan regex".to_owned())?;
         let mut escaping = false;
         let mut brace_opening = false;
         loop {
@@ -746,7 +746,7 @@ impl PathParser {
         let mut cnst = "".to_owned();
         let mut ch = self
             .curr()
-            .ok_or_else(|| "current postion is out of index when scan const".to_owned())?;
+            .ok_or_else(|| "current position is out of index when scan const".to_owned())?;
         while ch != '/' {
             if ch == '{' || ch == '}' {
                 // match `{{` or `}}`
@@ -797,7 +797,7 @@ impl PathParser {
     fn scan_wisps(&mut self) -> Result<Vec<WispKind>, String> {
         let mut ch = self
             .curr()
-            .ok_or_else(|| "current postion is out of index when scan part".to_owned())?;
+            .ok_or_else(|| "current position is out of index when scan part".to_owned())?;
         let mut wisps: Vec<WispKind> = vec![];
         while ch != '/' {
             if ch == '{' {
@@ -919,10 +919,10 @@ impl PathParser {
                     self.offset
                 ));
             }
-            let mut scaned = self.scan_wisps()?;
-            if scaned.len() > 1 {
-                wisps.push(CombWisp::new(scaned)?.into());
-            } else if let Some(wisp) = scaned.pop() {
+            let mut scanned = self.scan_wisps()?;
+            if scanned.len() > 1 {
+                wisps.push(CombWisp::new(scanned)?.into());
+            } else if let Some(wisp) = scanned.pop() {
                 wisps.push(wisp);
             } else {
                 return Err("scan parts is empty".to_owned());


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected spelling mistakes in variable names and error messages.

- Replaced `trimed_max` with `trimmed_max` for consistency.

- Fixed typos in error messages for better clarity.

- Improved code readability by aligning variable naming conventions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path.rs</strong><dd><code>Corrected spelling errors and improved clarity in `path.rs`</code></dd></summary>
<hr>

crates/core/src/routing/filters/path.rs

<li>Fixed spelling errors in variable names (<code>trimed_max</code> to <code>trimmed_max</code>).<br> <li> Corrected typos in error messages (<code>postion</code> to <code>position</code>).<br> <li> Updated variable names for better readability (<code>scaned</code> to <code>scanned</code>).<br> <li> Enhanced error message clarity and consistency.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1098/files#diff-f45602ac4e179934846508e732cd3dd7026d33b85190b62e0b342f4c6860c5ca">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>