### PR TITLE
Update caching_headers.rs. Spell mistake.

### DIFF
--- a/crates/extra/src/caching_headers.rs
+++ b/crates/extra/src/caching_headers.rs
@@ -199,15 +199,17 @@ mod tests {
         let router = Router::with_hoop(CachingHeaders::new()).get(hello);
         let service = Service::new(router);
 
-        let respone = TestClient::get("http://127.0.0.1:5800/").send(&service).await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
+        let response = TestClient::get("http://127.0.0.1:5800/")
+            .send(&service)
+            .await;
+        assert_eq!(response.status_code, Some(StatusCode::OK));
 
-        let etag = respone.headers().get(ETAG).unwrap();
-        let respone = TestClient::get("http://127.0.0.1:5800/")
+        let etag = response.headers().get(ETAG).unwrap();
+        let response = TestClient::get("http://127.0.0.1:5800/")
             .add_header(IF_NONE_MATCH, etag, true)
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::NOT_MODIFIED));
-        assert!(respone.body.is_none());
+        assert_eq!(response.status_code, Some(StatusCode::NOT_MODIFIED));
+        assert!(response.body.is_none());
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a spelling mistake in variable name `respone` to `response`.

- Updated test logic to use corrected variable name.

- Improved readability by reformatting method chaining.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caching_headers.rs</strong><dd><code>Fix variable name and reformat test code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/extra/src/caching_headers.rs

<li>Corrected spelling of <code>respone</code> to <code>response</code>.<br> <li> Adjusted test assertions to use the corrected variable.<br> <li> Reformatted method chaining for better readability.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1101/files#diff-63cdaf206bcffffcba5361f5b9d7d1eaa1f4f0a4588dd5e954505afdac3fc154">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>