### PR TITLE
Update lib.rs. Spell mistake.

### DIFF
--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -514,27 +514,27 @@ mod tests {
             .push(Router::with_path("logout").get(logout));
         let service = Service::new(router);
 
-        let respone = TestClient::post("http://127.0.0.1:5800/login")
+        let response = TestClient::post("http://127.0.0.1:5800/login")
             .raw_form("username=salvo")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::SEE_OTHER));
-        let cookie = respone.headers().get(SET_COOKIE).unwrap();
+        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
+        let cookie = response.headers().get(SET_COOKIE).unwrap();
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/")
+        let mut response = TestClient::get("http://127.0.0.1:5800/")
             .add_header(COOKIE, cookie, true)
             .send(&service)
             .await;
-        assert_eq!(respone.take_string().await.unwrap(), "salvo");
+        assert_eq!(response.take_string().await.unwrap(), "salvo");
 
-        let respone = TestClient::get("http://127.0.0.1:5800/logout")
+        let response = TestClient::get("http://127.0.0.1:5800/logout")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::SEE_OTHER));
+        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/")
+        let mut response = TestClient::get("http://127.0.0.1:5800/")
             .send(&service)
             .await;
-        assert_eq!(respone.take_string().await.unwrap(), "home");
+        assert_eq!(response.take_string().await.unwrap(), "home");
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected a spelling mistake in variable name.

- Updated test cases to use the corrected variable name.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Corrected spelling error in test variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/session/src/lib.rs

<li>Fixed spelling mistake in the variable <code>respone</code>, changing it to <br><code>response</code>.<br> <li> Updated all occurrences of <code>respone</code> in test cases to <code>response</code>.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1108/files#diff-ba7cc46118d67fb04d8d7f3893265f65d165d8b0b4f0a0ed340e7484b3db2206">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>