### PR TITLE
Update lib.rs. Spell mistake.

### DIFF
--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -298,50 +298,50 @@ mod tests {
         let router = Router::new().push(Router::with_path("limited").hoop(limiter).get(limited));
         let service = Service::new(router);
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
     }
 
     #[tokio::test]
@@ -378,49 +378,49 @@ mod tests {
         let router = Router::new().push(Router::with_path("limited").hoop(limiter).get(limited));
         let service = Service::new(router);
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        let respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
 
-        let mut respone = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
+        let mut response = TestClient::get("http://127.0.0.1:5800/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(respone.status_code, Some(StatusCode::OK));
-        assert_eq!(respone.take_string().await.unwrap(), "Limited page");
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "Limited page");
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected a spelling mistake in variable name `respone` to `response`.

- Updated multiple test cases for consistency and clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Corrected spelling in test variable names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/rate-limiter/src/lib.rs

<li>Renamed <code>respone</code> to <code>response</code> in multiple test cases.<br> <li> Improved code readability and consistency in test cases.<br> <li> Ensured all test cases use the corrected variable name.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1109/files#diff-940cf38f866420a8f0ad1ff1d176eeb14d325b9a01dcb0884d4bf0fd3e42e5d5">+36/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>