### PR TITLE
Remove meaningless content when cause or detail is None

### DIFF
--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -319,11 +319,11 @@ pub fn status_error_bytes(
     #[cfg(debug_assertions)]
     let cause = err.cause.as_ref().map(|e| format!("{:#?}", e));
     #[cfg(not(debug_assertions))]
-    let cause: Option<String> = None;
+    let cause: Option<&str> = None;
     #[cfg(debug_assertions)]
     let detail = err.detail.as_deref();
     #[cfg(not(debug_assertions))]
-    let detail: Option<String> = None;
+    let detail: Option<&str> = None;
     let content = match format.subtype().as_ref() {
         "plain" => status_error_plain(err.code, &err.name, &err.brief, detail, cause.as_deref()),
         "json" => status_error_json(err.code, &err.name, &err.brief, detail, cause.as_deref()),

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -210,8 +210,12 @@ fn status_error_html(
         code.as_u16(),
         name,
         brief,
-        detail.map(|detail| format!("<pre>{detail}</pre>")).unwrap_or_default(),
-        cause.map(|cause| format!("<pre>{cause:#?}</pre>")).unwrap_or_default(),
+        detail
+            .map(|detail| format!("<pre>{detail}</pre>"))
+            .unwrap_or_default(),
+        cause
+            .map(|cause| format!("<pre>{cause:#?}</pre>"))
+            .unwrap_or_default(),
         footer.unwrap_or(SALVO_LINK)
     )
 }
@@ -262,8 +266,12 @@ fn status_error_plain(
         code.as_u16(),
         name,
         brief,
-        detail.map(|detail| format!("\n\ndetail: {detail}")).unwrap_or_default(),
-        cause.map(|cause| format!("\n\ncause: {cause:#?}")).unwrap_or_default(),
+        detail
+            .map(|detail| format!("\n\ndetail: {detail}"))
+            .unwrap_or_default(),
+        cause
+            .map(|cause| format!("\n\ncause: {cause:#?}"))
+            .unwrap_or_default(),
     )
 }
 
@@ -309,24 +317,25 @@ pub fn status_error_bytes(
         prefer_format.clone()
     };
     #[cfg(debug_assertions)]
-    let cause = err.cause.as_ref().map(|e| format!("{:#?}", e.as_ref()));
+    let cause = err.cause.as_ref().map(|e| format!("{:#?}", e));
     #[cfg(not(debug_assertions))]
     let cause: Option<String> = None;
     #[cfg(debug_assertions)]
-    let detail = err.detail.clone();
+    let detail = err.detail.as_deref();
     #[cfg(not(debug_assertions))]
     let detail: Option<String> = None;
     let content = match format.subtype().as_ref() {
-        "plain" => status_error_plain(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref()),
-        "json" => status_error_json(
+        "plain" => status_error_plain(err.code, &err.name, &err.brief, detail, cause.as_deref()),
+        "json" => status_error_json(err.code, &err.name, &err.brief, detail, cause.as_deref()),
+        "xml" => status_error_xml(err.code, &err.name, &err.brief, detail, cause.as_deref()),
+        _ => status_error_html(
             err.code,
             &err.name,
             &err.brief,
-            detail.as_deref(),
+            detail,
             cause.as_deref(),
+            footer,
         ),
-        "xml" => status_error_xml(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref()),
-        _ => status_error_html(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref(), footer),
     };
     (format, Bytes::from(content))
 }

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -48,7 +48,6 @@ use crate::{Depot, FlowCtrl};
 
 static SUPPORTED_FORMATS: LazyLock<Vec<mime::Name>> =
     LazyLock::new(|| vec![mime::JSON, mime::HTML, mime::XML, mime::PLAIN]);
-const EMPTY_CAUSE_MSG: &str = "There is no more detailed explanation.";
 const SALVO_LINK: &str = r#"<a href="https://salvo.rs" target="_blank">salvo</a>"#;
 
 /// `Catcher` is used to catch errors.
@@ -169,6 +168,7 @@ fn status_error_html(
     code: StatusCode,
     name: &str,
     brief: &str,
+    detail: Option<&str>,
     cause: Option<&str>,
     footer: Option<&str>,
 ) -> String {
@@ -204,13 +204,14 @@ fn status_error_html(
     </style>
 </head>
 <body>
-    <div><h1>{0}: {1}</h1><h3>{2}</h3><pre>{3}</pre><hr><footer>{4}</footer></div>
+    <div><h1>{}: {}</h1><h3>{}</h3>{}{}<hr><footer>{}</footer></div>
 </body>
 </html>"#,
         code.as_u16(),
         name,
         brief,
-        cause.unwrap_or(EMPTY_CAUSE_MSG),
+        detail.map(|detail| format!("<pre>{detail}</pre>")).unwrap_or_default(),
+        cause.map(|cause| format!("<pre>{cause:#?}</pre>")).unwrap_or_default(),
         footer.unwrap_or(SALVO_LINK)
     )
 }
@@ -220,8 +221,8 @@ fn status_error_json(
     code: StatusCode,
     name: &str,
     brief: &str,
-    cause: Option<&str>,
     detail: Option<&str>,
+    cause: Option<&str>,
 ) -> String {
     #[derive(Serialize)]
     struct Data<'a> {
@@ -232,45 +233,64 @@ fn status_error_json(
         code: u16,
         name: &'a str,
         brief: &'a str,
-        detail: &'a str,
-        cause: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cause: Option<&'a str>,
     }
     let data = Data {
         error: Error {
             code: code.as_u16(),
             name,
             brief,
-            detail: detail.unwrap_or(EMPTY_CAUSE_MSG),
-            cause: cause.unwrap_or(EMPTY_CAUSE_MSG),
+            detail,
+            cause,
         },
     };
     serde_json::to_string(&data).unwrap_or_default()
 }
 
-fn status_error_plain(code: StatusCode, name: &str, brief: &str, cause: Option<&str>) -> String {
+fn status_error_plain(
+    code: StatusCode,
+    name: &str,
+    brief: &str,
+    detail: Option<&str>,
+    cause: Option<&str>,
+) -> String {
     format!(
-        "code: {}\n\nname: {}\n\nbrief: {}\n\ncause: {}",
+        "code: {}\n\nname: {}\n\nbrief: {}{}{}",
         code.as_u16(),
         name,
         brief,
-        cause.unwrap_or(EMPTY_CAUSE_MSG)
+        detail.map(|detail| format!("\n\ndetail: {detail}")).unwrap_or_default(),
+        cause.map(|cause| format!("\n\ncause: {cause:#?}")).unwrap_or_default(),
     )
 }
 
-fn status_error_xml(code: StatusCode, name: &str, brief: &str, cause: Option<&str>) -> String {
+fn status_error_xml(
+    code: StatusCode,
+    name: &str,
+    brief: &str,
+    detail: Option<&str>,
+    cause: Option<&str>,
+) -> String {
     #[derive(Serialize)]
     struct Data<'a> {
         code: u16,
         name: &'a str,
         brief: &'a str,
-        cause: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cause: Option<&'a str>,
     }
 
     let data = Data {
         code: code.as_u16(),
         name,
         brief,
-        cause: cause.unwrap_or(EMPTY_CAUSE_MSG),
+        detail,
+        cause,
     };
     serde_xml_rs::to_string(&data).unwrap_or_default()
 }
@@ -297,16 +317,16 @@ pub fn status_error_bytes(
     #[cfg(not(debug_assertions))]
     let detail: Option<String> = None;
     let content = match format.subtype().as_ref() {
-        "plain" => status_error_plain(err.code, &err.name, &err.brief, cause.as_deref()),
+        "plain" => status_error_plain(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref()),
         "json" => status_error_json(
             err.code,
             &err.name,
             &err.brief,
-            cause.as_deref(),
             detail.as_deref(),
+            cause.as_deref(),
         ),
-        "xml" => status_error_xml(err.code, &err.name, &err.brief, cause.as_deref()),
-        _ => status_error_html(err.code, &err.name, &err.brief, cause.as_deref(), footer),
+        "xml" => status_error_xml(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref()),
+        _ => status_error_html(err.code, &err.name, &err.brief, detail.as_deref(), cause.as_deref(), footer),
     };
     (format, Bytes::from(content))
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored error message generation to handle `None` values for `cause` and `detail`.

- Removed the `EMPTY_CAUSE_MSG` constant for cleaner error handling.

- Enhanced error serialization to skip `None` values in JSON and XML outputs.

- Updated error formatting functions to include `detail` and improve clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>catcher.rs</strong><dd><code>Refactor error handling and formatting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/catcher.rs

<li>Removed <code>EMPTY_CAUSE_MSG</code> constant for unused default messages.<br> <li> Updated error formatting functions to handle <code>detail</code> and <code>cause</code> as <br><code>Option</code>.<br> <li> Improved JSON and XML serialization to skip <code>None</code> values.<br> <li> Refactored error message generation for better clarity and <br>maintainability.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1112/files#diff-1c968903213a506970b014e51012133fedd8047a66fcc5c0b197ab535e55626f">+50/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>