### PR TITLE
oapi: Only wan if parameters not exist in debug mode

### DIFF
--- a/crates/oapi/src/openapi/mod.rs
+++ b/crates/oapi/src/openapi/mod.rs
@@ -498,6 +498,7 @@ impl OpenApi {
                             })
                     })
                     .collect::<Vec<_>>();
+                #[cfg(debug_assertions)]
                 if !meta_not_exist_parameters.is_empty() {
                     tracing::warn!(parameters = ?meta_not_exist_parameters, path, handler_name = node.handler_type_name, "parameters information not provided");
                 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add conditional compilation for debug mode warnings.

- Warn only in debug mode if parameters are missing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Conditional debug mode warnings for missing parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/oapi/src/openapi/mod.rs

<li>Added <code>#[cfg(debug_assertions)]</code> to conditionally compile warnings.<br> <li> Warnings for missing parameters now only appear in debug mode.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1114/files#diff-198619ded4debe85996e8c24a3e66842d819cc497d0b0b6e4a24ff874897b49c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>