### PR TITLE
Enhanced support for anyhow::Error

### DIFF
--- a/crates/core/src/http/errors/status_error.rs
+++ b/crates/core/src/http/errors/status_error.rs
@@ -44,7 +44,7 @@ pub struct StatusError {
     /// Detail information about http error.
     pub detail: Option<String>,
     /// Cause about http error. This field is only used for internal debugging and only used in debug mode.
-    pub cause: Option<Box<dyn StdError + Sync + Send + 'static>>,
+    pub cause: Option<Box<dyn std::any::Any + Sync + Send + 'static>>,
 }
 
 impl StatusError {
@@ -59,12 +59,12 @@ impl StatusError {
         self
     }
     /// Sets cause field and returns `Self`.
-    pub fn cause<C>(mut self, cause: C) -> Self
-    where
-        C: Into<Box<dyn StdError + Sync + Send + 'static>>,
-    {
-        self.cause = Some(cause.into());
+    pub fn cause<C: Send + Sync + 'static>(mut self, cause: C) -> Self {
+        self.cause = Some(Box::new(cause));
         self
+    }
+    pub fn downcast_cause<T: 'static>(&self) -> Option<&T> {
+        self.cause.as_ref().and_then(|c| c.downcast_ref::<T>())
     }
 
     default_errors! {
@@ -200,7 +200,15 @@ impl Display for StatusError {
             write!(&mut str_error, " detail: {}", detail)?;
         }
         if let Some(cause) = &self.cause {
-            write!(&mut str_error, " cause: {}", cause)?;
+            if let Some(err) = cause.downcast_ref::<&dyn StdError>() {
+                write!(&mut str_error, " cause: {}", err)?;
+            } else if let Some(err) = cause.downcast_ref::<String>() {
+                write!(&mut str_error, " cause: {}", err)?;
+            } else if let Some(err) = cause.downcast_ref::<&str>() {
+                write!(&mut str_error, " cause: {}", err)?;
+            } else {
+                write!(&mut str_error, " cause: <unknown error type>")?;
+            }
         }
         f.write_str(&str_error)
     }

--- a/crates/oapi/Cargo.toml
+++ b/crates/oapi/Cargo.toml
@@ -74,6 +74,7 @@ regex = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 http = { workspace = true }
+anyhow = { workspace = true }
 
 # Feature optional dependencies
 chrono = { workspace = true, optional = true }

--- a/crates/oapi/src/endpoint.rs
+++ b/crates/oapi/src/endpoint.rs
@@ -178,3 +178,61 @@ impl EndpointRegistry {
     }
 }
 inventory::collect!(EndpointRegistry);
+
+
+// ----> support anyhow::Result
+impl<T> EndpointOutRegister for anyhow::Result<T>
+where
+    T: EndpointOutRegister + Send,
+{
+    #[inline]
+    fn register(components: &mut Components, operation: &mut Operation) {
+        // 注册成功情况的响应
+        T::register(components, operation);
+
+        // 注册错误情况的响应
+        // anyhow::Error 可能代表多种错误情况，我们将其映射为 500 内部服务器错误
+        operation.responses.insert(
+            "500",
+            Response::new("Internal Server Error")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 可选：添加其他可能的状态码
+        operation.responses.insert(
+            "400",
+            Response::new("Bad Request")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 添加对 StatusError 的支持，因为 anyhow::Error 可能会包装 StatusError
+        StatusError::register(components, operation);
+    }
+}
+
+// 特殊处理 anyhow::Result<()> 的情况
+impl EndpointOutRegister for anyhow::Result<()> {
+    #[inline]
+    fn register(components: &mut Components, operation: &mut Operation) {
+        // 成功情况
+        operation.responses.insert("200", Response::new("Ok"));
+
+        // 错误情况
+        operation.responses.insert(
+            "500",
+            Response::new("Internal Server Error")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 可选：添加其他可能的状态码
+        operation.responses.insert(
+            "400",
+            Response::new("Bad Request")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 添加对 StatusError 的支持
+        StatusError::register(components, operation);
+    }
+}
+


### PR DESCRIPTION
### **User description**
With this change, we can use anyhow in salvo and salvo-oapi like this:
```
/// Create new user.
#[endpoint(tags("users"), status_codes(201, 500))]
pub async fn create_user(req: JsonBody<UserCreate>) -> anyhow::Result<StatusCode> {
   let a = std::fs::read("not_found")?; // If error occurred, it is returned directly via anyhow::Error
   Ok(StatusCode::CREATED)
}
```
At the same time, we can easily get the type of anyhow::Error and the stack information in the middleware.
Sample code:
```
use salvo::http::{Request, ResBody, Response, StatusError};
use salvo::prelude::*;
use sqlx::Error as SqlxError;
use std::error::Error as StdError;

#[derive(Default)]
pub struct ErrorHandlerMiddleware;

#[async_trait]
impl Handler for ErrorHandlerMiddleware {
    async fn handle(
        &self,
        req: &mut Request,
        depot: &mut Depot,
        res: &mut Response,
        ctrl: &mut FlowCtrl,
    ) {
        ctrl.call_next(req, depot, res).await;

        if res.body.is_error() {
            let body = res.body.take();
            if let ResBody::Error(mut status_error) = body {
                if let Some(anyhow_err) = status_error.downcast_cause::<anyhow::Error>() {
                    if let Some(sqlx_err) = anyhow_err.downcast_ref::<sqlx::Error>() {
                        match sqlx_err {
                            // got Sqlx::Error
                        }
                    }
                }
            }
        }
    }
}
```


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `StatusError` to store any error type as cause

- Added support for `anyhow::Result` in OpenAPI endpoint registration

- Improved error type introspection and formatting in `StatusError`

- Added `anyhow` as a dependency in oapi crate


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>status_error.rs</strong><dd><code>Refactor StatusError to support any error type as cause</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/http/errors/status_error.rs

<li>Changed <code>StatusError</code> to store cause as <code>Box<dyn Any + Sync + Send></code><br> <li> Updated <code>cause</code> setter to accept any type, not just <code>StdError</code><br> <li> Added <code>downcast_cause</code> method for type-safe error extraction<br> <li> Improved <code>Display</code> implementation to handle multiple error types


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1125/files#diff-f9921bc28cea15ef2aae53df3a41aab0c9e455259e841518948a8fe2c94f6140">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>endpoint.rs</strong><dd><code>Add OpenAPI registration for anyhow::Result endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/oapi/src/endpoint.rs

<li>Implemented <code>EndpointOutRegister</code> for <code>anyhow::Result<T></code> and <code>anyhow::Result<()></code><br> <li> Registered standard error responses (500, 400) for <code>anyhow::Result</code><br> <li> Ensured <code>StatusError</code> is registered for error cases


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1125/files#diff-9765d40aca8d4590a66be0c7eda960a0bfcafcd20f5e13598ef6dbabf5498722">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add anyhow dependency to oapi crate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/oapi/Cargo.toml

- Added `anyhow` as a workspace dependency


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1125/files#diff-b8863f92b4f3a29a0baf5e64f7d6d925ce60e42ec84c579fca99d76927fdd87b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>