### PR TITLE
Enhanced support for anyhow::Error, (fixed anyhow fmt)

### DIFF
--- a/crates/oapi/Cargo.toml
+++ b/crates/oapi/Cargo.toml
@@ -86,6 +86,7 @@ ulid = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 compact_str = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
 
 [build-dependencies]
 regex = { workspace = true }

--- a/crates/oapi/src/endpoint.rs
+++ b/crates/oapi/src/endpoint.rs
@@ -178,3 +178,62 @@ impl EndpointRegistry {
     }
 }
 inventory::collect!(EndpointRegistry);
+
+
+// ----> support anyhow::Result
+#[cfg(feature = "anyhow")]
+impl<T> EndpointOutRegister for anyhow::Result<T>
+where
+    T: EndpointOutRegister + Send,
+{
+    #[inline]
+    fn register(components: &mut Components, operation: &mut Operation) {
+        // 注册成功情况的响应
+        T::register(components, operation);
+
+        // 注册错误情况的响应
+        // anyhow::Error 可能代表多种错误情况，我们将其映射为 500 内部服务器错误
+        operation.responses.insert(
+            "500",
+            Response::new("Internal Server Error")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 可选：添加其他可能的状态码
+        operation.responses.insert(
+            "400",
+            Response::new("Bad Request")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 添加对 StatusError 的支持，因为 anyhow::Error 可能会包装 StatusError
+        StatusError::register(components, operation);
+    }
+}
+
+// 特殊处理 anyhow::Result<()> 的情况
+#[cfg(feature = "anyhow")]
+impl EndpointOutRegister for anyhow::Result<()> {
+    #[inline]
+    fn register(components: &mut Components, operation: &mut Operation) {
+        // 成功情况
+        operation.responses.insert("200", Response::new("Ok"));
+
+        // 错误情况
+        operation.responses.insert(
+            "500",
+            Response::new("Internal Server Error")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 可选：添加其他可能的状态码
+        operation.responses.insert(
+            "400",
+            Response::new("Bad Request")
+                .add_content("text/plain", String::to_schema(components)),
+        );
+
+        // 添加对 StatusError 的支持
+        StatusError::register(components, operation);
+    }
+}


### PR DESCRIPTION
### **User description**
With this change, we can use anyhow in salvo and salvo-oapi like this:
```
/// Create new user.
#[endpoint(tags("users"), status_codes(201, 500))]
pub async fn create_user(req: JsonBody<UserCreate>) -> anyhow::Result<StatusCode> {
   let a = std::fs::read("not_found")?; // If error occurred, it is returned directly via anyhow::Error
   Ok(StatusCode::CREATED)
}
```

At the same time, we can easily get the type of anyhow::Error and the stack information in the middleware.
Sample code:
```
use salvo::http::{Request, ResBody, Response, StatusError};
use salvo::prelude::*;
use sqlx::Error as SqlxError;
use std::error::Error as StdError;

#[derive(Default)]
pub struct ErrorHandlerMiddleware;

#[async_trait]
impl Handler for ErrorHandlerMiddleware {
    async fn handle(
        &self,
        req: &mut Request,
        depot: &mut Depot,
        res: &mut Response,
        ctrl: &mut FlowCtrl,
    ) {
        ctrl.call_next(req, depot, res).await;

        if res.body.is_error() {
            let body = res.body.take();
            if let ResBody::Error(mut status_error) = body {
                if let Some(anyhow_err) = status_error.downcast_cause::<anyhow::Error>() {
                    if let Some(sqlx_err) = anyhow_err.downcast_ref::<sqlx::Error>() {
                        match sqlx_err {
                            // got Sqlx::Error
                        }
                    }
                }
            }
        }
    }
}
```


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced support for `anyhow::Error` in error handling.

- Added OpenAPI registration for `anyhow::Result` response types.

- Improved formatting and downcasting of error causes in `StatusError`.

- Added optional `anyhow` dependency to oapi crate.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>status_error.rs</strong><dd><code>Generalize and improve error cause handling in StatusError</code></dd></summary>
<hr>

crates/core/src/http/errors/status_error.rs

<li>Changed <code>StatusError.cause</code> to store any type using <code>std::any::Any</code>.<br> <li> Updated <code>cause</code> setter to accept any type, not just <code>StdError</code>.<br> <li> Added <code>downcast_cause</code> method for type-safe error extraction.<br> <li> Enhanced error formatting to handle multiple cause types, including <br><code>anyhow::Error</code>.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1126/files#diff-f9921bc28cea15ef2aae53df3a41aab0c9e455259e841518948a8fe2c94f6140">+26/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>endpoint.rs</strong><dd><code>Add OpenAPI support for endpoints returning anyhow::Result</code></dd></summary>
<hr>

crates/oapi/src/endpoint.rs

<li>Added OpenAPI registration for <code>anyhow::Result<T></code> and <code>anyhow::Result<()></code>.<br> <li> Mapped <code>anyhow::Error</code> to 500 and 400 HTTP responses in OpenAPI.<br> <li> Ensured <code>StatusError</code> is registered for error responses.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1126/files#diff-9765d40aca8d4590a66be0c7eda960a0bfcafcd20f5e13598ef6dbabf5498722">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add optional anyhow dependency to oapi crate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/oapi/Cargo.toml

- Added optional `anyhow` dependency for feature-based support.


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1126/files#diff-b8863f92b4f3a29a0baf5e64f7d6d925ce60e42ec84c579fca99d76927fdd87b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>