### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,8 @@
 name: ci-linux
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/salvo-rs/salvo/security/code-scanning/10](https://github.com/salvo-rs/salvo/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Based on the workflow's actions, it primarily interacts with the repository's contents (e.g., checking out code, running Rust commands). Therefore, the `contents: read` permission is sufficient. If any job requires additional permissions, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
