### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,8 @@ on:
       - '*'
 
 name: "Format Code"
+permissions:
+  contents: read
 
 jobs:
   format:


### PR DESCRIPTION
Potential fix for [https://github.com/salvo-rs/salvo/security/code-scanning/1](https://github.com/salvo-rs/salvo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this workflow is for formatting code, it only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
