### PR TITLE
Fix: impl Scribe for anyhow::Error{}

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -186,7 +186,7 @@ cfg_feature! {
         #[inline]
         fn render(self, res: &mut Response) {
             tracing::error!(error = ?self, "anyhow error occurred");
-            res.render(StatusError::internal_server_error().cause(self));
+            res.render(StatusError::internal_server_error().origin(self));
         }
     }
 }


### PR DESCRIPTION
### **User description**
In this way, the correct type can be obtained:
```
if let Some(anyhow_err) = status_error.downcast_origin::<anyhow::Error>() {
```

code:
```
cfg_feature! {
    #![feature = "anyhow"]
    impl Scribe for anyhow::Error {
        #[inline]
        fn render(self, res: &mut Response) {
            tracing::error!(error = ?self, "anyhow error occurred");
            // res.render(StatusError::internal_server_error().cause(self));
            res.render(StatusError::internal_server_error().origin(self));
        }
    }
}
```


___

### **PR Type**
bug_fix


___

### **Description**
- Fixes `Scribe` implementation for `anyhow::Error`

- Uses `origin(self)` instead of deprecated `cause(self)`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Update Scribe for anyhow::Error to use origin method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/error.rs

<li>Replaces <code>cause(self)</code> with <code>origin(self)</code> in <code>Scribe</code> for <code>anyhow::Error</code><br> <li> Ensures correct error origin is set in response rendering


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1134/files#diff-246c401623efcdd6d37575a9c3e55e6b5c18bb8fbaeaf91800261a97b365d12b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>