### PR TITLE
Do not log H3_NO_ERROR

### DIFF
--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -114,7 +114,9 @@ impl Builder {
                     break;
                 }
                 Err(e) => {
-                    tracing::error!("Connection errored with {}", e);
+                    if !e.is_h3_no_error() {
+                        tracing::error!("Connection errored with {}", e);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
### **User description**
The H3 status [H3_NO_ERROR](https://www.rfc-editor.org/rfc/rfc9114.html#H3_NO_ERROR) (0x0100) simply marks a clean shutdown of a connection or stream, not an actual error. I see many of these messages due to heavy HTTP/3 usage and logging them as errors clutters the logs in such scenarios, so they should be skipped.

```
H3_NO_ERROR (0x0100):
No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
```


___

### **PR Type**
Bug fix


___

### **Description**
- Suppress logging for `H3_NO_ERROR` connection shutdowns

- Prevents log clutter from normal HTTP/3 connection closures


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>builder.rs</strong><dd><code>Skip logging for H3_NO_ERROR connection shutdowns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/conn/quinn/builder.rs

<li>Added conditional to skip logging when error is <code>H3_NO_ERROR</code><br> <li> Only logs actual errors, not clean shutdowns


</details>


  </td>
  <td><a href="https://github.com/salvo-rs/salvo/pull/1144/files#diff-237c516e518e8f1fc8c803f9ed51a8652c9c87af8438bd3c2fe8287be86cf7a1">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>