### PR TITLE
Add `unix-sock-client` to the full futures for salvo-proxy

### DIFF
--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["ring", "hyper-client", "unix-sock-client"]
-full = ["ring", "hyper-client", "reqwest-client"]
+full = ["ring", "hyper-client", "reqwest-client", "unix-sock-client"]
 # aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
 ring = ["hyper-rustls/ring"]
 hyper-client = ["dep:hyper-util", "dep:hyper-rustls"]


### PR DESCRIPTION
Since you've wrapped the Unix sock client with the `cfg_feature!` macro but haven't updated all the features, it won't work. This is because the `salvo-proxy` features are set to full.

