### PR TITLE
feat: pass req and depot into Upstreams::elect to allow more flexible upstream election

### DIFF
--- a/crates/proxy/src/hyper_client.rs
+++ b/crates/proxy/src/hyper_client.rs
@@ -109,7 +109,9 @@ mod tests {
     async fn test_upstreams_elect() {
         let upstreams = vec!["https://www.example.com", "https://www.example2.com"];
         let proxy = Proxy::new(upstreams.clone(), HyperClient::default());
-        let elected_upstream = proxy.upstreams().elect().await.unwrap();
+        let request = Request::new();
+        let depot = Depot::new();
+        let elected_upstream = proxy.upstreams().elect(&request, &depot).await.unwrap();
         assert!(upstreams.contains(&elected_upstream));
     }
 

--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -115,7 +115,9 @@ mod tests {
     async fn test_upstreams_elect() {
         let upstreams = vec!["https://www.example.com", "https://www.example2.com"];
         let proxy = Proxy::new(upstreams.clone(), ReqwestClient::default());
-        let elected_upstream = proxy.upstreams().elect().await.unwrap();
+        let request = Request::new();
+        let depot = Depot::new();
+        let elected_upstream = proxy.upstreams().elect(&request, &depot).await.unwrap();
         assert!(upstreams.contains(&elected_upstream));
     }
 


### PR DESCRIPTION
Changes introduced in this PR alternate Upstreams trait and Proxy::build_proxied_request method to pass references to Request and Depot into Upstreams::elect call.

This in turn provides more flexibility for upstream selection and make it possible to implement smart request forwarding like:
* Path-based upstream election (e.g. for distributed resource caching)
* Load-based upstream election (e.g. forwarding to the least loaded or the most responsive upstream node by keeping node performance stats in the Depot)
* Upstream failover (e.g. by keeping a list of failed upstream nodes in the Depot)
* Sticky upstreams forwarding (e.g. based on request cookies or incoming IP address)