### PR TITLE
feat: Implement client IP forwarding support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ hyper-util = { version = "0.1", default-features = true }
 indexmap = "2"
 inventory = "0.3"
 jsonwebtoken = "10"
+local-ip-address = "0.6.5"
 mime = "0.3"
 mime-infer = "4"
 moka = "0.12"

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -52,10 +52,10 @@ hyper-util = { workspace = true, optional = true, features = [
 ] }
 percent-encoding = { workspace = true }
 reqwest = { workspace = true, optional = true, features = ["stream"] }
+local-ip-address = { workspace = true }
 
 [dev-dependencies]
 salvo_core = { workspace = true, features = ["http1", "server", "test"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Implemented client IP forwarding in Proxy via X-Forwarded-For HTTP header.

Please note, that the `local-ip-address` crate was added to dependencies to provide system IP address detection.