### PR TITLE
Use `SALVO_STATUS_ERROR` to control default error page

### DIFF
--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -363,7 +363,7 @@ pub fn status_error_bytes(
         prefer_format.clone()
     };
 
-    let env_set = env::var("SALVO_STATUS_ERROR")
+    let env_sets = env::var("SALVO_STATUS_ERROR")
         .unwrap_or_default()
         .split(',')
         .filter_map(|s| {
@@ -379,18 +379,18 @@ pub fn status_error_bytes(
         })
         .collect::<HashSet<_>>();
 
-    let detail = if !env_set.contains("never_detail")
-        && (env_set.contains("force_detail")
-            || (env_set.contains("debug_detail") && cfg!(debug_assertions)))
+    let detail = if !env_sets.contains("never_detail")
+        && (env_sets.contains("force_detail")
+            || (env_sets.contains("debug_detail") && cfg!(debug_assertions)))
     {
         err.detail.as_deref()
     } else {
         None
     };
 
-    let cause = if !env_set.contains("never_cause")
-        && (env_set.contains("force_cause")
-            || (env_set.contains("debug_cause") && cfg!(debug_assertions)))
+    let cause = if !env_sets.contains("never_cause")
+        && (env_sets.contains("force_cause")
+            || (env_sets.contains("debug_cause") && cfg!(debug_assertions)))
     {
         err.cause.as_ref().map(|e| format!("{e:#?}"))
     } else {


### PR DESCRIPTION
You can use environment variable `SALVO_STATUS_ERROR` to control whether to show `detail` and `cause` information in default error page.

force_detail: always show detail information in error page even in release mode.
debug_detail: only show detail information in error page in debug mode.
never_detail: never show detail information in error page.
force_cause: always show cause information in error page even in release mode.
debug_cause: only show cause information in error page in debug mode.
never_cause: never show detail information in error page.

For example:
```sh
SALVO_STATUS_ERROR=force_cause,force_detail
```
will always show `detail` and `cause` information in error page even in release mode.

If `SALVO_STATUS_ERROR` is not set, then `detail` and `cause` will only be shown in error page in debug mode for security reason.