### PR TITLE
fix: improper use of AllOf in nullable property schema generation

### DIFF
--- a/crates/oapi-macros/src/component.rs
+++ b/crates/oapi-macros/src/component.rs
@@ -423,7 +423,7 @@ impl ComponentSchema {
                             .transpose()?;
                         let schema = if default.is_some() || nullable {
                             quote_spanned! {type_path.span()=>
-                                #oapi::oapi::schema::AllOf::new()
+                                #oapi::oapi::schema::OneOf::new()
                                     #nullable_item
                                     .item(<#type_path as #oapi::oapi::ToSchema>::to_schema(components))
                                 #default
@@ -448,7 +448,7 @@ impl ComponentSchema {
                         // `description` of the ref. Should we consider supporting the summary?
                         let schema = if default.is_some() || nullable {
                             quote! {
-                                #oapi::oapi::schema::AllOf::new()
+                                #oapi::oapi::schema::OneOf::new()
                                     #nullable_item
                                     .item(#schema)
                                     #default


### PR DESCRIPTION
There is no open issue for this PR.

Using AllOf to build a nullable ref property is not correct.
I believe that OneOf is the correct choice here, given the context.

Please let me know what your thoughts. 🙏 
There are currently no unit tests validating this behaviour.

Consequence of the PR:

Rust

```rust
#[derive(Debug, Clone, Serialize, Deserialize, salvo::oapi::ToSchema)]
pub struct SomeType {
    pub some_nullable_property: Option<SomeSubType>,
}
```

```diff
 "some_nullable_property": {
-  "allOf": [
+  "oneOf": [
     {
       "type": "null"
     },
     {
       "$ref": "#/components/schemas/SomeSubType"
     }
   ]
 },
```

Generated:

```diff
 export type SomeType = {
-    some_nullable_property?: null & SomeSubType;
+    some_nullable_property?: null | SomeSubType;
 };
```

References:
https://danott.dev/thoughts/openapi-nullable-object-anyof-oneof-allof
https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/