### PR TITLE
feat(oapi-macros): Supports using expressions in tags and adjusts the generation logic

### DIFF
--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -1,7 +1,6 @@
 use proc_macro2::Ident;
 use syn::punctuated::Punctuated;
-use syn::{Expr, LitStr};
-use syn::{parenthesized, parse::Parse};
+use syn::{parenthesized, parse::Parse, Expr};
 
 use crate::operation::request_body::RequestBodyAttr;
 use crate::{
@@ -14,7 +13,7 @@ pub(crate) struct EndpointAttr<'p> {
     pub(crate) responses: Vec<Response<'p>>,
     pub(crate) status_codes: Vec<Expr>,
     pub(crate) operation_id: Option<Expr>,
-    pub(crate) tags: Option<Vec<String>>,
+    pub(crate) tags: Option<Vec<Expr>>,
     pub(crate) parameters: Vec<Parameter<'p>>,
     pub(crate) security: Option<Array<'p, SecurityRequirementsAttr>>,
 
@@ -68,16 +67,9 @@ impl Parse for EndpointAttr<'_> {
                 "tags" => {
                     let tags;
                     parenthesized!(tags in input);
-                    attr.tags = Some(
-                        Punctuated::<LitStr, Token![,]>::parse_terminated(&tags).map(
-                            |punctuated| {
-                                punctuated
-                                    .into_iter()
-                                    .map(|t| t.value())
-                                    .collect::<Vec<_>>()
-                            },
-                        )?,
-                    );
+                    let parsed: Punctuated<Expr, Token![,]> =
+                        Punctuated::<Expr, Token![,]>::parse_terminated(&tags)?;
+                    attr.tags = Some(parsed.into_iter().collect());
                 }
                 "security" => {
                     let security;

--- a/crates/oapi-macros/src/operation.rs
+++ b/crates/oapi-macros/src/operation.rs
@@ -22,7 +22,7 @@ pub(crate) mod status;
 pub(crate) struct Operation<'a> {
     deprecated: &'a Option<bool>,
     operation_id: Option<&'a Expr>,
-    tags: &'a Option<Vec<String>>,
+    tags: &'a Option<Vec<Expr>>,
     parameters: &'a Vec<Parameter<'a>>,
     request_body: Option<&'a RequestBodyAttr<'a>>,
     responses: &'a Vec<Response<'a>>,
@@ -124,10 +124,10 @@ impl<'a> Operation<'a> {
         }
 
         if let Some(tags) = self.tags {
-            let tags = tags.iter().collect::<Array<_>>();
+            let tags = tags.iter();
             modifiers.push(quote! {
-                operation.tags.extend(#tags.into_iter().map(|t|t.into()));
-            })
+                #( operation.tags.push((#tags).into()); )*
+            });
         }
 
         if let Some(summary) = &self.summary


### PR DESCRIPTION
## PR content

> Related issue: https://github.com/salvo-rs/salvo/issues/1243

### Usage example

Allow tags as expressions and adjust tag emission

```rust
pub enum MyTag { A, B }

impl From<MyTag> for Tag {
    fn from(value: MyTag) -> Self {
        match value {
            MyTag::A => {
                Tag::new("A")
            },
            MyTag::B => Tag::new("B"),
        }
    }
}

impl From<MyTag> for String {
    fn from(t: MyTag) -> Self {
        match t {
            MyTag::A => "A".to_string(),
            MyTag::B => "B".to_string(),
        }
    }
}

#[derive(Clone, Copy, Debug)]
pub enum ApiTag {
    Posts,
    Admin,
}

impl From<ApiTag> for Tag {
    fn from(value: ApiTag) -> Self {
        match value {
            ApiTag::Posts => {
                Tag::new("Posts").description("Operations about posts")
            },
            ApiTag::Admin => Tag::new("Admin").description("Operations about admin"),
        }
    }
}

impl From<ApiTag> for String {
    fn from(t: ApiTag) -> Self {
        match t {
            ApiTag::Posts => "Posts".to_string(),
            ApiTag::Admin => "Admin".to_string(),
        }
    }
}

/// 2) Struct tag：marker type
#[derive(Clone, Copy, Debug)]
pub struct InternalTag;

impl From<InternalTag> for String {
    fn from(_: InternalTag) -> Self {
        "Internal".to_string()
    }
}


#[endpoint(
    tags(ApiTag::Posts, ApiTag::Admin, InternalTag, format!("v{}", 2), MyTag::A, MyTag::B),
    summary = "get all posts",
    description = "the objective of this endpoint is to retreive all posts",
    responses(
        (status_code = 200, description = "Ok"),
        (status_code = 400, description = "Bad Request"),
    )
)]
fn get_all_posts(res: &mut Response){
    res.render("get all posts")
}
```