### PR TITLE
refactor(rate-limiter): use `IpAddr` as `RemoteIpIssuer::Key`

### DIFF
--- a/crates/core/src/conn/addr.rs
+++ b/crates/core/src/conn/addr.rs
@@ -68,6 +68,32 @@ impl SocketAddr {
         matches!(*self, Self::IPv6(_))
     }
 
+    /// Returns the IP address associated with this socket address.
+    ///
+    /// Returns `None` if this address is not an IP-based socket address.
+    #[inline]
+    #[must_use]
+    pub fn ip(&self) -> Option<std::net::IpAddr> {
+        match self {
+            SocketAddr::IPv4(a) => Some(std::net::IpAddr::V4(*a.ip())),
+            SocketAddr::IPv6(a) => Some(std::net::IpAddr::V6(*a.ip())),
+            _ => None,
+        }
+    }
+
+    /// Returns the port number associated with this socket address.
+    ///
+    /// Returns `None` if this address is not an IP-based socket address.
+    #[must_use]
+    #[inline]
+    pub fn port(&self) -> Option<u16> {
+        match self {
+            SocketAddr::IPv4(a) => Some(a.port()),
+            SocketAddr::IPv6(a) => Some(a.port()),
+            _ => None,
+        }
+    }
+
     /// Convert to [`std::net::SocketAddr`].
     #[inline]
     #[must_use]

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -19,8 +19,8 @@ use std::borrow::Borrow;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
+use std::net::IpAddr;
 
-use salvo_core::conn::SocketAddr;
 use salvo_core::handler::{Skipper, none_skipper};
 use salvo_core::http::{HeaderValue, Request, Response, StatusCode, StatusError};
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
@@ -77,13 +77,9 @@ where
 #[derive(Debug)]
 pub struct RemoteIpIssuer;
 impl RateIssuer for RemoteIpIssuer {
-    type Key = String;
+    type Key = IpAddr;
     async fn issue(&self, req: &mut Request, _depot: &Depot) -> Option<Self::Key> {
-        match req.remote_addr() {
-            SocketAddr::IPv4(addr) => Some(addr.ip().to_string()),
-            SocketAddr::IPv6(addr) => Some(addr.ip().to_string()),
-            _ => None,
-        }
+        req.remote_addr().ip()
     }
 }
 


### PR DESCRIPTION
`IpAddr` already implements `Hash`, so converting it to `String` is unnecessary.