### PR TITLE
feat(proxy): add unix-sock-client to full feature set

### DIFF
--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["aws-lc-rs", "hyper-client", "unix-sock-client"]
-full = ["aws-lc-rs", "hyper-client", "reqwest-client"]
+full = ["aws-lc-rs", "hyper-client", "reqwest-client", "unix-sock-client"]
 aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "reqwest?/rustls"]
 ring = ["hyper-rustls?/ring", "reqwest?/rustls-no-provider", "rustls", "rustls/ring"]
 hyper-client = ["dep:hyper-util", "dep:hyper-rustls"]


### PR DESCRIPTION
This PR fixes an issue where the `full` feature does not include the `unix-sock-client` in the proxy crate. As a result, when using the proxy crate, `unix-sock-client` cannot be used with Salvo.