### PR TITLE
fix: affix-state description in docs

### DIFF
--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! | Feature | Description |
 //! | --- | --- |
-//! | [`affix-state`](affix_state) | Middleware for adding prefix and suffix to the request path |
+//! | [`affix-state`](affix_state) | Middleware for adding shared application state to the request context |
 //! | [`basic-auth`](basic_auth) | Middleware for basic authentication |
 //! | [`caching-headers`](caching_headers) | Middleware for setting caching headers |
 //! | [`catch-panic`](catch_panic) | Middleware for catching panics |

--- a/crates/salvo/src/lib.rs
+++ b/crates/salvo/src/lib.rs
@@ -22,7 +22,7 @@
 //! | `tower-compat` | Adapters for `tower::Layer` and `tower::Service` | ❌ |
 //! | `anyhow` | Integrate with the [`anyhow`](https://crates.io/crates/anyhow) crate | ❌ |
 //! | `eyre` | Integrate with the [`eyre`](https://crates.io/crates/eyre) crate | ❌ |
-//! | `affix-state` | Middleware for adding prefix and suffix to the request path | ❌ |
+//! | `affix-state` | Middleware for adding shared application state to the request context | ❌ |
 //! | `craft` | Generate handlers or endpoints with shared data | ❌ |
 //! | `basic-auth` | Middleware for basic authentication | ❌ |
 //! | `caching-headers` | Middleware for setting caching headers | ❌ |


### PR DESCRIPTION
Fix the description of `affix-state` in docs