### PR TITLE
Uses full qualified path for Result

### DIFF
--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -420,7 +420,7 @@ pub(crate) fn generate(args: DeriveInput) -> Result<TokenStream, Error> {
                 #metadata
 
                 #[allow(refining_impl_trait)]
-                async fn extract(req: &'__macro_gen_ex mut #salvo::http::Request, depot: &'__macro_gen_ex mut #salvo::Depot) -> Result<Self, #salvo::http::ParseError>
+                async fn extract(req: &'__macro_gen_ex mut #salvo::http::Request, depot: &'__macro_gen_ex mut #salvo::Depot) -> ::std::result::Result<Self, #salvo::http::ParseError>
                 where
                     Self: Sized {
                     #salvo::serde::from_request(req, depot, Self::metadata()).await
@@ -437,7 +437,7 @@ pub(crate) fn generate(args: DeriveInput) -> Result<TokenStream, Error> {
                 #metadata
 
                 #[allow(refining_impl_trait)]
-                async fn extract(req: &'__macro_gen_ex mut #salvo::http::Request, depot: &'__macro_gen_ex mut #salvo::Depot) -> Result<Self, #salvo::http::ParseError>
+                async fn extract(req: &'__macro_gen_ex mut #salvo::http::Request, depot: &'__macro_gen_ex mut #salvo::Depot) -> ::std::result::Result<Self, #salvo::http::ParseError>
                 where
                     Self: Sized {
                     #salvo::serde::from_request(req, depot, Self::metadata()).await


### PR DESCRIPTION
Because I like redefined a `Result` type, this causes a compilation error.