### PR TITLE
docs: fix shell commands for Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@
 
 Create a new project:
 ```bash
-cargo new hello-salvo && cd hello-salvo
+cargo new hello-salvo
+cd hello-salvo
 cargo add salvo tokio --features salvo/oapi,tokio/macros
 ```
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -50,7 +50,8 @@
 建立專案：
 
 ```bash
-cargo new hello-salvo && cd hello-salvo
+cargo new hello-salvo
+cd hello-salvo
 cargo add salvo tokio --features salvo/oapi,tokio/macros
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,7 +52,8 @@
 创建项目：
 
 ```bash
-cargo new hello-salvo && cd hello-salvo
+cargo new hello-salvo
+cd hello-salvo
 cargo add salvo tokio --features salvo/oapi,tokio/macros
 ```
 


### PR DESCRIPTION
Split `cargo new && cd` into separate commands for Windows cmd.exe compatibility. The `&&` operator is not supported in traditional Windows Command Prompt.

Updated:
- README.md (English)
- README.zh.md (Simplified Chinese)
- README.zh-hant.md (Traditional Chinese)