### PR TITLE
test(acme): add comprehensive unit tests for acme module

### DIFF
--- a/crates/acme/Cargo.toml
+++ b/crates/acme/Cargo.toml
@@ -59,6 +59,7 @@ x509-parser = { workspace = true }
 salvo_core = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 time = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/acme/src/key_pair.rs
+++ b/crates/acme/src/key_pair.rs
@@ -55,3 +55,89 @@ impl KeyPair {
         self.0.public_key().as_ref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_pair_generate() {
+        let key_pair = KeyPair::generate();
+        assert!(key_pair.is_ok());
+    }
+
+    #[test]
+    fn test_key_pair_generate_unique() {
+        let key_pair1 = KeyPair::generate().unwrap();
+        let key_pair2 = KeyPair::generate().unwrap();
+
+        // Each generated key pair should have a unique public key
+        assert_ne!(key_pair1.public_key(), key_pair2.public_key());
+    }
+
+    #[test]
+    fn test_key_pair_public_key_not_empty() {
+        let key_pair = KeyPair::generate().unwrap();
+        let public_key = key_pair.public_key();
+
+        assert!(!public_key.is_empty());
+        // P-256 public key should be 65 bytes (uncompressed format: 0x04 + 32 bytes x + 32 bytes y)
+        assert_eq!(public_key.len(), 65);
+        // First byte should be 0x04 for uncompressed point
+        assert_eq!(public_key[0], 0x04);
+    }
+
+    #[test]
+    fn test_key_pair_sign() {
+        let key_pair = KeyPair::generate().unwrap();
+        let message = b"test message to sign";
+
+        let signature = key_pair.sign(message);
+        assert!(signature.is_ok());
+
+        let sig = signature.unwrap();
+        let sig_bytes: &[u8] = sig.as_ref();
+        // ECDSA P-256 signature should be 64 bytes (r: 32 bytes, s: 32 bytes)
+        assert_eq!(sig_bytes.len(), 64);
+    }
+
+    #[test]
+    fn test_key_pair_sign_different_messages() {
+        let key_pair = KeyPair::generate().unwrap();
+        let message1 = b"message one";
+        let message2 = b"message two";
+
+        let sig1 = key_pair.sign(message1).unwrap();
+        let sig2 = key_pair.sign(message2).unwrap();
+
+        // Different messages should produce different signatures
+        let sig1_bytes: &[u8] = sig1.as_ref();
+        let sig2_bytes: &[u8] = sig2.as_ref();
+        assert_ne!(sig1_bytes, sig2_bytes);
+    }
+
+    #[test]
+    fn test_key_pair_sign_empty_message() {
+        let key_pair = KeyPair::generate().unwrap();
+        let message = b"";
+
+        let signature = key_pair.sign(message);
+        assert!(signature.is_ok());
+    }
+
+    #[test]
+    fn test_key_pair_sign_large_message() {
+        let key_pair = KeyPair::generate().unwrap();
+        let message = vec![0u8; 10000]; // 10KB message
+
+        let signature = key_pair.sign(&message);
+        assert!(signature.is_ok());
+    }
+
+    #[test]
+    fn test_key_pair_from_pkcs8_invalid() {
+        let invalid_pkcs8 = b"not a valid pkcs8 key";
+        let result = KeyPair::from_pkcs8(invalid_pkcs8);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Add 42 new unit tests covering:

cache.rs:
- Key write/read operations
- Certificate write/read operations
- Read operations for non-existent files (returns None)
- Different domains produce different cache files
- Overwrite existing keys
- file_hash_part determinism, uniqueness, and order sensitivity
- String path support
- Automatic directory creation

config.rs:
- AcmeConfigBuilder defaults
- Builder methods (directory, domains, contacts, add_domain, add_contact)
- Challenge type switching (http01, tls_alpn01)
- Error cases (no domains, invalid URL)
- Debug trait implementations

jose.rs:
- Jwk creation and determinism
- JWK thumbprint SHA256 base64 encoding
- Protected header base64 encoding (with jwk and kid)
- key_authorization format and determinism
- key_authorization_sha256
- SHA256 helper function
- Body serialization

key_pair.rs:
- Key pair generation
- Unique key pair generation
- Public key format validation (65 bytes, 0x04 prefix)
- Signing operations (normal, empty, large messages)
- Different messages produce different signatures
- Invalid PKCS8 rejection

This improves test coverage from 1 test to 43 tests.