### PR TITLE
feat(oapi): use $ref for non-primitive generic type parameters

### DIFF
--- a/crates/oapi-macros/src/component.rs
+++ b/crates/oapi-macros/src/component.rs
@@ -418,6 +418,14 @@ impl ComponentSchema {
                     } else {
                         None
                     };
+                    // Only inline primitive types (String, i32, bool, etc.).
+                    // Non-primitive types (structs, enums) should use $ref
+                    // to avoid schema duplication.
+                    let schema_type = SchemaType {
+                        path: type_path,
+                        nullable,
+                    };
+                    let is_inline = is_inline && schema_type.is_primitive();
                     if is_inline {
                         let default = pop_feature!(features => Feature::Default(_))
                             .map(|feature| feature.try_to_token_stream())

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -563,7 +563,7 @@ mod tests {
                                 salvo::oapi::parameter::Parameter::new("kind")
                                     .description("Kind of pet")
                                     .required(salvo::oapi::Required::True)
-                                    .schema(<PetKind as salvo::oapi::ToSchema>::to_schema(components)),
+                                    .schema(salvo::oapi::RefOr::from(<PetKind as salvo::oapi::ToSchema>::to_schema(components))),
                             ]
                             .to_vec()
                         )


### PR DESCRIPTION
## Summary
- Non-primitive type parameters (structs/enums) now use `$ref` instead of being inlined
- Prevents schema duplication in generated OpenAPI output

Ref: utoipa#1184