### PR TITLE
Expand security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,36 @@
 # Security Policy
 
+## Supported Versions
+
+Security fixes are provided for the latest stable release line and the `main` branch.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest stable release series | Yes |
+| `main` | Best effort |
+| Older release series | No |
+
 ## Reporting a Vulnerability
 
-chris@acroidea.com
+Please do not report security issues in public GitHub issues, pull requests, or discussions.
+
+Report vulnerabilities by email to [chris@acroidea.com](mailto:chris@acroidea.com). Include:
+
+- A clear description of the issue and affected components.
+- The Salvo version or commit you tested.
+- Steps to reproduce or a minimal proof of concept.
+- Any impact assessment you already have.
+
+## Response Process
+
+- Initial acknowledgement target: within 3 business days.
+- Status update target: within 7 business days after acknowledgement.
+- Fix timelines depend on severity, exploitability, and release coordination needs.
+
+If the report is accepted, we will work on a fix privately before public disclosure.
+
+## Disclosure Policy
+
+- We will coordinate public disclosure after a fix or mitigation is available.
+- When possible, the fix will be released in a stable version and documented in release notes.
+- Reporters will be credited after disclosure if they want to be named.


### PR DESCRIPTION
## Summary
- define which versions receive security fixes
- document private reporting expectations and required report details
- add response-time targets and disclosure policy guidance

## Why
The current `SECURITY.md` only lists an email address, which is too thin for a formal release and does not set expectations for reporters or maintainers.

## Validation
- documentation-only change
