### PR TITLE
Add changelog skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- Changelog established for upcoming releases.
+
+### Changed
+
+- None yet.
+
+### Fixed
+
+- None yet.
+
+## Historical Releases
+
+Releases published before this changelog was introduced are available in the GitHub Releases page:
+<https://github.com/salvo-rs/salvo/releases>


### PR DESCRIPTION
## Summary
- add a top-level `CHANGELOG.md`
- establish an `Unreleased` section for upcoming release notes
- point older release history to the GitHub Releases page until historical entries are backfilled

## Why
The project currently has no changelog file, which makes release-note curation and formal release communication harder.

## Validation
- documentation-only change
