### PR TITLE
Reload TLS configs in background

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ certon = "0.1.2"
 
 aead = "0.5"
 aes-gcm = "0.10"
+arc-swap = "1.9"
 anyhow = "1"
 async-trait = "0.1"
 assert-json-diff = "2"

--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -28,7 +28,6 @@ cfg_feature! {
     use salvo_core::conn::quinn::QuinnAcceptor;
     use salvo_core::conn::JoinedAcceptor;
     use salvo_core::conn::quinn::QuinnListener;
-    use futures_util::stream::BoxStream;
 }
 
 /// ACME TLS-ALPN-01 protocol name.
@@ -431,7 +430,7 @@ cfg_feature! {
         <T::Acceptor as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
         A: std::net::ToSocketAddrs + Send + 'static,
     {
-        type Acceptor = JoinedAcceptor<AcmeAcceptor<T::Acceptor>, QuinnAcceptor<BoxStream<'static, salvo_core::conn::quinn::ServerConfig>, salvo_core::conn::quinn::ServerConfig, std::convert::Infallible>>;
+        type Acceptor = JoinedAcceptor<AcmeAcceptor<T::Acceptor>, QuinnAcceptor>;
 
         async fn try_bind(self) -> CoreResult<Self::Acceptor> {
             let Self { acme, local_addr } = self;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -57,9 +57,9 @@ http1 = []
 http2 = ["hyper/http2"]
 http2-cleartext = ["http2"]
 quinn = ["dep:salvo-http3", "dep:quinn", "dep:h3-datagram", "rustls"]
-rustls = ["dep:tokio-rustls"]
-native-tls = ["dep:tokio-native-tls", "dep:native-tls"]
-openssl = ["dep:openssl", "dep:tokio-openssl"]
+rustls = ["dep:tokio-rustls", "dep:arc-swap"]
+native-tls = ["dep:tokio-native-tls", "dep:native-tls", "dep:arc-swap"]
+openssl = ["dep:openssl", "dep:tokio-openssl", "dep:arc-swap"]
 unix = ["http1", "dep:nix"]
 test = [
     "dep:brotli",
@@ -75,6 +75,7 @@ matched-path = []
 tls12 = ["tokio-rustls?/tls12"]
 
 [dependencies]
+arc-swap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/crates/core/src/conn.rs
+++ b/crates/core/src/conn.rs
@@ -119,13 +119,18 @@ cfg_feature! {
 ///
 /// This trait enables dynamic TLS configuration updates at runtime.
 /// Implementations can provide a stream of configuration values that
-/// will be applied to new connections as they arrive.
+/// will be consumed by a background reload task and applied to subsequent
+/// connections without waiting for new traffic to drive the stream forward.
 ///
 /// # Use Cases
 ///
 /// - Hot-reloading TLS certificates without server restart
 /// - Rotating certificates on a schedule
 /// - Loading certificates from external sources (e.g., HashiCorp Vault)
+///
+/// The first item yielded by the stream is used as the initial TLS config
+/// during bind. Later items replace the active config only after they are
+/// successfully converted into the backend-specific TLS acceptor state.
 ///
 /// # Example
 ///

--- a/crates/core/src/conn/native_tls/listener.rs
+++ b/crates/core/src/conn/native_tls/listener.rs
@@ -213,10 +213,6 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
-            return Err(IoError::other("native_tls: no active tls config"));
-        };
-
         let Accepted {
             coupler: _,
             stream,
@@ -225,6 +221,9 @@ where
             remote_addr,
             ..
         } = self.inner.accept(fuse_factory).await?;
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("native_tls: no active tls config"));
+        };
         let conn = async move { tls_acceptor.accept(stream).await.map_err(IoError::other) };
         Ok(Accepted {
             coupler: TcpCoupler::new(),

--- a/crates/core/src/conn/native_tls/listener.rs
+++ b/crates/core/src/conn/native_tls/listener.rs
@@ -2,18 +2,19 @@
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Error as IoError, Result as IoResult};
-use std::marker::PhantomData;
-use std::task::{Context, Poll};
+use std::sync::Arc;
 
-use futures_util::stream::{BoxStream, Stream, StreamExt};
-use futures_util::task::noop_waker_ref;
+use arc_swap::ArcSwapOption;
+use futures_util::stream::{BoxStream, StreamExt};
 use http::uri::Scheme;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_native_tls::TlsStream;
+use tokio_util::sync::CancellationToken;
 
 use crate::conn::tcp::{DynTcpAcceptor, TcpCoupler, ToDynTcpAcceptor};
 use crate::conn::{Accepted, Acceptor, HandshakeStream, Holding, IntoConfigStream, Listener};
 use crate::fuse::ArcFuseFactory;
+use crate::Error;
 
 use super::Identity;
 
@@ -21,7 +22,7 @@ use super::Identity;
 pub struct NativeTlsListener<S, C, T, E> {
     config_stream: S,
     inner: T,
-    _phantom: PhantomData<(C, E)>,
+    _phantom: std::marker::PhantomData<(C, E)>,
 }
 impl<S, C, T: Debug, E> Debug for NativeTlsListener<S, C, T, E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -43,7 +44,7 @@ where
         Self {
             config_stream,
             inner,
-            _phantom: PhantomData,
+            _phantom: std::marker::PhantomData,
         }
     }
 }
@@ -57,41 +58,97 @@ where
     <T::Acceptor as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     E: StdError + Send + 'static,
 {
-    type Acceptor = NativeTlsAcceptor<BoxStream<'static, C>, C, T::Acceptor, E>;
+    type Acceptor = NativeTlsAcceptor<T::Acceptor>;
 
     async fn try_bind(self) -> crate::Result<Self::Acceptor> {
-        Ok(NativeTlsAcceptor::new(
-            self.config_stream.into_stream().boxed(),
-            self.inner.try_bind().await?,
-        ))
+        let mut config_stream = self.config_stream.into_stream().boxed();
+        let initial = config_stream
+            .next()
+            .await
+            .ok_or_else(|| Error::other("native_tls: config stream ended before yielding an initial tls config"))?;
+        let identity = initial
+            .try_into()
+            .map_err(|err| IoError::other(err.to_string()))?;
+        let acceptor = tokio_native_tls::native_tls::TlsAcceptor::new(identity)
+            .map_err(|err| IoError::other(err.to_string()))?;
+        let current_acceptor = Arc::new(ArcSwapOption::from(Some(Arc::new(
+            tokio_native_tls::TlsAcceptor::from(acceptor),
+        ))));
+        let inner = self.inner.try_bind().await?;
+        let cancel_reload = CancellationToken::new();
+
+        tracing::info!("tls config loaded.");
+        tokio::spawn(reload_configs(
+            config_stream,
+            Arc::clone(&current_acceptor),
+            cancel_reload.clone(),
+        ));
+
+        Ok(NativeTlsAcceptor::new(inner, current_acceptor, cancel_reload))
+    }
+}
+
+async fn reload_configs<C, E>(
+    mut config_stream: BoxStream<'static, C>,
+    current_acceptor: Arc<ArcSwapOption<tokio_native_tls::TlsAcceptor>>,
+    cancel_reload: CancellationToken,
+) where
+    C: TryInto<Identity, Error = E> + Send + 'static,
+    E: StdError + Send + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = cancel_reload.cancelled() => break,
+            next = config_stream.next() => {
+                let Some(config) = next else {
+                    break;
+                };
+                match config.try_into() {
+                    Ok(identity) => match tokio_native_tls::native_tls::TlsAcceptor::new(identity) {
+                        Ok(acceptor) => {
+                            current_acceptor.store(Some(Arc::new(tokio_native_tls::TlsAcceptor::from(
+                                acceptor,
+                            ))));
+                            tracing::info!("tls config changed.");
+                        }
+                        Err(err) => {
+                            tracing::error!(error = ?err, "native_tls: invalid tls config, keeping previous config");
+                        }
+                    },
+                    Err(err) => {
+                        tracing::error!(error = ?err, "native_tls: invalid tls config, keeping previous config");
+                    }
+                }
+            }
+        }
     }
 }
 
 /// NativeTlsAcceptor
-pub struct NativeTlsAcceptor<S, C, T, E> {
-    config_stream: S,
+pub struct NativeTlsAcceptor<T> {
     inner: T,
     holdings: Vec<Holding>,
-    tls_acceptor: Option<tokio_native_tls::TlsAcceptor>,
-    _phantom: PhantomData<(C, E)>,
+    current_acceptor: Arc<ArcSwapOption<tokio_native_tls::TlsAcceptor>>,
+    cancel_reload: CancellationToken,
 }
-impl<S, C, T: Debug, E> Debug for NativeTlsAcceptor<S, C, T, E> {
+impl<T: Debug> Debug for NativeTlsAcceptor<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("NativeTlsAcceptor")
             .field("inner", &self.inner)
             .finish()
     }
 }
-impl<S, C, T, E> NativeTlsAcceptor<S, C, T, E>
+impl<T> NativeTlsAcceptor<T>
 where
-    S: Stream<Item = C> + Send + Unpin + 'static,
-    C: TryInto<Identity, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     <T as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send,
-    E: StdError + Send + 'static,
 {
     /// Create a new `NativeTlsAcceptor`.
-    pub fn new(config_stream: S, inner: T) -> Self {
+    pub fn new(
+        inner: T,
+        current_acceptor: Arc<ArcSwapOption<tokio_native_tls::TlsAcceptor>>,
+        cancel_reload: CancellationToken,
+    ) -> Self {
         let holdings = inner
             .holdings()
             .iter()
@@ -114,11 +171,10 @@ where
             })
             .collect();
         Self {
-            config_stream,
             inner,
             holdings,
-            tls_acceptor: None,
-            _phantom: PhantomData,
+            current_acceptor,
+            cancel_reload,
         }
     }
 
@@ -133,13 +189,16 @@ where
     }
 }
 
-impl<S, C, T, E> Acceptor for NativeTlsAcceptor<S, C, T, E>
+impl<T> Drop for NativeTlsAcceptor<T> {
+    fn drop(&mut self) {
+        self.cancel_reload.cancel();
+    }
+}
+
+impl<T> Acceptor for NativeTlsAcceptor<T>
 where
-    S: Stream<Item = C> + Send + Unpin + 'static,
-    C: TryInto<Identity, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     <T as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send,
-    E: StdError + Send,
 {
     type Coupler = TcpCoupler<Self::Stream>;
     type Stream = HandshakeStream<TlsStream<T::Stream>>;
@@ -154,38 +213,10 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let config = {
-            let mut config = None;
-            while let Poll::Ready(Some(item)) = self
-                .config_stream
-                .poll_next_unpin(&mut Context::from_waker(noop_waker_ref()))
-            {
-                config = Some(item);
-            }
-            config
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("native_tls: no active tls config"));
         };
-        if let Some(config) = config {
-            let identity = config
-                .try_into()
-                .map_err(|e| IoError::other(e.to_string()))?;
-            let tls_acceptor = tokio_native_tls::native_tls::TlsAcceptor::new(identity);
-            match tls_acceptor {
-                Ok(tls_acceptor) => {
-                    if self.tls_acceptor.is_some() {
-                        tracing::info!("TLS config changed.");
-                    } else {
-                        tracing::info!("TLS config loaded.");
-                    }
-                    self.tls_acceptor = Some(tokio_native_tls::TlsAcceptor::from(tls_acceptor));
-                }
-                Err(e) => tracing::error!(error = ?e, "native_tls: invalid TLS config"),
-            }
-        }
 
-        let tls_acceptor = match &self.tls_acceptor {
-            Some(tls_acceptor) => tls_acceptor.clone(),
-            None => return Err(IoError::other("native_tls: invalid TLS config")),
-        };
         let Accepted {
             coupler: _,
             stream,
@@ -193,7 +224,7 @@ where
             local_addr,
             remote_addr,
             ..
-        } = self.inner.accept(fuse_factory.clone()).await?;
+        } = self.inner.accept(fuse_factory).await?;
         let conn = async move { tls_acceptor.accept(stream).await.map_err(IoError::other) };
         Ok(Accepted {
             coupler: TcpCoupler::new(),

--- a/crates/core/src/conn/openssl/listener.rs
+++ b/crates/core/src/conn/openssl/listener.rs
@@ -203,10 +203,6 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
-            return Err(IoError::other("openssl: no active tls config"));
-        };
-
         let Accepted {
             coupler: _,
             stream,
@@ -215,6 +211,9 @@ where
             remote_addr,
             ..
         } = self.inner.accept(fuse_factory).await?;
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("openssl: no active tls config"));
+        };
         let conn = async move {
             let ssl = Ssl::new(tls_acceptor.context()).map_err(IoError::other)?;
             let mut tls_stream = SslStream::new(ssl, stream).map_err(IoError::other)?;

--- a/crates/core/src/conn/openssl/listener.rs
+++ b/crates/core/src/conn/openssl/listener.rs
@@ -2,28 +2,28 @@
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Error as IoError, Result as IoResult};
-use std::marker::PhantomData;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-use futures_util::stream::{BoxStream, Stream, StreamExt};
-use futures_util::task::noop_waker_ref;
+use arc_swap::ArcSwapOption;
+use futures_util::stream::{BoxStream, StreamExt};
 use http::uri::Scheme;
 use openssl::ssl::{Ssl, SslAcceptor};
-use tokio_openssl::SslStream;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_openssl::SslStream;
+use tokio_util::sync::CancellationToken;
 
 use super::SslAcceptorBuilder;
 
 use crate::conn::tcp::{DynTcpAcceptor, TcpCoupler, ToDynTcpAcceptor};
 use crate::conn::{Accepted, Acceptor, HandshakeStream, Holding, IntoConfigStream, Listener};
 use crate::fuse::ArcFuseFactory;
+use crate::Error;
 
 /// OpensslListener
 pub struct OpensslListener<S, C, T, E> {
     config_stream: S,
     inner: T,
-    _phantom: PhantomData<(C, E)>,
+    _phantom: std::marker::PhantomData<(C, E)>,
 }
 impl<S, C, T: Debug, E> Debug for OpensslListener<S, C, T, E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -46,7 +46,7 @@ where
         Self {
             config_stream,
             inner,
-            _phantom: PhantomData,
+            _phantom: std::marker::PhantomData,
         }
     }
 }
@@ -60,41 +60,86 @@ where
     <T::Acceptor as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     E: StdError + Send + 'static,
 {
-    type Acceptor = OpensslAcceptor<BoxStream<'static, C>, C, T::Acceptor, E>;
+    type Acceptor = OpensslAcceptor<T::Acceptor>;
 
     async fn try_bind(self) -> crate::Result<Self::Acceptor> {
-        Ok(OpensslAcceptor::new(
-            self.config_stream.into_stream().boxed(),
-            self.inner.try_bind().await?,
-        ))
+        let mut config_stream = self.config_stream.into_stream().boxed();
+        let initial = config_stream
+            .next()
+            .await
+            .ok_or_else(|| Error::other("openssl: config stream ended before yielding an initial tls config"))?;
+        let builder: SslAcceptorBuilder = initial
+            .try_into()
+            .map_err(|err| IoError::other(err.to_string()))?;
+        let current_acceptor = Arc::new(ArcSwapOption::from(Some(Arc::new(builder.build()))));
+        let inner = self.inner.try_bind().await?;
+        let cancel_reload = CancellationToken::new();
+
+        tracing::info!("tls config loaded.");
+        tokio::spawn(reload_configs(
+            config_stream,
+            Arc::clone(&current_acceptor),
+            cancel_reload.clone(),
+        ));
+
+        Ok(OpensslAcceptor::new(inner, current_acceptor, cancel_reload))
+    }
+}
+
+async fn reload_configs<C, E>(
+    mut config_stream: BoxStream<'static, C>,
+    current_acceptor: Arc<ArcSwapOption<SslAcceptor>>,
+    cancel_reload: CancellationToken,
+) where
+    C: TryInto<SslAcceptorBuilder, Error = E> + Send + 'static,
+    E: StdError + Send + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = cancel_reload.cancelled() => break,
+            next = config_stream.next() => {
+                let Some(config) = next else {
+                    break;
+                };
+                match config.try_into() {
+                    Ok(builder) => {
+                        current_acceptor.store(Some(Arc::new(builder.build())));
+                        tracing::info!("tls config changed.");
+                    }
+                    Err(err) => {
+                        tracing::error!(error = ?err, "openssl: invalid tls config, keeping previous config");
+                    }
+                }
+            }
+        }
     }
 }
 
 /// OpensslAcceptor
-pub struct OpensslAcceptor<S, C, T, E> {
-    config_stream: S,
+pub struct OpensslAcceptor<T> {
     inner: T,
     holdings: Vec<Holding>,
-    tls_acceptor: Option<Arc<SslAcceptor>>,
-    _phantom: PhantomData<(C, E)>,
+    current_acceptor: Arc<ArcSwapOption<SslAcceptor>>,
+    cancel_reload: CancellationToken,
 }
-impl<S, C, T, E> Debug for OpensslAcceptor<S, C, T, E> {
+impl<T> Debug for OpensslAcceptor<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpensslAcceptor")
             .field("holdings", &self.holdings)
             .finish()
     }
 }
-impl<S, C, T, E> OpensslAcceptor<S, C, T, E>
+impl<T> OpensslAcceptor<T>
 where
-    S: Stream<Item = C> + Unpin + Send + 'static,
-    C: TryInto<SslAcceptorBuilder, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     T::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    E: StdError + Send + 'static,
 {
     /// Create new OpensslAcceptor.
-    pub fn new(config_stream: S, inner: T) -> Self {
+    pub fn new(
+        inner: T,
+        current_acceptor: Arc<ArcSwapOption<SslAcceptor>>,
+        cancel_reload: CancellationToken,
+    ) -> Self {
         let holdings = inner
             .holdings()
             .iter()
@@ -117,11 +162,10 @@ where
             })
             .collect();
         Self {
-            config_stream,
             inner,
             holdings,
-            tls_acceptor: None,
-            _phantom: PhantomData,
+            current_acceptor,
+            cancel_reload,
         }
     }
 
@@ -136,13 +180,16 @@ where
     }
 }
 
-impl<S, C, T, E> Acceptor for OpensslAcceptor<S, C, T, E>
+impl<T> Drop for OpensslAcceptor<T> {
+    fn drop(&mut self) {
+        self.cancel_reload.cancel();
+    }
+}
+
+impl<T> Acceptor for OpensslAcceptor<T>
 where
-    S: Stream<Item = C> + Send + Unpin + 'static,
-    C: TryInto<SslAcceptorBuilder, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     T::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    E: StdError + Send,
 {
     type Coupler = TcpCoupler<Self::Stream>;
     type Stream = HandshakeStream<SslStream<T::Stream>>;
@@ -156,32 +203,8 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let config = {
-            let mut config = None;
-            while let Poll::Ready(Some(item)) = self
-                .config_stream
-                .poll_next_unpin(&mut Context::from_waker(noop_waker_ref()))
-            {
-                config = Some(item);
-            }
-            config
-        };
-        if let Some(config) = config {
-            match config.try_into() {
-                Ok(builder) => {
-                    if self.tls_acceptor.is_some() {
-                        tracing::info!("tls config changed.");
-                    } else {
-                        tracing::info!("tls config loaded.");
-                    }
-                    self.tls_acceptor = Some(Arc::new(builder.build()));
-                }
-                Err(e) => tracing::error!(error = ?e, "openssl: invalid tls config."),
-            }
-        }
-        let tls_acceptor = match &self.tls_acceptor {
-            Some(tls_acceptor) => tls_acceptor.clone(),
-            None => return Err(IoError::other("openssl: tls_acceptor is none.")),
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("openssl: no active tls config"));
         };
 
         let Accepted {

--- a/crates/core/src/conn/quinn/listener.rs
+++ b/crates/core/src/conn/quinn/listener.rs
@@ -5,20 +5,19 @@ use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::vec;
 
-use futures_util::stream::{BoxStream, Stream, StreamExt};
-use futures_util::task::noop_waker_ref;
+use futures_util::stream::{BoxStream, StreamExt};
 use http::uri::Scheme;
 use salvo_http3::quinn::{self, Endpoint};
+use tokio_util::sync::CancellationToken;
 
 use super::{QuinnConnection, QuinnCoupler};
 use crate::conn::quinn::ServerConfig;
 use crate::conn::{Accepted, Acceptor, Holding, IntoConfigStream, Listener};
 use crate::fuse::{ArcFuseFactory, FuseInfo, TransProto};
 use crate::http::Version;
+use crate::Error;
 
 /// A wrapper of `Listener` with quinn.
 pub struct QuinnListener<S, C, T, E> {
@@ -57,7 +56,7 @@ where
     T: ToSocketAddrs + Send + 'static,
     E: StdError + Send + 'static,
 {
-    type Acceptor = QuinnAcceptor<BoxStream<'static, C>, C, C::Error>;
+    type Acceptor = QuinnAcceptor;
 
     async fn try_bind(self) -> crate::Result<Self::Acceptor> {
         let Self {
@@ -69,23 +68,67 @@ where
             .to_socket_addrs()?
             .next()
             .ok_or_else(|| IoError::new(ErrorKind::AddrNotAvailable, "No address available"))?;
-        Ok(QuinnAcceptor::new(
-            config_stream.into_stream().boxed(),
-            socket,
-        ))
+
+        let mut config_stream = config_stream.into_stream().boxed();
+        let initial = config_stream
+            .next()
+            .await
+            .ok_or_else(|| Error::other("quinn: config stream ended before yielding an initial tls config"))?;
+        let initial = initial
+            .try_into()
+            .map_err(|err| IoError::other(err.to_string()))?;
+        let endpoint = Endpoint::server(initial, socket)?;
+        let cancel_reload = CancellationToken::new();
+
+        tracing::info!("quinn config loaded.");
+        tokio::spawn(reload_configs(
+            config_stream,
+            endpoint.clone(),
+            cancel_reload.clone(),
+        ));
+
+        Ok(QuinnAcceptor::new(endpoint, socket, cancel_reload))
+    }
+}
+
+async fn reload_configs<C, E>(
+    mut config_stream: BoxStream<'static, C>,
+    endpoint: Endpoint,
+    cancel_reload: CancellationToken,
+) where
+    C: TryInto<ServerConfig, Error = E> + Send + 'static,
+    E: StdError + Send + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = cancel_reload.cancelled() => break,
+            next = config_stream.next() => {
+                let Some(config) = next else {
+                    break;
+                };
+                match config.try_into() {
+                    Ok(config) => {
+                        endpoint.set_server_config(Some(config));
+                        tracing::info!("quinn config changed.");
+                    }
+                    Err(err) => {
+                        tracing::error!(error = ?err, "quinn: invalid tls config, keeping previous config");
+                    }
+                }
+            }
+        }
     }
 }
 
 /// A wrapper of `Acceptor` with quinn.
-pub struct QuinnAcceptor<S, C, E> {
-    config_stream: S,
+pub struct QuinnAcceptor {
     socket: SocketAddr,
     holdings: Vec<Holding>,
-    endpoint: Option<Endpoint>,
-    _phantom: PhantomData<(C, E)>,
+    endpoint: Endpoint,
+    cancel_reload: CancellationToken,
 }
 
-impl<S, C, E> Debug for QuinnAcceptor<S, C, E> {
+impl Debug for QuinnAcceptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QuinnAcceptor")
             .field("socket", &self.socket)
@@ -95,35 +138,30 @@ impl<S, C, E> Debug for QuinnAcceptor<S, C, E> {
     }
 }
 
-impl<S, C, E> QuinnAcceptor<S, C, E>
-where
-    S: Stream<Item = C> + Send + 'static,
-    C: TryInto<ServerConfig, Error = E> + Send + 'static,
-    E: StdError + Send,
-{
+impl QuinnAcceptor {
     /// Create a new `QuinnAcceptor`.
-    pub fn new(config_stream: S, socket: SocketAddr) -> Self {
+    pub fn new(endpoint: Endpoint, socket: SocketAddr, cancel_reload: CancellationToken) -> Self {
         let holding = Holding {
             local_addr: socket.into(),
             http_versions: vec![Version::HTTP_3],
             http_scheme: Scheme::HTTPS,
         };
         Self {
-            config_stream,
             socket,
             holdings: vec![holding],
-            endpoint: None,
-            _phantom: PhantomData,
+            endpoint,
+            cancel_reload,
         }
     }
 }
 
-impl<S, C, E> Acceptor for QuinnAcceptor<S, C, E>
-where
-    S: Stream<Item = C> + Send + Unpin + 'static,
-    C: TryInto<ServerConfig, Error = E> + Send + 'static,
-    E: StdError + Send,
-{
+impl Drop for QuinnAcceptor {
+    fn drop(&mut self) {
+        self.cancel_reload.cancel();
+    }
+}
+
+impl Acceptor for QuinnAcceptor {
     type Coupler = QuinnCoupler;
     type Stream = QuinnConnection;
 
@@ -135,32 +173,7 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let config = {
-            let mut config = None;
-            while let Poll::Ready(Some(item)) = Pin::new(&mut self.config_stream)
-                .poll_next(&mut Context::from_waker(noop_waker_ref()))
-            {
-                config = Some(item);
-            }
-            config
-        };
-        if let Some(config) = config {
-            let config = config
-                .try_into()
-                .map_err(|e| IoError::other(e.to_string()))?;
-            let endpoint = Endpoint::server(config, self.socket)?;
-            if self.endpoint.is_some() {
-                tracing::info!("quinn config changed.");
-            } else {
-                tracing::info!("quinn config loaded.");
-            }
-            self.endpoint = Some(endpoint);
-        }
-        let Some(endpoint) = &self.endpoint else {
-          return Err(IoError::other("quinn: invalid quinn config."));
-        };
-
-        if let Some(new_conn) = endpoint.accept().await {
+        if let Some(new_conn) = self.endpoint.accept().await {
             let remote_addr = new_conn.remote_address();
             let local_addr = self.holdings[0].local_addr.clone();
             match new_conn.await {
@@ -174,10 +187,7 @@ where
                     });
                     return Ok(Accepted {
                         coupler: QuinnCoupler,
-                        stream: QuinnConnection::new(
-                            quinn::Connection::new(conn),
-                            fusewire.clone(),
-                        ),
+                        stream: QuinnConnection::new(quinn::Connection::new(conn), fusewire.clone()),
                         fusewire,
                         local_addr: self.holdings[0].local_addr.clone(),
                         remote_addr: remote_addr.into(),

--- a/crates/core/src/conn/rustls/listener.rs
+++ b/crates/core/src/conn/rustls/listener.rs
@@ -2,20 +2,19 @@
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Error as IoError, Result as IoResult};
-use std::marker::PhantomData;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-use futures_util::stream::{BoxStream, Stream, StreamExt};
-use futures_util::task::noop_waker_ref;
+use arc_swap::ArcSwapOption;
+use futures_util::stream::{BoxStream, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::sync::CancellationToken;
 use tokio_rustls::server::TlsStream;
 
 use crate::conn::tcp::{DynTcpAcceptor, TcpCoupler, ToDynTcpAcceptor};
 use crate::conn::{Accepted, Acceptor, HandshakeStream, Holding, IntoConfigStream, Listener};
 use crate::fuse::ArcFuseFactory;
 use crate::http::uri::Scheme;
+use crate::Error;
 
 use super::ServerConfig;
 
@@ -23,7 +22,7 @@ use super::ServerConfig;
 pub struct RustlsListener<S, C, T, E> {
     config_stream: S,
     inner: T,
-    _phantom: PhantomData<(C, E)>,
+    _phantom: std::marker::PhantomData<(C, E)>,
 }
 
 impl<S, C, T, E> Debug for RustlsListener<S, C, T, E> {
@@ -45,7 +44,7 @@ where
         Self {
             config_stream,
             inner,
-            _phantom: PhantomData,
+            _phantom: std::marker::PhantomData,
         }
     }
 }
@@ -59,41 +58,90 @@ where
     <T::Acceptor as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     E: StdError + Send + 'static,
 {
-    type Acceptor = RustlsAcceptor<BoxStream<'static, C>, C, T::Acceptor, E>;
+    type Acceptor = RustlsAcceptor<T::Acceptor>;
 
     async fn try_bind(self) -> crate::Result<Self::Acceptor> {
-        Ok(RustlsAcceptor::new(
-            self.config_stream.into_stream().boxed(),
-            self.inner.try_bind().await?,
-        ))
+        let mut config_stream = self.config_stream.into_stream().boxed();
+        let initial = config_stream
+            .next()
+            .await
+            .ok_or_else(|| Error::other("rustls: config stream ended before yielding an initial tls config"))?;
+        let initial: ServerConfig = initial
+            .try_into()
+            .map_err(|err| IoError::other(err.to_string()))?;
+        let current_acceptor = Arc::new(ArcSwapOption::from(Some(Arc::new(
+            tokio_rustls::TlsAcceptor::from(Arc::new(initial)),
+        ))));
+        let inner = self.inner.try_bind().await?;
+        let cancel_reload = CancellationToken::new();
+
+        tracing::info!("tls config loaded.");
+        tokio::spawn(reload_configs(
+            config_stream,
+            Arc::clone(&current_acceptor),
+            cancel_reload.clone(),
+        ));
+
+        Ok(RustlsAcceptor::new(inner, current_acceptor, cancel_reload))
+    }
+}
+
+async fn reload_configs<C, E>(
+    mut config_stream: BoxStream<'static, C>,
+    current_acceptor: Arc<ArcSwapOption<tokio_rustls::TlsAcceptor>>,
+    cancel_reload: CancellationToken,
+) where
+    C: TryInto<ServerConfig, Error = E> + Send + 'static,
+    E: StdError + Send + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = cancel_reload.cancelled() => break,
+            next = config_stream.next() => {
+                let Some(config) = next else {
+                    break;
+                };
+                match config.try_into() {
+                    Ok(config) => {
+                        current_acceptor.store(Some(Arc::new(tokio_rustls::TlsAcceptor::from(Arc::new(
+                            config,
+                        )))));
+                        tracing::info!("tls config changed.");
+                    }
+                    Err(err) => {
+                        tracing::error!(error = ?err, "rustls: invalid tls config, keeping previous config");
+                    }
+                }
+            }
+        }
     }
 }
 
 /// A wrapper of `Acceptor` with rustls.
-pub struct RustlsAcceptor<S, C, T, E> {
-    config_stream: S,
+pub struct RustlsAcceptor<T> {
     inner: T,
     holdings: Vec<Holding>,
-    tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
-    _phantom: PhantomData<(C, E)>,
+    current_acceptor: Arc<ArcSwapOption<tokio_rustls::TlsAcceptor>>,
+    cancel_reload: CancellationToken,
 }
 
-impl<S, C, T, E> Debug for RustlsAcceptor<S, C, T, E> {
+impl<T> Debug for RustlsAcceptor<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("RustlsAcceptor").finish()
     }
 }
 
-impl<S, C, T, E> RustlsAcceptor<S, C, T, E>
+impl<T> RustlsAcceptor<T>
 where
-    S: Stream<Item = C> + Unpin + Send + 'static,
-    C: TryInto<ServerConfig, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     T::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    E: StdError + Send + 'static,
 {
     /// Create a new `RustlsAcceptor`.
-    pub fn new(config_stream: S, inner: T) -> Self {
+    pub fn new(
+        inner: T,
+        current_acceptor: Arc<ArcSwapOption<tokio_rustls::TlsAcceptor>>,
+        cancel_reload: CancellationToken,
+    ) -> Self {
         let holdings = inner
             .holdings()
             .iter()
@@ -116,11 +164,10 @@ where
             })
             .collect();
         Self {
-            config_stream,
             inner,
             holdings,
-            tls_acceptor: None,
-            _phantom: PhantomData,
+            current_acceptor,
+            cancel_reload,
         }
     }
 
@@ -135,13 +182,16 @@ where
     }
 }
 
-impl<S, C, T, E> Acceptor for RustlsAcceptor<S, C, T, E>
+impl<T> Drop for RustlsAcceptor<T> {
+    fn drop(&mut self) {
+        self.cancel_reload.cancel();
+    }
+}
+
+impl<T> Acceptor for RustlsAcceptor<T>
 where
-    S: Stream<Item = C> + Send + Unpin + 'static,
-    C: TryInto<ServerConfig, Error = E> + Send + 'static,
     T: Acceptor + Send + 'static,
     <T as Acceptor>::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    E: StdError + Send,
 {
     type Coupler = TcpCoupler<Self::Stream>;
     type Stream = HandshakeStream<TlsStream<T::Stream>>;
@@ -154,29 +204,8 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let config = {
-            let mut config = None;
-            while let Poll::Ready(Some(item)) = Pin::new(&mut self.config_stream)
-                .poll_next(&mut Context::from_waker(noop_waker_ref()))
-            {
-                config = Some(item);
-            }
-            config
-        };
-        if let Some(config) = config {
-            let config: ServerConfig = config
-                .try_into()
-                .map_err(|e| IoError::other(e.to_string()))?;
-            let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
-            if self.tls_acceptor.is_some() {
-                tracing::info!("tls config changed.");
-            } else {
-                tracing::info!("tls config loaded.");
-            }
-            self.tls_acceptor = Some(tls_acceptor);
-        }
-        let Some(tls_acceptor) = &self.tls_acceptor else {
-            return Err(IoError::other("rustls: invalid tls config."));
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("rustls: no active tls config"));
         };
 
         let Accepted {

--- a/crates/core/src/conn/rustls/listener.rs
+++ b/crates/core/src/conn/rustls/listener.rs
@@ -204,10 +204,6 @@ where
         &mut self,
         fuse_factory: Option<ArcFuseFactory>,
     ) -> IoResult<Accepted<Self::Coupler, Self::Stream>> {
-        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
-            return Err(IoError::other("rustls: no active tls config"));
-        };
-
         let Accepted {
             coupler: _,
             stream,
@@ -216,6 +212,9 @@ where
             remote_addr,
             ..
         } = self.inner.accept(fuse_factory).await?;
+        let Some(tls_acceptor) = self.current_acceptor.load_full() else {
+            return Err(IoError::other("rustls: no active tls config"));
+        };
         Ok(Accepted {
             coupler: TcpCoupler::new(),
             stream: HandshakeStream::new(tls_acceptor.accept(stream), fusewire.clone()),


### PR DESCRIPTION
## Summary
- move `rustls`, `native-tls`, `openssl`, and `quinn` reload handling out of `accept()` and into background tasks
- require an initial TLS config during `bind`, then atomically swap in later valid configs for new handshakes
- document the background reload semantics in `IntoConfigStream`

## Why
The previous implementation only polled config streams while accepting new connections. That meant periodic reload streams would stall on idle servers, so the reload examples did not actually reload on schedule unless traffic arrived.

This changes the runtime model so TLS config streams continue progressing in the background and later valid configs are picked up even when the listener is idle.

## Impact
- periodic TLS reload now works as documented for `rustls`, `native-tls`, and `openssl`
- QUIC server config reload follows the same background model
- invalid follow-up configs no longer drop the active TLS state; the previous valid config stays in use
- bind now fails fast if the config stream ends before yielding an initial config

Closes #745
Closes #809

## Validation
- `cargo check -p salvo_core --features rustls,native-tls,openssl,quinn`
- `cargo test -p salvo_core test_rustls_listener --features rustls,native-tls,openssl,quinn -- --nocapture`
- `cargo test -p salvo_core test_openssl_listener --features rustls,native-tls,openssl,quinn -- --nocapture`
- `cargo test -p salvo_core test_native_tls_listener --features rustls,native-tls,openssl,quinn -- --nocapture`