### PR TITLE
fix: prevent panic on empty Range header in NamedFile and ReadSeeker

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -614,7 +614,9 @@ impl NamedFile {
         let range = req_headers.get(RANGE);
         if let Some(range) = range {
             if let Ok(range) = range.to_str() {
-                if let Ok(range) = HttpRange::parse(range, length) {
+                if let Ok(range) = HttpRange::parse(range, length)
+                    && !range.is_empty()
+                {
                     length = range[0].length;
                     offset = range[0].start;
                 } else {

--- a/crates/core/src/writing/seek.rs
+++ b/crates/core/src/writing/seek.rs
@@ -104,7 +104,9 @@ where
         let range = req_headers.get(RANGE);
         if let Some(range) = range {
             if let Ok(range) = range.to_str() {
-                if let Ok(range) = HttpRange::parse(range, length) {
+                if let Ok(range) = HttpRange::parse(range, length)
+                    && !range.is_empty()
+                {
                     length = range[0].length;
                     offset = range[0].start;
                 } else {


### PR DESCRIPTION
`HttpRange::parse` returns `Ok(vec![])` for range headers like `bytes=` or `bytes=,,,` (valid prefix but no actual range specs). `NamedFile::send` and `ReadSeeker::send` both index `range[0]` without checking, which panics on the empty vec.

Same `!range.is_empty()` guard that `embed.rs` already uses.