### PR TITLE
perf: reduce allocations during route matching

### DIFF
--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -515,7 +515,7 @@ impl PathWisp for NamedWisp {
                 return false;
             }
             if !rest.is_empty() || !self.0.starts_with("*+") {
-                let rest = rest.to_string();
+                let rest = rest.into_owned();
                 state.params.insert(&self.0, rest);
                 state.cursor.0 = state.parts.len();
                 #[cfg(feature = "matched-path")]

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -71,12 +71,21 @@ impl PathState {
                     Some(Cow::Borrowed(picked))
                 }
             } else {
-                let last = self.parts[self.cursor.0 + 1..].join("/");
-                if self.end_slash {
-                    Some(Cow::Owned(format!("{picked}/{last}/")))
-                } else {
-                    Some(Cow::Owned(format!("{picked}/{last}")))
+                let rest = &self.parts[self.cursor.0 + 1..];
+                let trailing = usize::from(self.end_slash);
+                let cap = picked.len()
+                    + rest.iter().map(|s| s.len() + 1).sum::<usize>()
+                    + trailing;
+                let mut buf = String::with_capacity(cap);
+                buf.push_str(picked);
+                for part in rest {
+                    buf.push('/');
+                    buf.push_str(part);
                 }
+                if self.end_slash {
+                    buf.push('/');
+                }
+                Some(Cow::Owned(buf))
             }
         } else {
             None

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -100,9 +100,15 @@ impl Router {
                 let original_matched_parts_len = path_state.matched_parts.len();
                 for child in &self.routers {
                     if let Some(dm) = child.detect(req, path_state).await {
-                        let mut hoops = Vec::with_capacity(self.hoops.len() + dm.hoops.len());
-                        hoops.extend_from_slice(&self.hoops);
-                        hoops.extend_from_slice(&dm.hoops);
+                        let hoops = if self.hoops.is_empty() {
+                            dm.hoops
+                        } else {
+                            let mut hoops =
+                                Vec::with_capacity(self.hoops.len() + dm.hoops.len());
+                            hoops.extend_from_slice(&self.hoops);
+                            hoops.extend_from_slice(&dm.hoops);
+                            hoops
+                        };
                         return Some(DetectMatched {
                             hoops,
                             goal: dm.goal.clone(),


### PR DESCRIPTION
Some small allocation improvements in route matching.

In `router.rs`, if a parent router has no hoops, we can reuse the child's hoops instead of allocating a new `Vec` and copying them over.

In `path_state.rs`, `all_rest()` used to allocate twice for multi-segment paths: once with `join("/")`, then again when building the final string. It now builds the result in a single pre-sized allocation.

In `filters/path.rs`, `rest.to_string()` is replaced with `rest.into_owned()`, which avoids an extra copy when `all_rest()` already returns an owned string.