### PR TITLE
replace string clones with to_owned

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -365,7 +365,7 @@ fn build_content_disposition(
             None => file_path
                 .as_ref()
                 .file_name()
-                .map(|file_name| file_name.to_string_lossy().to_string())
+                .map(|file_name| file_name.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "file".into())
                 .into(),
         };

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -73,9 +73,7 @@ impl PathState {
             } else {
                 let rest = &self.parts[self.cursor.0 + 1..];
                 let trailing = usize::from(self.end_slash);
-                let cap = picked.len()
-                    + rest.iter().map(|s| s.len() + 1).sum::<usize>()
-                    + trailing;
+                let cap = picked.len() + rest.iter().map(|s| s.len() + 1).sum::<usize>() + trailing;
                 let mut buf = String::with_capacity(cap);
                 buf.push_str(picked);
                 for part in rest {

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -103,8 +103,7 @@ impl Router {
                         let hoops = if self.hoops.is_empty() {
                             dm.hoops
                         } else {
-                            let mut hoops =
-                                Vec::with_capacity(self.hoops.len() + dm.hoops.len());
+                            let mut hoops = Vec::with_capacity(self.hoops.len() + dm.hoops.len());
                             hoops.extend_from_slice(&self.hoops);
                             hoops.extend_from_slice(&dm.hoops);
                             hoops

--- a/crates/core/src/serde/flat_value.rs
+++ b/crates/core/src/serde/flat_value.rs
@@ -238,7 +238,7 @@ impl<'de> Iterator for FlatParser<'de> {
                 '"' | '\'' => {
                     in_next = true;
                     if quote == Some(c) {
-                        let item = Cow::Owned(self.input[self.start..end].to_string());
+                        let item = Cow::Owned(self.input[self.start..end].to_owned());
                         self.start = end + 2;
                         return Some(CowValue(item));
                     } else {
@@ -248,7 +248,7 @@ impl<'de> Iterator for FlatParser<'de> {
                 }
                 ',' | ']' => {
                     if quote.is_none() && in_next {
-                        let item = Cow::Owned(self.input[self.start..end].to_string());
+                        let item = Cow::Owned(self.input[self.start..end].to_owned());
                         self.start = end + 1;
                         return Some(CowValue(item));
                     }

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -164,7 +164,7 @@ impl WebSocketUpgrade {
     #[inline]
     #[must_use]
     pub fn protocols(mut self, protocols: &[&str]) -> Self {
-        self.protocols = protocols.iter().map(|s| s.to_string()).collect();
+        self.protocols = protocols.iter().map(|s| (*s).to_owned()).collect();
         self
     }
 

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -438,7 +438,7 @@ mod tests {
         .build()
         .unwrap();
 
-        let session_name = "my-custom-session-name".to_string();
+        let session_name = "my-custom-session-name".to_owned();
         let router = Router::new()
             .hoop(session_handler)
             .hoop(SessionStore::new().name(&session_name).into_handler())

--- a/crates/oapi-macros/src/endpoint/server.rs
+++ b/crates/oapi-macros/src/endpoint/server.rs
@@ -431,7 +431,7 @@ mod tests {
         server_variables_extend:
         {
             let mut variables = ServerVariables::new().server_variable("version", ServerVariable::new().default_value("v1"));
-            variables.extend(vec![("username".to_string(), ServerVariable::new().default_value("the_user"))]);
+            variables.extend(vec![("username".to_owned(), ServerVariable::new().default_value("the_user"))]);
             variables
         };
         r###"{

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -222,7 +222,7 @@ impl SchemaReference {
     #[must_use]
     pub fn compose_name(&self) -> String {
         if self.references.is_empty() {
-            self.name.to_string()
+            self.name.as_ref().to_owned()
         } else {
             let generic_names: Vec<String> =
                 self.references.iter().map(|r| r.compose_name()).collect();

--- a/crates/oapi/src/naming.rs
+++ b/crates/oapi/src/naming.rs
@@ -219,7 +219,7 @@ pub fn get_name<T: 'static>() -> String {
 
 fn type_generic_part(type_name: &str) -> String {
     if let Some(pos) = type_name.find('<') {
-        type_name[pos..].to_string()
+        type_name[pos..].to_owned()
     } else {
         String::new()
     }
@@ -238,7 +238,7 @@ fn resolve_and_format_generic_part(type_name: &str, short_mode: bool) -> String 
     // Apply formatting (:: -> . for non-short mode, or strip module paths for short mode)
     if short_mode {
         let re = Regex::new(r"([^<>, ]*::)+").expect("Invalid regex");
-        re.replace_all(&resolved, "").to_string()
+        re.replace_all(&resolved, "").into_owned()
     } else {
         resolved.replace("::", ".")
     }
@@ -285,7 +285,7 @@ impl Namer for FlexNamer {
 
                 let mut base = if self.short_mode {
                     let re = Regex::new(r"([^<>, ]*::)+").expect("Invalid regex");
-                    re.replace_all(&resolved_type_name, "").to_string()
+                    re.replace_all(&resolved_type_name, "").into_owned()
                 } else {
                     resolved_type_name.replace("::", ".")
                 };

--- a/crates/oapi/src/swagger_ui/config.rs
+++ b/crates/oapi/src/swagger_ui/config.rs
@@ -180,7 +180,10 @@ impl<'a> Config<'a> {
     }
 
     fn new_config_with_multiple_urls(urls: Vec<Url<'a>>) -> Self {
-        let primary_name = urls.iter().find(|url| url.primary).map(|url| url.name.to_string());
+        let primary_name = urls
+            .iter()
+            .find(|url| url.primary)
+            .map(|url| url.name.as_ref().to_owned());
 
         Self {
             urls_primary_name: primary_name,
@@ -202,12 +205,16 @@ impl<'a> Config<'a> {
 
     fn new_config_with_single_url(mut urls: Vec<Url<'a>>) -> Self {
         let url = urls.get_mut(0).map(std::mem::take).expect("urls should not be empty");
-        let primary_name = if url.primary { Some(url.name.to_string()) } else { None };
+        let primary_name = if url.primary {
+            Some(url.name.as_ref().to_owned())
+        } else {
+            None
+        };
 
         Self {
             urls_primary_name: primary_name,
             url: if url.name.is_empty() {
-                Some(url.url.to_string())
+                Some(url.url.as_ref().to_owned())
             } else {
                 None
             },

--- a/crates/proxy/src/unix_sock_client.rs
+++ b/crates/proxy/src/unix_sock_client.rs
@@ -82,7 +82,7 @@ fn extract_unix_paths(uri: &hyper::Uri) -> Result<(String, String), Error> {
                 "Invalid socket path: directory traversal ('..') is not allowed.",
             ));
         }
-        let mut request_path = full_path[sock_path_end..].to_string();
+        let mut request_path = full_path[sock_path_end..].to_owned();
         if request_path.is_empty() {
             request_path = "/".to_owned();
         }

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -502,7 +502,7 @@ impl Handler for StaticDir {
             // list the dir
             if let Ok(mut entries) = tokio::fs::read_dir(&abs_path).await {
                 while let Ok(Some(entry)) = entries.next_entry().await {
-                    let file_name = entry.file_name().to_string_lossy().to_string();
+                    let file_name = entry.file_name().to_string_lossy().into_owned();
                     if self.include_dot_files || !file_name.starts_with('.') {
                         let raw_path = join_path!(&abs_path, &file_name);
                         if self.exclude_filters.iter().any(|filter| filter(&raw_path)) {

--- a/crates/tus/src/error.rs
+++ b/crates/tus/src/error.rs
@@ -122,7 +122,7 @@ mod tests {
             "missing tus-resumable"
         );
         assert_eq!(
-            ProtocolError::UnsupportedTusVersion("2.0.0".to_string()).to_string(),
+            ProtocolError::UnsupportedTusVersion("2.0.0".to_owned()).to_string(),
             "unsupported tus version: 2.0.0"
         );
         assert_eq!(
@@ -201,7 +201,7 @@ mod tests {
             "file no longer exists"
         );
         assert_eq!(
-            TusError::Internal("test error".to_string()).to_string(),
+            TusError::Internal("test error".to_owned()).to_string(),
             "internal: test error"
         );
     }
@@ -315,7 +315,7 @@ mod tests {
             StatusCode::INTERNAL_SERVER_ERROR
         );
         assert_eq!(
-            TusError::Internal("error".to_string()).status(),
+            TusError::Internal("error".to_owned()).status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
     }

--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -65,12 +65,12 @@ impl Metadata {
             }
 
             let key = tokens[0];
-            if !validate_key(key) || !seen.insert(key.to_string()) {
+            if !validate_key(key) || !seen.insert(key.to_owned()) {
                 return Err(ProtocolError::InvalidMetadata);
             }
 
             if tokens.len() == 1 {
-                map.insert(key.to_string(), None);
+                map.insert(key.to_owned(), None);
                 continue;
             }
 
@@ -82,9 +82,9 @@ impl Metadata {
             let decoded = base64::engine::general_purpose::STANDARD
                 .decode(value)
                 .map_err(|_| ProtocolError::InvalidMetadata)?;
-            let decoded_value = String::from_utf8_lossy(&decoded).to_string();
+            let decoded_value = String::from_utf8_lossy(&decoded).into_owned();
 
-            map.insert(key.to_string(), Some(decoded_value));
+            map.insert(key.to_owned(), Some(decoded_value));
         }
 
         Ok(Metadata(map))
@@ -100,7 +100,7 @@ impl Metadata {
                         base64::engine::general_purpose::STANDARD.encode(value.as_bytes());
                     format!("{} {}", key, encoded)
                 }
-                None => key.to_string(),
+                None => key.to_owned(),
             })
             .collect::<Vec<_>>()
             .join(", ")
@@ -156,23 +156,17 @@ mod tests {
     fn test_metadata_parse_single_key_value() {
         let raw = "filename dGVzdC50eHQ="; // "test.txt" in base64
         let metadata = Metadata::parse_metadata(raw).unwrap();
-        assert_eq!(
-            metadata.get("filename"),
-            Some(&Some("test.txt".to_string()))
-        );
+        assert_eq!(metadata.get("filename"), Some(&Some("test.txt".to_owned())));
     }
 
     #[test]
     fn test_metadata_parse_multiple_key_values() {
         let raw = "filename dGVzdC50eHQ=,filetype dGV4dC9wbGFpbg=="; // "test.txt", "text/plain"
         let metadata = Metadata::parse_metadata(raw).unwrap();
-        assert_eq!(
-            metadata.get("filename"),
-            Some(&Some("test.txt".to_string()))
-        );
+        assert_eq!(metadata.get("filename"), Some(&Some("test.txt".to_owned())));
         assert_eq!(
             metadata.get("filetype"),
-            Some(&Some("text/plain".to_string()))
+            Some(&Some("text/plain".to_owned()))
         );
     }
 
@@ -187,12 +181,9 @@ mod tests {
     fn test_metadata_parse_mixed_keys() {
         let raw = "filename dGVzdC50eHQ=,is_private,size MTAyNA=="; // "test.txt", no value, "1024"
         let metadata = Metadata::parse_metadata(raw).unwrap();
-        assert_eq!(
-            metadata.get("filename"),
-            Some(&Some("test.txt".to_string()))
-        );
+        assert_eq!(metadata.get("filename"), Some(&Some("test.txt".to_owned())));
         assert_eq!(metadata.get("is_private"), Some(&None));
-        assert_eq!(metadata.get("size"), Some(&Some("1024".to_string())));
+        assert_eq!(metadata.get("size"), Some(&Some("1024".to_owned())));
     }
 
     #[test]
@@ -236,7 +227,7 @@ mod tests {
         let raw = "file,name dGVzdA==";
         let result = Metadata::parse_metadata(raw).unwrap();
         assert_eq!(result.get("file"), Some(&None));
-        assert_eq!(result.get("name"), Some(&Some("test".to_string())));
+        assert_eq!(result.get("name"), Some(&Some("test".to_owned())));
     }
 
     #[test]
@@ -267,7 +258,7 @@ mod tests {
     #[test]
     fn test_metadata_stringify_single_key_value() {
         let mut metadata = Metadata::default();
-        metadata.insert("filename".to_string(), Some("test.txt".to_string()));
+        metadata.insert("filename".to_owned(), Some("test.txt".to_owned()));
         let result = Metadata::stringify(metadata);
         assert_eq!(result, "filename dGVzdC50eHQ=");
     }
@@ -275,7 +266,7 @@ mod tests {
     #[test]
     fn test_metadata_stringify_key_without_value() {
         let mut metadata = Metadata::default();
-        metadata.insert("is_private".to_string(), None);
+        metadata.insert("is_private".to_owned(), None);
         let result = Metadata::stringify(metadata);
         assert_eq!(result, "is_private");
     }
@@ -283,8 +274,8 @@ mod tests {
     #[test]
     fn test_metadata_stringify_multiple_keys() {
         let mut metadata = Metadata::default();
-        metadata.insert("filename".to_string(), Some("test.txt".to_string()));
-        metadata.insert("is_private".to_string(), None);
+        metadata.insert("filename".to_owned(), Some("test.txt".to_owned()));
+        metadata.insert("is_private".to_owned(), None);
         let result = Metadata::stringify(metadata);
         // Order may vary due to HashMap, so check both parts are present
         assert!(result.contains("filename dGVzdC50eHQ="));
@@ -310,14 +301,14 @@ mod tests {
     #[test]
     fn test_metadata_deref() {
         let mut metadata = Metadata::default();
-        metadata.insert("key".to_string(), Some("value".to_string()));
+        metadata.insert("key".to_owned(), Some("value".to_owned()));
 
         // Test Deref
         assert!(metadata.contains_key("key"));
         assert_eq!(metadata.len(), 1);
 
         // Test DerefMut
-        metadata.insert("key2".to_string(), None);
+        metadata.insert("key2".to_owned(), None);
         assert_eq!(metadata.len(), 2);
     }
 
@@ -326,7 +317,7 @@ mod tests {
         // "文件" (Chinese for "file") in base64
         let raw = "name 5paH5Lu2";
         let metadata = Metadata::parse_metadata(raw).unwrap();
-        assert_eq!(metadata.get("name"), Some(&Some("文件".to_string())));
+        assert_eq!(metadata.get("name"), Some(&Some("文件".to_owned())));
     }
 
     #[test]
@@ -336,7 +327,7 @@ mod tests {
         let metadata = Metadata::parse_metadata(raw).unwrap();
         assert_eq!(
             metadata.get("content"),
-            Some(&Some("hello\nworld".to_string()))
+            Some(&Some("hello\nworld".to_owned()))
         );
     }
 

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -70,9 +70,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         on_incoming_request(req, id.clone()).await;
     }
 
-    let max_file_size = opts
-        .get_configured_max_size(req, Some(id.to_string()))
-        .await;
+    let max_file_size = opts.get_configured_max_size(req, Some(id.to_owned())).await;
     let _lock = match opts
         .acquire_write_lock(req, &id, CancellationContext::new())
         .await

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -134,7 +134,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     };
 
     let max_file_size = opts
-        .get_configured_max_size(req, Some(upload_id.to_string()))
+        .get_configured_max_size(req, Some(upload_id.to_owned()))
         .await;
 
     if let Some(size) = upload_length_value

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -552,7 +552,7 @@ mod tests {
     #[tokio::test]
     async fn test_tus_with_upload_id_naming_function() {
         let tus = Tus::new().with_upload_id_naming_function(|_req, _meta| async move {
-            Ok("custom-id".to_string())
+            Ok("custom-id".to_owned())
         });
 
         // Verify the function is set by calling it
@@ -587,7 +587,7 @@ mod tests {
 
         assert!(tus.options.on_incoming_request.is_some());
         let req = Request::default();
-        (tus.options.on_incoming_request.unwrap())(&req, "test-id".to_string()).await;
+        (tus.options.on_incoming_request.unwrap())(&req, "test-id".to_owned()).await;
         assert!(called.load(Ordering::SeqCst));
     }
 

--- a/crates/tus/src/lockers/memory_locker.rs
+++ b/crates/tus/src/lockers/memory_locker.rs
@@ -27,7 +27,7 @@ impl MemoryLocker {
 
         map.retain(|_, lock| Arc::strong_count(lock) > 1);
         let lock = Arc::new(RwLock::new(()));
-        map.insert(id.to_string(), lock.clone());
+        map.insert(id.to_owned(), lock.clone());
         lock
     }
 }

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -158,7 +158,7 @@ impl TusOptions {
 
         re.captures(path)
             .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_string())
+            .map(|m| m.as_str().to_owned())
             .ok_or(TusError::FileIdError)
     }
 
@@ -280,7 +280,7 @@ impl TusOptions {
 impl Default for TusOptions {
     fn default() -> Self {
         TusOptions {
-            path: "/tus-files".to_string(),
+            path: "/tus-files".to_owned(),
             max_size: Some(MaxSize::Fixed(2 * 1024 * 1024 * 1024)), // Default max size 2GiB
             relative_location: true,
             respect_forwarded_headers: false,

--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -122,7 +122,7 @@ impl DiskStore {
             .as_ref()
             .and_then(|m| m.get(key))
             .and_then(|v| v.as_ref())
-            .map(|v| v.to_string())
+            .map(|v| v.to_owned())
     }
 
     fn sanitize_filename(name: &str) -> Option<String> {
@@ -132,7 +132,7 @@ impl DiskStore {
         }
         let file_name = Path::new(trimmed)
             .file_name()
-            .map(|s| s.to_string_lossy().to_string())?;
+            .map(|s| s.to_string_lossy().into_owned())?;
         if file_name == "." || file_name == ".." {
             return None;
         }
@@ -149,7 +149,7 @@ impl DiskStore {
         if subtype.is_empty() {
             return None;
         }
-        Some(subtype.to_string())
+        Some(subtype.to_owned())
     }
 
     fn desired_filename(meta: &MetaUpload) -> Option<String> {
@@ -215,11 +215,11 @@ impl DiskStore {
         }
 
         let storage = meta.storage.get_or_insert_with(|| MetaStoreInfo {
-            type_name: "file".to_string(),
-            path: target_path.to_string_lossy().to_string(),
+            type_name: "file".to_owned(),
+            path: target_path.to_string_lossy().into_owned(),
             bucket: None,
         });
-        storage.path = target_path.to_string_lossy().to_string();
+        storage.path = target_path.to_string_lossy().into_owned();
     }
 
     async fn read_meta(&self, id: &str) -> TusResult<MetaUpload> {
@@ -276,8 +276,8 @@ impl DataStore for DiskStore {
         let mut file = file;
         if file.storage.is_none() {
             file.storage = Some(StoreInfo {
-                type_name: "file".to_string(),
-                path: self.data_path(&file.id).to_string_lossy().to_string(),
+                type_name: "file".to_owned(),
+                path: self.data_path(&file.id).to_string_lossy().into_owned(),
                 bucket: None,
             });
         }
@@ -423,12 +423,12 @@ mod tests {
 
     fn create_test_upload_info(id: &str) -> UploadInfo {
         UploadInfo {
-            id: id.to_string(),
+            id: id.to_owned(),
             size: Some(1024),
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01T00:00:00Z".to_string(),
+            creation_date: "2024-01-01T00:00:00Z".to_owned(),
         }
     }
 
@@ -491,17 +491,17 @@ mod tests {
     fn test_sanitize_filename_valid() {
         assert_eq!(
             DiskStore::sanitize_filename("test.txt"),
-            Some("test.txt".to_string())
+            Some("test.txt".to_owned())
         );
         assert_eq!(
             DiskStore::sanitize_filename("  test.txt  "),
-            Some("test.txt".to_string())
+            Some("test.txt".to_owned())
         );
         assert_eq!(
             DiskStore::sanitize_filename("/path/to/file.txt"),
-            Some("file.txt".to_string())
+            Some("file.txt".to_owned())
         );
-        assert_eq!(DiskStore::sanitize_filename("a"), Some("a".to_string()));
+        assert_eq!(DiskStore::sanitize_filename("a"), Some("a".to_owned()));
     }
 
     #[test]
@@ -515,32 +515,32 @@ mod tests {
     #[test]
     fn test_filename_from_meta_with_filename() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filename".to_string(), Some("document.pdf".to_string()));
+                m.insert("filename".to_owned(), Some("document.pdf".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::filename_from_meta(&meta),
-            Some("document.pdf".to_string())
+            Some("document.pdf".to_owned())
         );
     }
 
     #[test]
     fn test_filename_from_meta_without_filename() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(DiskStore::filename_from_meta(&meta), None);
     }
@@ -548,56 +548,56 @@ mod tests {
     #[test]
     fn test_extension_from_filetype() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filetype".to_string(), Some("application/pdf".to_string()));
+                m.insert("filetype".to_owned(), Some("application/pdf".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::extension_from_filetype(&meta),
-            Some("pdf".to_string())
+            Some("pdf".to_owned())
         );
     }
 
     #[test]
     fn test_extension_from_filetype_image() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filetype".to_string(), Some("image/png".to_string()));
+                m.insert("filetype".to_owned(), Some("image/png".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::extension_from_filetype(&meta),
-            Some("png".to_string())
+            Some("png".to_owned())
         );
     }
 
     #[test]
     fn test_extension_from_filetype_invalid() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filetype".to_string(), Some("invalid".to_string()));
+                m.insert("filetype".to_owned(), Some("invalid".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(DiskStore::extension_from_filetype(&meta), None);
     }
@@ -605,16 +605,16 @@ mod tests {
     #[test]
     fn test_extension_from_filetype_empty_subtype() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filetype".to_string(), Some("application/".to_string()));
+                m.insert("filetype".to_owned(), Some("application/".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(DiskStore::extension_from_filetype(&meta), None);
     }
@@ -622,73 +622,73 @@ mod tests {
     #[test]
     fn test_desired_filename_with_name_and_extension() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filename".to_string(), Some("document.pdf".to_string()));
+                m.insert("filename".to_owned(), Some("document.pdf".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::desired_filename(&meta),
-            Some("document.pdf".to_string())
+            Some("document.pdf".to_owned())
         );
     }
 
     #[test]
     fn test_desired_filename_with_name_without_extension() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filename".to_string(), Some("document".to_string()));
-                m.insert("filetype".to_string(), Some("application/pdf".to_string()));
+                m.insert("filename".to_owned(), Some("document".to_owned()));
+                m.insert("filetype".to_owned(), Some("application/pdf".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::desired_filename(&meta),
-            Some("document.pdf".to_string())
+            Some("document.pdf".to_owned())
         );
     }
 
     #[test]
     fn test_desired_filename_only_filetype() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("filetype".to_string(), Some("image/png".to_string()));
+                m.insert("filetype".to_owned(), Some("image/png".to_owned()));
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(
             DiskStore::desired_filename(&meta),
-            Some("test-id.png".to_string())
+            Some("test-id.png".to_owned())
         );
     }
 
     #[test]
     fn test_desired_filename_no_metadata() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: 0,
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert_eq!(DiskStore::desired_filename(&meta), None);
     }
@@ -718,8 +718,8 @@ mod tests {
     fn test_resolve_data_path_with_storage() {
         let store = DiskStore::new().disk_root("/uploads");
         let storage = Some(MetaStoreInfo {
-            type_name: "file".to_string(),
-            path: "/custom/path/file.bin".to_string(),
+            type_name: "file".to_owned(),
+            path: "/custom/path/file.bin".to_owned(),
             bucket: None,
         });
         let path = store.resolve_data_path("test-id", &storage);
@@ -736,21 +736,21 @@ mod tests {
     #[test]
     fn test_meta_store_info_from_store_info() {
         let store_info = StoreInfo {
-            type_name: "disk".to_string(),
-            path: "/path/to/file".to_string(),
-            bucket: Some("bucket".to_string()),
+            type_name: "disk".to_owned(),
+            path: "/path/to/file".to_owned(),
+            bucket: Some("bucket".to_owned()),
         };
         let meta_info: MetaStoreInfo = store_info.into();
         assert_eq!(meta_info.type_name, "disk");
         assert_eq!(meta_info.path, "/path/to/file");
-        assert_eq!(meta_info.bucket, Some("bucket".to_string()));
+        assert_eq!(meta_info.bucket, Some("bucket".to_owned()));
     }
 
     #[test]
     fn test_store_info_from_meta_store_info() {
         let meta_info = MetaStoreInfo {
-            type_name: "disk".to_string(),
-            path: "/path/to/file".to_string(),
+            type_name: "disk".to_owned(),
+            path: "/path/to/file".to_owned(),
             bucket: None,
         };
         let store_info: StoreInfo = meta_info.into();
@@ -762,12 +762,12 @@ mod tests {
     #[test]
     fn test_meta_upload_from_upload_info() {
         let upload_info = UploadInfo {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: Some(512),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         let meta: MetaUpload = upload_info.into();
         assert_eq!(meta.id, "test-id");
@@ -778,12 +778,12 @@ mod tests {
     #[test]
     fn test_meta_upload_from_upload_info_no_offset() {
         let upload_info = UploadInfo {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(1024),
             offset: None,
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         let meta: MetaUpload = upload_info.into();
         assert_eq!(meta.offset, 0); // defaults to 0
@@ -792,12 +792,12 @@ mod tests {
     #[test]
     fn test_upload_info_from_meta_upload() {
         let meta = MetaUpload {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(2048),
             offset: 1024,
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         let upload_info: UploadInfo = meta.into();
         assert_eq!(upload_info.id, "test-id");
@@ -824,12 +824,12 @@ mod tests {
     async fn test_disk_store_create_with_deferred_size() {
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-deferred".to_string(),
+            id: "test-deferred".to_owned(),
             size: None, // deferred
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         let _created = store.create(upload_info).await.unwrap();
@@ -872,12 +872,12 @@ mod tests {
     async fn test_disk_store_declare_upload_length() {
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-declare".to_string(),
+            id: "test-declare".to_owned(),
             size: None,
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -895,12 +895,12 @@ mod tests {
     async fn test_disk_store_declare_upload_length_too_small() {
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-declare-small".to_string(),
+            id: "test-declare-small".to_owned(),
             size: None,
             offset: Some(100), // Already has some offset
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -918,12 +918,12 @@ mod tests {
 
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-write".to_string(),
+            id: "test-write".to_owned(),
             size: Some(100),
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -972,12 +972,12 @@ mod tests {
 
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-write-large".to_string(),
+            id: "test-write-large".to_owned(),
             size: Some(5), // Only 5 bytes allowed
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -1014,12 +1014,12 @@ mod tests {
 
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
-            id: "test-multi-chunk".to_string(),
+            id: "test-multi-chunk".to_owned(),
             size: Some(100),
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -1053,15 +1053,15 @@ mod tests {
         let (store, temp_dir) = create_test_store();
 
         let mut metadata = HashMap::new();
-        metadata.insert("filename".to_string(), Some("myfile.txt".to_string()));
+        metadata.insert("filename".to_owned(), Some("myfile.txt".to_owned()));
 
         let upload_info = UploadInfo {
-            id: "test-finalize".to_string(),
+            id: "test-finalize".to_owned(),
             size: Some(5),
             offset: Some(0),
             metadata: Some(Metadata(metadata)),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -1086,16 +1086,16 @@ mod tests {
         let (store, _temp_dir) = create_test_store();
 
         let mut metadata = HashMap::new();
-        metadata.insert("filename".to_string(), Some("test.pdf".to_string()));
-        metadata.insert("filetype".to_string(), Some("application/pdf".to_string()));
+        metadata.insert("filename".to_owned(), Some("test.pdf".to_owned()));
+        metadata.insert("filetype".to_owned(), Some("application/pdf".to_owned()));
 
         let upload_info = UploadInfo {
-            id: "test-metadata".to_string(),
+            id: "test-metadata".to_owned(),
             size: Some(1024),
             offset: Some(0),
             metadata: Some(Metadata(metadata)),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         store.create(upload_info).await.unwrap();
@@ -1103,28 +1103,28 @@ mod tests {
         let info = store.get_upload_file_info("test-metadata").await.unwrap();
         assert!(info.metadata.is_some());
         let meta = info.metadata.unwrap();
-        assert_eq!(meta.get("filename"), Some(&Some("test.pdf".to_string())));
+        assert_eq!(meta.get("filename"), Some(&Some("test.pdf".to_owned())));
     }
 
     #[test]
     fn test_metadata_value_extraction() {
         let meta = MetaUpload {
-            id: "test".to_string(),
+            id: "test".to_owned(),
             size: Some(100),
             offset: 0,
             metadata: Some({
                 let mut m = HashMap::new();
-                m.insert("key1".to_string(), Some("value1".to_string()));
-                m.insert("key2".to_string(), None);
+                m.insert("key1".to_owned(), Some("value1".to_owned()));
+                m.insert("key2".to_owned(), None);
                 m
             }),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         assert_eq!(
             DiskStore::metadata_value(&meta, "key1"),
-            Some("value1".to_string())
+            Some("value1".to_owned())
         );
         assert_eq!(DiskStore::metadata_value(&meta, "key2"), None);
         assert_eq!(DiskStore::metadata_value(&meta, "key3"), None);

--- a/crates/tus/src/stores/mod.rs
+++ b/crates/tus/src/stores/mod.rs
@@ -183,12 +183,12 @@ mod tests {
     #[test]
     fn test_upload_info_get_size_is_deferred_true() {
         let info = UploadInfo {
-            id: "test".to_string(),
+            id: "test".to_owned(),
             size: None,
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert!(info.get_size_is_deferred());
     }
@@ -196,12 +196,12 @@ mod tests {
     #[test]
     fn test_upload_info_get_size_is_deferred_false() {
         let info = UploadInfo {
-            id: "test".to_string(),
+            id: "test".to_owned(),
             size: Some(1024),
             offset: Some(0),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         assert!(!info.get_size_is_deferred());
     }
@@ -209,16 +209,16 @@ mod tests {
     #[test]
     fn test_upload_info_clone() {
         let info = UploadInfo {
-            id: "test-id".to_string(),
+            id: "test-id".to_owned(),
             size: Some(2048),
             offset: Some(512),
             metadata: None,
             storage: Some(StoreInfo {
-                type_name: "disk".to_string(),
-                path: "/uploads/test.bin".to_string(),
+                type_name: "disk".to_owned(),
+                path: "/uploads/test.bin".to_owned(),
                 bucket: None,
             }),
-            creation_date: "2024-01-01T00:00:00Z".to_string(),
+            creation_date: "2024-01-01T00:00:00Z".to_owned(),
         };
 
         let cloned = info.clone();
@@ -234,15 +234,15 @@ mod tests {
     #[test]
     fn test_store_info_clone() {
         let info = StoreInfo {
-            type_name: "s3".to_string(),
-            path: "uploads/file.bin".to_string(),
-            bucket: Some("my-bucket".to_string()),
+            type_name: "s3".to_owned(),
+            path: "uploads/file.bin".to_owned(),
+            bucket: Some("my-bucket".to_owned()),
         };
 
         let cloned = info.clone();
         assert_eq!(cloned.type_name, "s3");
         assert_eq!(cloned.path, "uploads/file.bin");
-        assert_eq!(cloned.bucket, Some("my-bucket".to_string()));
+        assert_eq!(cloned.bucket, Some("my-bucket".to_owned()));
     }
 
     #[test]
@@ -252,23 +252,20 @@ mod tests {
         use crate::handlers::Metadata;
 
         let mut map = HashMap::new();
-        map.insert("filename".to_string(), Some("test.txt".to_string()));
+        map.insert("filename".to_owned(), Some("test.txt".to_owned()));
 
         let info = UploadInfo {
-            id: "test".to_string(),
+            id: "test".to_owned(),
             size: Some(100),
             offset: Some(0),
             metadata: Some(Metadata(map)),
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
 
         assert!(info.metadata.is_some());
         let metadata = info.metadata.unwrap();
-        assert_eq!(
-            metadata.get("filename"),
-            Some(&Some("test.txt".to_string()))
-        );
+        assert_eq!(metadata.get("filename"), Some(&Some("test.txt".to_owned())));
     }
 
     #[test]
@@ -281,8 +278,8 @@ mod tests {
     #[test]
     fn test_store_info_debug() {
         let info = StoreInfo {
-            type_name: "disk".to_string(),
-            path: "/uploads/test.bin".to_string(),
+            type_name: "disk".to_owned(),
+            path: "/uploads/test.bin".to_owned(),
             bucket: None,
         };
         let debug_str = format!("{:?}", info);
@@ -293,12 +290,12 @@ mod tests {
     #[test]
     fn test_upload_info_debug() {
         let info = UploadInfo {
-            id: "abc123".to_string(),
+            id: "abc123".to_owned(),
             size: Some(1024),
             offset: Some(512),
             metadata: None,
             storage: None,
-            creation_date: "2024-01-01".to_string(),
+            creation_date: "2024-01-01".to_owned(),
         };
         let debug_str = format!("{:?}", info);
         assert!(debug_str.contains("abc123"));

--- a/crates/tus/src/utils.rs
+++ b/crates/tus/src/utils.rs
@@ -6,7 +6,7 @@ use crate::error::ProtocolError;
 pub fn check_tus_version(v: Option<&str>) -> Result<(), ProtocolError> {
     let v = v.ok_or(ProtocolError::MissingTusResumable)?;
     if v != TUS_VERSION {
-        return Err(ProtocolError::UnsupportedTusVersion(v.to_string()));
+        return Err(ProtocolError::UnsupportedTusVersion(v.to_owned()));
     }
     Ok(())
 }
@@ -19,14 +19,14 @@ pub fn parse_u64(v: Option<&str>, name: &'static str) -> Result<u64, ProtocolErr
 
 pub fn normalize_path(p: &str) -> String {
     if p.is_empty() {
-        return "/".to_string();
+        return "/".to_owned();
     }
-    let mut out = p.to_string();
+    let mut out = p.to_owned();
     if !out.starts_with('/') {
         out = format!("/{}", out);
     }
     if out.len() > 1 {
-        out = out.trim_end_matches('/').to_string();
+        out = out.trim_end_matches('/').to_owned();
     }
     out
 }

--- a/examples/affix-state/src/main.rs
+++ b/examples/affix-state/src/main.rs
@@ -38,8 +38,8 @@ async fn main() {
 
     // Create a Config instance with default username and password
     let config = Config {
-        username: "root".to_string(),
-        password: "pwd".to_string(),
+        username: "root".to_owned(),
+        password: "pwd".to_owned(),
     };
 
     // Set up the router with state injection and custom data

--- a/examples/db-postgres-sea-orm/src/routers/users.rs
+++ b/examples/db-postgres-sea-orm/src/routers/users.rs
@@ -274,7 +274,7 @@ async fn delete_users(
         if row_affected == 0 {
             res.status_code(StatusCode::NOT_FOUND);
             res.render(Json(ErrorResponseModel {
-                detail: "❌ User not found".to_string(),
+                detail: "❌ User not found".to_owned(),
             }));
             return;
         } else {

--- a/examples/extract-data/src/main.rs
+++ b/examples/extract-data/src/main.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 async fn inject_user(depot: &mut Depot) {
     // Simulate injecting authenticated user data into depot
     depot.insert("user_id", 42i64);
-    depot.insert("user_role", "admin".to_string());
+    depot.insert("user_role", "admin".to_owned());
     depot.insert("is_verified", true);
 }
 

--- a/examples/oapi-generics/src/main.rs
+++ b/examples/oapi-generics/src/main.rs
@@ -53,7 +53,7 @@ async fn get_city() -> Json<ApiResponse<CityDTO>> {
         code: 200,
         data: CityDTO {
             id: 1,
-            name: "Beijing".to_string(),
+            name: "Beijing".to_owned(),
         },
     })
 }
@@ -63,7 +63,7 @@ async fn get_city() -> Json<ApiResponse<CityDTO>> {
 async fn get_message() -> Json<ApiResponse<String>> {
     Json(ApiResponse {
         code: 200,
-        data: "Hello, World!".to_string(),
+        data: "Hello, World!".to_owned(),
     })
 }
 

--- a/examples/otel-jaeger/src/client.rs
+++ b/examples/otel-jaeger/src/client.rs
@@ -46,10 +46,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let cx = Context::current();
         let span = cx.span();
 
-        span.add_event("Send request to server1".to_string(), vec![]);
+        span.add_event("Send request to server1".to_owned(), vec![]);
         let resp = client.execute(req).await.unwrap();
         span.add_event(
-            "Got response from server1!".to_string(),
+            "Got response from server1!".to_owned(),
             vec![KeyValue::new("status", resp.status().to_string())],
         );
         println!("{}", resp.text().await.unwrap());

--- a/examples/otel-jaeger/src/server1.rs
+++ b/examples/otel-jaeger/src/server1.rs
@@ -50,10 +50,10 @@ async fn index(req: &mut Request, depot: &mut Depot) -> String {
         let cx = opentelemetry::Context::current();
         let span = cx.span();
 
-        span.add_event("Send request to server2".to_string(), vec![]);
+        span.add_event("Send request to server2".to_owned(), vec![]);
         let resp = client.execute(req).await.unwrap();
         span.add_event(
-            "Got response from server2!".to_string(),
+            "Got response from server2!".to_owned(),
             vec![KeyValue::new("status", resp.status().to_string())],
         );
         resp


### PR DESCRIPTION
## Summary
- replace string-clone style `.to_string()` calls with `.to_owned()` where the source is already string-like
- use `into_owned()` or `as_ref().to_owned()` for `Cow<str>`-backed cases such as `to_string_lossy()` and `from_utf8_lossy()`
- keep `.to_string()` in places that rely on `Display` formatting semantics rather than string ownership conversion

## Why
This tightens string ownership conversions across the codebase and avoids using formatting-oriented APIs when the code is only cloning existing string data.

## Impact
This is a mechanical cleanup with no intended behavior change. It mainly affects TUS handling, OpenAPI helpers, static/file serving utilities, websocket configuration, and several examples/tests.

## Validation
- `cargo test -p salvo-tus --lib`
- `cargo test -p salvo_core --lib`
- `cargo test -p salvo-oapi --lib` currently has 2 existing assertion failures in `openapi` tests around `StatusError.code` schema formatting (`uint16` vs `int32`)
