### PR TITLE
Run cargo clippy for code linting

### DIFF
--- a/crates/core/src/conn/tcp.rs
+++ b/crates/core/src/conn/tcp.rs
@@ -398,7 +398,7 @@ impl DynTcpAcceptor for DynTcpAcceptors {
                 let fuse_factory = fuse_factory.clone();
                 set.push(async move { inner.accept(fuse_factory).await }.boxed());
             }
-            futures_util::future::select_all(set.into_iter()).await.0
+            futures_util::future::select_all(set).await.0
         }
         .boxed()
     }

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -77,14 +77,12 @@ where
     // Ensure body is parsed correctly.
     if let Some(ctype) = req.content_type() {
         match ctype.subtype() {
-            mime::WWW_FORM_URLENCODED | mime::FORM_DATA
-                if metadata.has_body_required() => {
-                    let _ = req.form_data().await;
-                }
-            mime::JSON
-                if metadata.has_body_required() => {
-                    let _ = req.payload().await;
-                }
+            mime::WWW_FORM_URLENCODED | mime::FORM_DATA if metadata.has_body_required() => {
+                let _ = req.form_data().await;
+            }
+            mime::JSON if metadata.has_body_required() => {
+                let _ = req.payload().await;
+            }
             _ => {}
         }
     }

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -77,16 +77,14 @@ where
     // Ensure body is parsed correctly.
     if let Some(ctype) = req.content_type() {
         match ctype.subtype() {
-            mime::WWW_FORM_URLENCODED | mime::FORM_DATA => {
-                if metadata.has_body_required() {
+            mime::WWW_FORM_URLENCODED | mime::FORM_DATA
+                if metadata.has_body_required() => {
                     let _ = req.form_data().await;
                 }
-            }
-            mime::JSON => {
-                if metadata.has_body_required() {
+            mime::JSON
+                if metadata.has_body_required() => {
                     let _ = req.payload().await;
                 }
-            }
             _ => {}
         }
     }

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -207,16 +207,13 @@ impl ExtractibleArgs {
                 let nested = metas.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)?;
                 for meta in nested {
                     match meta {
-                        Meta::List(meta)
-                            if meta.path.is_ident("default_source") => {
-                                default_sources.push(meta.parse_args()?);
-                            }
-                        Meta::NameValue(meta)
-                            if meta.path.is_ident("rename_all") => {
-                                rename_all = Some(
-                                    parse_path_or_lit_str(&meta.value)?.parse::<RenameRule>()?,
-                                );
-                            }
+                        Meta::List(meta) if meta.path.is_ident("default_source") => {
+                            default_sources.push(meta.parse_args()?);
+                        }
+                        Meta::NameValue(meta) if meta.path.is_ident("rename_all") => {
+                            rename_all =
+                                Some(parse_path_or_lit_str(&meta.value)?.parse::<RenameRule>()?);
+                        }
                         _ => {}
                     }
                 }

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -207,18 +207,16 @@ impl ExtractibleArgs {
                 let nested = metas.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)?;
                 for meta in nested {
                     match meta {
-                        Meta::List(meta) => {
-                            if meta.path.is_ident("default_source") {
+                        Meta::List(meta)
+                            if meta.path.is_ident("default_source") => {
                                 default_sources.push(meta.parse_args()?);
                             }
-                        }
-                        Meta::NameValue(meta) => {
-                            if meta.path.is_ident("rename_all") {
+                        Meta::NameValue(meta)
+                            if meta.path.is_ident("rename_all") => {
                                 rename_all = Some(
                                     parse_path_or_lit_str(&meta.value)?.parse::<RenameRule>()?,
                                 );
                             }
-                        }
                         _ => {}
                     }
                 }


### PR DESCRIPTION
This pull request focuses on simplifying and improving Rust pattern matching and iterator usage across several files. The changes primarily refactor match arms to use more concise syntax and remove unnecessary code, making the codebase easier to read and maintain.

Refactoring pattern matching:

* Combined match arms with guard conditions into single lines using `if` guards in `crates/core/src/serde/request.rs` and `crates/macros/src/extract.rs`, reducing nesting and improving readability. [[1]](diffhunk://#diff-af5466e7f9c80a74de2d19833e8c8d5e584bd73d7f8b828db8b6aa22a6537017L80-L89) [[2]](diffhunk://#diff-946b74fc5d870ad674d4ab97940cbbe91d8705c8b2b3841caa4fc6d43faabd2dL210-R215)

Iterator and API usage improvements:

* Removed an unnecessary `.into_iter()` call in the `select_all` usage in `crates/core/src/conn/tcp.rs`, streamlining the code.