### PR TITLE
[codex] fix csrf session store missing session

### DIFF
--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -431,6 +431,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_session_store_without_session_middleware_does_not_panic() {
+        let csrf = Csrf::new(
+            BcryptCipher::new(),
+            SessionStore::new(),
+            HeaderFinder::new("x-csrf-token"),
+        );
+        let router = Router::new().hoop(csrf).get(get_index);
+
+        let mut res = TestClient::get("http://127.0.0.1:5801").send(router).await;
+
+        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_ne!(res.take_string().await.unwrap(), "");
+    }
+
+    #[tokio::test]
     async fn test_per_session_reuses_token_across_safe_requests() {
         let csrf = Csrf::new(
             BcryptCipher::new(),

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -430,6 +430,7 @@ mod tests {
         assert_ne!(res.cookie("salvo.csrf"), None);
     }
 
+    #[cfg(feature = "session-store")]
     #[tokio::test]
     async fn test_session_store_without_session_middleware_does_not_panic() {
         let csrf = Csrf::new(

--- a/crates/csrf/src/session_store.rs
+++ b/crates/csrf/src/session_store.rs
@@ -40,10 +40,12 @@ impl CsrfStore for SessionStore {
         token: &str,
         proof: &str,
     ) -> Result<(), Self::Error> {
-        depot
-            .session_mut()
-            .expect("session must be exist")
-            .insert(&self.name, format!("{token}.{proof}"))?;
+        let Some(session) = depot.session_mut() else {
+            return Err(Error::other(
+                "session is not available in depot; add SessionHandler before Csrf<_, SessionStore>",
+            ));
+        };
+        session.insert(&self.name, format!("{token}.{proof}"))?;
         Ok(())
     }
 }


### PR DESCRIPTION
## What changed
- replace the `SessionStore` panic path with a normal framework error when no session is present in the depot
- add a regression test that exercises `SessionStore` without `SessionHandler`

## Why it changed
Using `Csrf<_, SessionStore>` without session middleware caused a runtime panic instead of a recoverable error.

## Impact
Misconfigured CSRF session storage now logs a normal save error and continues safely.

## Validation
- `cargo test -p salvo-csrf --features session-store --lib --locked`