### PR TITLE
[codex] improve proxy host header copy

### DIFF
--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -244,9 +244,9 @@ pub fn preserve_original_host_header_getter(
     _depot: &Depot,
 ) -> Option<String> {
     if let Some(host_header) = req.headers().get(HOST)
-        && let Ok(host) = String::from_utf8(host_header.as_bytes().to_vec())
+        && let Ok(host) = host_header.to_str()
     {
-        return Some(host);
+        return Some(host.to_owned());
     }
 
     default_host_header_getter(forward_uri, req, _depot)


### PR DESCRIPTION
## What changed
- stop converting the preserved `Host` header through `Vec<u8>` and `String::from_utf8`
- use `HeaderValue::to_str()` plus `to_owned()` directly

## Why it changed
The previous code paid for an unnecessary allocation and byte copy on the preserved host-header path.

## Impact
Proxy host-header preservation does less work on every request.

## Validation
- `cargo test -p salvo-proxy --lib --locked`