### PR TITLE
Normalize error and log message style

### DIFF
--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 //! Automatic HTTPS/TLS certificate management for Salvo via the ACME protocol.
 //!
-//! This crate integrates [certon](https://crates.io/crates/certon) — a
-//! production-grade ACME client — with Salvo's listener/acceptor system.
+//! This crate integrates [certon](https://crates.io/crates/certon), a
+//! production-grade ACME client, with Salvo's listener/acceptor system.
 //!
 //! ## Features
 //!
@@ -14,7 +14,7 @@
 //! - **Persistent storage**: pluggable storage backend via [`certon::Storage`].
 //! - **Background renewal**: automatic certificate renewal and OCSP refresh.
 //!
-//! ## Quick Start — HTTP-01
+//! ## Quick Start - HTTP-01
 //!
 //! ```ignore
 //! use salvo_acme::AcmeListener;
@@ -38,7 +38,7 @@
 //! }
 //! ```
 //!
-//! ## Quick Start — TLS-ALPN-01
+//! ## Quick Start - TLS-ALPN-01
 //!
 //! ```ignore
 //! use salvo_acme::AcmeListener;
@@ -174,7 +174,7 @@ impl Handler for Http01Handler {
             tracing::error!(token, "key not found for ACME challenge token");
             res.render(token);
         } else {
-            res.render(StatusError::not_found().brief("Token is not provided."));
+            res.render(StatusError::not_found().brief("missing token"));
         }
     }
 }

--- a/crates/core/src/conn/native_tls/listener.rs
+++ b/crates/core/src/conn/native_tls/listener.rs
@@ -77,7 +77,7 @@ where
         let inner = self.inner.try_bind().await?;
         let cancel_reload = CancellationToken::new();
 
-        tracing::info!("tls config loaded.");
+        tracing::info!("tls config loaded");
         tokio::spawn(reload_configs(
             config_stream,
             Arc::clone(&current_acceptor),
@@ -109,7 +109,7 @@ async fn reload_configs<C, E>(
                             current_acceptor.store(Some(Arc::new(tokio_native_tls::TlsAcceptor::from(
                                 acceptor,
                             ))));
-                            tracing::info!("tls config changed.");
+                            tracing::info!("tls config changed");
                         }
                         Err(err) => {
                             tracing::error!(error = ?err, "native_tls: invalid tls config, keeping previous config");
@@ -235,3 +235,4 @@ where
         })
     }
 }
+

--- a/crates/core/src/conn/openssl/listener.rs
+++ b/crates/core/src/conn/openssl/listener.rs
@@ -75,7 +75,7 @@ where
         let inner = self.inner.try_bind().await?;
         let cancel_reload = CancellationToken::new();
 
-        tracing::info!("tls config loaded.");
+        tracing::info!("tls config loaded");
         tokio::spawn(reload_configs(
             config_stream,
             Arc::clone(&current_acceptor),
@@ -104,7 +104,7 @@ async fn reload_configs<C, E>(
                 match config.try_into() {
                     Ok(builder) => {
                         current_acceptor.store(Some(Arc::new(builder.build())));
-                        tracing::info!("tls config changed.");
+                        tracing::info!("tls config changed");
                     }
                     Err(err) => {
                         tracing::error!(error = ?err, "openssl: invalid tls config, keeping previous config");
@@ -234,3 +234,4 @@ where
         })
     }
 }
+

--- a/crates/core/src/conn/quinn/listener.rs
+++ b/crates/core/src/conn/quinn/listener.rs
@@ -80,7 +80,7 @@ where
         let endpoint = Endpoint::server(initial, socket)?;
         let cancel_reload = CancellationToken::new();
 
-        tracing::info!("quinn config loaded.");
+        tracing::info!("quinn config loaded");
         tokio::spawn(reload_configs(
             config_stream,
             endpoint.clone(),
@@ -109,7 +109,7 @@ async fn reload_configs<C, E>(
                 match config.try_into() {
                     Ok(config) => {
                         endpoint.set_server_config(Some(config));
-                        tracing::info!("quinn config changed.");
+                        tracing::info!("quinn config changed");
                     }
                     Err(err) => {
                         tracing::error!(error = ?err, "quinn: invalid tls config, keeping previous config");
@@ -200,3 +200,4 @@ impl Acceptor for QuinnAcceptor {
         Err(IoError::other("quinn accept error"))
     }
 }
+

--- a/crates/core/src/conn/rustls/listener.rs
+++ b/crates/core/src/conn/rustls/listener.rs
@@ -75,7 +75,7 @@ where
         let inner = self.inner.try_bind().await?;
         let cancel_reload = CancellationToken::new();
 
-        tracing::info!("tls config loaded.");
+        tracing::info!("tls config loaded");
         tokio::spawn(reload_configs(
             config_stream,
             Arc::clone(&current_acceptor),
@@ -106,7 +106,7 @@ async fn reload_configs<C, E>(
                         current_acceptor.store(Some(Arc::new(tokio_rustls::TlsAcceptor::from(Arc::new(
                             config,
                         )))));
-                        tracing::info!("tls config changed.");
+                        tracing::info!("tls config changed");
                     }
                     Err(err) => {
                         tracing::error!(error = ?err, "rustls: invalid tls config, keeping previous config");
@@ -225,3 +225,4 @@ where
         })
     }
 }
+

--- a/crates/core/src/routing/path_params.rs
+++ b/crates/core/src/routing/path_params.rs
@@ -43,7 +43,7 @@ impl PathParams {
         #[cfg(debug_assertions)]
         {
             if self.greedy {
-                panic!("only one wildcard param is allowed and it must be the last one.");
+                panic!("only one wildcard param is allowed and it must be the last one");
             }
         }
         if name.starts_with('*') {

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -208,7 +208,7 @@ impl<'de> RequestDeserializer<'de> {
                 .metadata
                 .fields
                 .get(self.field_index as usize)
-                .expect("field must exist.");
+                .expect("field must exist");
             let metadata = field.metadata.expect("field's metadata must exist");
             seed.deserialize(RequestDeserializer {
                 params: self.params,

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -276,7 +276,7 @@ impl<A: Acceptor + Send> Server<A> {
                     alt_svc_h3 = Some(
                         format!(r#"h3=":{port}"; ma=2592000,h3-29=":{port}"; ma=2592000"#)
                             .parse::<HeaderValue>()
-                            .expect("Parse alt-svc header should not failed."),
+                            .expect("parsing alt-svc header should not fail"),
                     );
                 }
             }
@@ -385,7 +385,7 @@ impl<A: Acceptor + Send> Server<A> {
                     alt_svc_h3 = Some(
                         format!(r#"h3=":{port}"; ma=2592000,h3-29=":{port}"; ma=2592000"#)
                             .parse::<HeaderValue>()
-                            .expect("Parse alt-svc header should not failed."),
+                            .expect("parsing alt-svc header should not fail"),
                     );
                 }
             }
@@ -636,3 +636,4 @@ mod tests {
         };
     }
 }
+

--- a/crates/extra/src/catch_panic.rs
+++ b/crates/extra/src/catch_panic.rs
@@ -53,7 +53,7 @@ impl Handler for CatchPanic {
             tracing::error!(error = ?e, "panic occurred");
             res.render(
                 StatusError::internal_server_error()
-                    .brief("Panic occurred on server.")
+                    .brief("panic occurred on server")
                     .cause(Error::other(format!("{e:#?}"))),
             );
         }
@@ -89,3 +89,4 @@ mod tests {
         assert!(logs_contain("panic occurred"));
     }
 }
+

--- a/crates/extra/src/concurrency_limiter.rs
+++ b/crates/extra/src/concurrency_limiter.rs
@@ -100,11 +100,11 @@ impl Handler for MaxConcurrency {
                         "Max concurrency semaphore is never closed, acquire should never fail: {}",
                         e
                     );
-                    res.render(StatusError::payload_too_large().brief("Max concurrency reached."));
+                    res.render(StatusError::payload_too_large().brief("max concurrency reached"));
                 }
                 TryAcquireError::NoPermits => {
-                    tracing::error!("NoPermits : {}", e);
-                    res.render(StatusError::too_many_requests().brief("Max concurrency reached."));
+                    tracing::error!("no permits: {}", e);
+                    res.render(StatusError::too_many_requests().brief("max concurrency reached"));
                 }
             },
         }
@@ -117,3 +117,4 @@ impl Handler for MaxConcurrency {
         semaphore: Semaphore::new(size),
     }
 }
+

--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -88,7 +88,7 @@ impl Handler for MaxSize {
                 ctrl.call_next(req, depot, res).await;
             }
         } else {
-            res.render(StatusError::bad_request().brief("Request body size is unknown."));
+            res.render(StatusError::bad_request().brief("request body size is unknown"));
             ctrl.skip_rest();
         }
     }
@@ -135,3 +135,4 @@ mod tests {
         assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }
+

--- a/crates/extra/src/timeout.rs
+++ b/crates/extra/src/timeout.rs
@@ -68,7 +68,8 @@ impl Timeout {
         Self {
             value,
             error: Box::new(|| {
-                StatusError::service_unavailable().brief("Server process the request timeout.")
+                StatusError::service_unavailable()
+                    .brief("server timed out while processing the request")
             }),
         }
     }
@@ -76,7 +77,7 @@ impl Timeout {
     /// Custom error returned when timeout.
     ///
     /// By default, a `503 Service Unavailable` error is returned. You can set this function to other error types,
-    /// such as `403 Request Timeout`, but the 403 error code may cause the browser to automatically resend the
+    /// such as `408 Request Timeout`, but the 408 error code may cause the browser to automatically resend the
     /// request multiple times.
     #[must_use]
     pub fn error(mut self, error: impl Fn() -> StatusError + Send + Sync + 'static) -> Self {
@@ -136,7 +137,7 @@ mod tests {
             .take_string()
             .await
             .unwrap();
-        assert!(content.contains("timeout"));
+        assert!(content.contains("timed out while processing the request"));
 
         let content = TestClient::get("http://127.0.0.1:5801/fast")
             .send(&service)
@@ -147,3 +148,4 @@ mod tests {
         assert!(content.contains("hello"));
     }
 }
+

--- a/crates/extra/src/tower_compat.rs
+++ b/crates/extra/src/tower_compat.rs
@@ -99,14 +99,14 @@ where
     ) {
         let mut svc = self.0.clone();
         if svc.ready().await.is_err() {
-            tracing::error!("tower service not ready.");
-            res.render(StatusError::internal_server_error().cause("tower service not ready."));
+            tracing::error!("tower service not ready");
+            res.render(StatusError::internal_server_error().cause("tower service not ready"));
             return;
         }
         let Ok(hyper_req) = req.strip_to_hyper::<QB>() else {
-            tracing::error!("strip request to hyper failed.");
+            tracing::error!("strip request to hyper failed");
             res.render(
-                StatusError::internal_server_error().cause("strip request to hyper failed."),
+                StatusError::internal_server_error().cause("strip request to hyper failed"),
             );
             return;
         };
@@ -255,15 +255,15 @@ where
     ) {
         let mut svc = self.0.clone();
         if svc.ready().await.is_err() {
-            tracing::error!("tower service not ready.");
-            res.render(StatusError::internal_server_error().cause("tower service not ready."));
+            tracing::error!("tower service not ready");
+            res.render(StatusError::internal_server_error().cause("tower service not ready"));
             return;
         }
 
         let Ok(mut hyper_req) = req.strip_to_hyper::<QB>() else {
-            tracing::error!("strip request to hyper failed.");
+            tracing::error!("strip request to hyper failed");
             res.render(
-                StatusError::internal_server_error().cause("strip request to hyper failed."),
+                StatusError::internal_server_error().cause("strip request to hyper failed"),
             );
             return;
         };
@@ -373,3 +373,4 @@ mod tests {
         );
     }
 }
+

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -293,7 +293,7 @@ impl WebSocketUpgrade {
             .unwrap_or(false);
         if !matched {
             tracing::debug!("missing connection upgrade");
-            return Err(StatusError::bad_request().brief("Missing connection upgrade."));
+            return Err(StatusError::bad_request().brief("missing connection upgrade"));
         }
         let matched = req_headers
             .get(UPGRADE)
@@ -301,9 +301,9 @@ impl WebSocketUpgrade {
             .map(|v| v.to_lowercase() == "websocket")
             .unwrap_or(false);
         if !matched {
-            tracing::debug!("missing upgrade header or it is not equal websocket");
+            tracing::debug!("missing upgrade header or it is not websocket");
             return Err(StatusError::bad_request()
-                .brief("Missing upgrade header or it is not equal websocket."));
+                .brief("missing upgrade header or it is not websocket"));
         }
         let matched = !req_headers
             .get(SEC_WEBSOCKET_VERSION)
@@ -311,13 +311,12 @@ impl WebSocketUpgrade {
             .map(|v| v == "13")
             .unwrap_or(false);
         if matched {
-            tracing::debug!("websocket version is not equal 13");
-            return Err(StatusError::bad_request().brief("Websocket version is not equal 13."));
+            tracing::debug!("websocket version is not 13");
+            return Err(StatusError::bad_request().brief("websocket version is not 13"));
         }
         let Some(sec_ws_key) = req_headers.typed_get::<SecWebsocketKey>() else {
-            tracing::debug!("sec_websocket_key is not exist in request headers");
-            return Err(StatusError::bad_request()
-                .brief("sec_websocket_key is not exist in request headers."));
+            tracing::debug!("missing sec-websocket-key header");
+            return Err(StatusError::bad_request().brief("missing sec-websocket-key header"));
         };
 
         res.status_code(StatusCode::SWITCHING_PROTOCOLS);
@@ -363,9 +362,9 @@ impl WebSocketUpgrade {
             });
             Ok(())
         } else {
-            tracing::debug!("websocket couldn't be upgraded since no upgrade state was present");
+            tracing::debug!("websocket cannot be upgraded because no upgrade state was present");
             Err(StatusError::bad_request()
-                .brief("Websocket couldn't be upgraded since no upgrade state was present."))
+                .brief("websocket cannot be upgraded because no upgrade state was present"))
         }
     }
 }
@@ -792,7 +791,7 @@ mod tests {
         let res = sender.send_request(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::SWITCHING_PROTOCOLS);
-        // Should select "chat.v2" — first supported protocol in client's list
+        // Should select "chat.v2", the first supported protocol in the client's list
         assert_eq!(
             res.headers().get(SEC_WEBSOCKET_PROTOCOL),
             Some(&HeaderValue::from_static("chat.v2")),
@@ -837,7 +836,7 @@ mod tests {
         let res = sender.send_request(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::SWITCHING_PROTOCOLS);
-        // No overlap — response should not contain Sec-WebSocket-Protocol
+        // No overlap, so the response should not contain Sec-WebSocket-Protocol
         assert!(res.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
     }
 
@@ -878,7 +877,7 @@ mod tests {
         let res = sender.send_request(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::SWITCHING_PROTOCOLS);
-        // Client didn't send any protocol — response should not contain one
+        // Client did not send any protocol, so the response should not contain one
         assert!(res.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
     }
 
@@ -972,3 +971,4 @@ mod tests {
         );
     }
 }
+

--- a/crates/oapi/src/extract/parameter/cookie.rs
+++ b/crates/oapi/src/extract/parameter/cookie.rs
@@ -78,7 +78,7 @@ impl<T: Display> Display for CookieParam<T, true> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0
             .as_ref()
-            .expect("`CookieParam<T, true>` value should not be None.")
+            .expect("`CookieParam<T, true>` value should not be None")
             .fmt(f)
     }
 }

--- a/crates/oapi/src/extract/parameter/header.rs
+++ b/crates/oapi/src/extract/parameter/header.rs
@@ -90,7 +90,7 @@ impl<T: Display> Display for HeaderParam<T, true> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0
             .as_ref()
-            .expect("HeaderParam value should not None.")
+            .expect("HeaderParam value should not be None")
             .fmt(f)
     }
 }

--- a/crates/oapi/src/extract/parameter/query.rs
+++ b/crates/oapi/src/extract/parameter/query.rs
@@ -91,7 +91,7 @@ where
     }
     #[allow(refining_impl_trait)]
     async fn extract(_req: &'ex mut Request, _depot: &'ex mut Depot) -> Result<Self, ParseError> {
-        panic!("query parameter can not be extracted from request")
+        panic!("query parameter cannot be extracted from request")
     }
     #[allow(refining_impl_trait)]
     async fn extract_with_arg(
@@ -117,7 +117,7 @@ where
     }
     #[allow(refining_impl_trait)]
     async fn extract(_req: &'ex mut Request, _depot: &'ex mut Depot) -> Result<Self, ParseError> {
-        panic!("query parameter can not be extracted from request")
+        panic!("query parameter cannot be extracted from request")
     }
     #[allow(refining_impl_trait)]
     async fn extract_with_arg(

--- a/crates/oapi/src/extract/payload/file.rs
+++ b/crates/oapi/src/extract/payload/file.rs
@@ -87,7 +87,7 @@ impl<'ex> Extractible<'ex> for FormFile {
     }
     #[allow(refining_impl_trait)]
     async fn extract(_req: &'ex mut Request, _depot: &'ex mut Depot) -> Result<Self, ParseError> {
-        panic!("query parameter can not be extracted from request")
+        panic!("query parameter cannot be extracted from request")
     }
     #[allow(refining_impl_trait)]
     async fn extract_with_arg(
@@ -163,7 +163,7 @@ impl<'ex> Extractible<'ex> for FormFiles {
     }
     #[allow(refining_impl_trait)]
     async fn extract(_req: &'ex mut Request, _depot: &'ex mut Depot) -> Result<Self, ParseError> {
-        panic!("query parameter can not be extracted from request")
+        panic!("query parameter cannot be extracted from request")
     }
     #[allow(refining_impl_trait)]
     async fn extract_with_arg(

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -130,7 +130,7 @@ pub struct OpenApi {
     pub external_docs: Option<ExternalDocs>,
 
     /// Schema keyword can be used to override default _`$schema`_ dialect which is by default
-    /// “<https://spec.openapis.org/oas/3.1/dialect/base>”.
+    /// `<https://spec.openapis.org/oas/3.1/dialect/base>`.
     ///
     /// All the references and individual files could use their own schema dialect.
     #[serde(rename = "$schema", default, skip_serializing_if = "String::is_empty")]
@@ -521,7 +521,7 @@ impl OpenApi {
                     .skip(1)
                     .map(|capture| {
                         capture
-                            .expect("Regex captures should not be None.")
+                            .expect("regex captures should not be None")
                             .as_str()
                             .to_owned()
                     })
@@ -1325,7 +1325,7 @@ mod tests {
 
         assert_eq!(
             res.content_type()
-                .expect("content type should exists")
+                .expect("content type should exist")
                 .to_string(),
             "application/json; charset=utf-8".to_owned()
         );
@@ -1357,7 +1357,7 @@ mod tests {
 
         assert_eq!(
             res.content_type()
-                .expect("content type should exists")
+                .expect("content type should exist")
                 .to_string(),
             "application/json; charset=utf-8".to_owned()
         );

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -66,7 +66,7 @@ impl Handler for Metrics {
         let elapsed = s.elapsed();
 
         let status = res.status_code.unwrap_or_else(|| {
-            tracing::info!("[otel::Metrics] Treat status_code=none as 200(OK).");
+            tracing::info!("[otel::Metrics] Treat status_code=none as 200(OK)");
             StatusCode::OK
         });
         labels.push(KeyValue::new(

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -47,8 +47,8 @@ where
         // TODO: Will remove after opentelemetry_http updated
         let mut headers = HeaderMap::with_capacity(req.headers().len());
         headers.extend(req.headers().into_iter().map(|(name, value)| {
-            let name = HeaderName::from_bytes(name.as_ref()).expect("Invalid header name");
-            let value = HeaderValue::from_bytes(value.as_ref()).expect("Invalid header value");
+            let name = HeaderName::from_bytes(name.as_ref()).expect("invalid header name");
+            let value = HeaderValue::from_bytes(value.as_ref()).expect("invalid header value");
             (name, value)
         }));
 
@@ -91,7 +91,7 @@ where
             let span = cx.span();
 
             let status = res.status_code.unwrap_or_else(|| {
-                tracing::info!("[otel::Tracing] Treat status_code=none as 200(OK).");
+                tracing::info!("[otel::Tracing] Treat status_code=none as 200(OK)");
                 StatusCode::OK
             });
             let event = if status.is_client_error() || status.is_server_error() {

--- a/crates/proxy/src/hyper_client.rs
+++ b/crates/proxy/src/hyper_client.rs
@@ -92,16 +92,16 @@ where
                                 )
                                 .await
                                 {
-                                    tracing::error!(error = ?e, "coping between upgraded connections failed.");
+                                    tracing::error!(error = ?e, "copying between upgraded connections failed");
                                 }
                             }
                             Err(e) => {
-                                tracing::error!(error = ?e, "upgrade request failed.");
+                                tracing::error!(error = ?e, "upgrade request failed");
                             }
                         }
                     });
                 } else {
-                    return Err(Error::other("request does not have an upgrade extension."));
+                    return Err(Error::other("request does not have an upgrade extension"));
                 }
             } else {
                 return Err(Error::other("upgrade type mismatch"));
@@ -159,3 +159,4 @@ mod tests {
         assert_eq!(handler.upstreams_mut().len(), 1);
     }
 }
+

--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -89,7 +89,7 @@ impl Client for ReqwestClient {
                                 )
                                 .await
                                 {
-                                    tracing::error!(error = ?e, "coping between upgraded connections failed");
+                                    tracing::error!(error = ?e, "copying between upgraded connections failed");
                                 }
                             }
                             Err(e) => {

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -366,14 +366,14 @@ where
             return;
         }
         let Some(key) = self.issuer.issue(req, depot).await else {
-            res.render(StatusError::bad_request().brief("Invalid identifier."));
+            res.render(StatusError::bad_request().brief("invalid identifier"));
             ctrl.skip_rest();
             return;
         };
         let quota = match self.quota_getter.get(&key).await {
             Ok(quota) => quota,
             Err(e) => {
-                tracing::error!(error = ?e, "RateLimiter error: {}", e);
+                tracing::error!(error = ?e, "rate limiter error: {}", e);
                 res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
                 ctrl.skip_rest();
                 return;
@@ -382,7 +382,7 @@ where
         let mut guard = match self.store.load_guard(&key, &self.guard).await {
             Ok(guard) => guard,
             Err(e) => {
-                tracing::error!(error = ?e, "RateLimiter error: {}", e);
+                tracing::error!(error = ?e, "rate limiter error: {}", e);
                 res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
                 ctrl.skip_rest();
                 return;
@@ -409,7 +409,7 @@ where
             ctrl.skip_rest();
         }
         if let Err(e) = self.store.save_guard(key, guard).await {
-            tracing::error!(error = ?e, "RateLimiter save guard failed");
+            tracing::error!(error = ?e, "rate limiter save guard failed");
         }
     }
 }

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -496,7 +496,7 @@ impl Handler for StaticDir {
                 let headers = req.headers();
                 named_file.send(headers, res).await;
             } else {
-                res.render(StatusError::internal_server_error().brief("Read file failed."));
+                res.render(StatusError::internal_server_error().brief("read file failed"));
             }
         } else if !is_file {
             // list the dir


### PR DESCRIPTION
## Summary
- normalize custom error, log, panic, and expect messages toward Rust-style lowercase messages without trailing periods
- fix a few wording issues while touching those call sites, including websocket, timeout, proxy, and rate-limiter messages
- update the timeout assertion to match the new message text

## Why
Several crates were using inconsistent message casing, punctuation, and phrasing. This makes diagnostics noisier and less consistent across the workspace.

## Impact
User-facing and diagnostic messages are more uniform across the touched crates. This should make logs and error output read more consistently without changing behavior.

## Validation
- `cargo test --workspace --lib --tests`
