### PR TITLE
Add targeted regression tests

### DIFF
--- a/crates/craft/Cargo.toml
+++ b/crates/craft/Cargo.toml
@@ -21,5 +21,9 @@ authors = ["Andeya Lee <andeyalee@outlook.com>"]
 [dependencies]
 salvo-craft-macros = { workspace = true }
 
+[dev-dependencies]
+salvo_core = { workspace = true, features = ["http1", "test", "aws-lc-rs"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/crates/craft/tests/craft_smoke.rs
+++ b/crates/craft/tests/craft_smoke.rs
@@ -1,0 +1,34 @@
+#![allow(missing_docs)]
+
+extern crate salvo_core as salvo;
+
+use salvo::prelude::*;
+use salvo::test::{ResponseExt, TestClient};
+use salvo_craft::craft;
+
+#[derive(Clone, Debug)]
+pub struct GreetingService {
+    prefix: &'static str,
+}
+
+#[craft]
+impl GreetingService {
+    #[craft(handler)]
+    fn hello(&self) -> String {
+        format!("{} world", self.prefix)
+    }
+}
+
+#[tokio::test]
+async fn crafted_handler_can_be_registered_on_a_router() {
+    let router = Router::new().get(GreetingService { prefix: "hello" }.hello());
+
+    let body = TestClient::get("http://127.0.0.1:5801")
+        .send(router)
+        .await
+        .take_string()
+        .await
+        .unwrap();
+
+    assert_eq!(body, "hello world");
+}

--- a/crates/extra/src/tower_compat.rs
+++ b/crates/extra/src/tower_compat.rs
@@ -320,7 +320,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::future::{Ready, ready};
+    use std::io;
+
+    use http_body_util::Full;
+
     use super::*;
+    use salvo_core::http::{ResBody, StatusCode};
     use salvo_core::test::{ResponseExt, TestClient};
     use salvo_core::{Router, handler};
 
@@ -372,5 +378,71 @@ mod tests {
             "Hello World"
         );
     }
-}
 
+    #[derive(Clone)]
+    struct NotReadyService;
+
+    impl Service<hyper::Request<ReqBody>> for NotReadyService {
+        type Response = hyper::Response<Full<Bytes>>;
+        type Error = io::Error;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(io::Error::other("not ready")))
+        }
+
+        fn call(&mut self, _req: hyper::Request<ReqBody>) -> Self::Future {
+            ready(Ok(hyper::Response::new(Full::new(Bytes::from_static(
+                b"unused",
+            )))))
+        }
+    }
+
+    #[derive(Clone)]
+    struct FailingService;
+
+    impl Service<hyper::Request<ReqBody>> for FailingService {
+        type Response = hyper::Response<Full<Bytes>>;
+        type Error = io::Error;
+        type Future = Ready<Result<Self::Response, io::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: hyper::Request<ReqBody>) -> Self::Future {
+            ready(Err(io::Error::other("boom")))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tower_service_compat_ready_error_renders_consistent_message() {
+        let mut response = TestClient::get("http://127.0.0.1:8698")
+            .send(NotReadyService.compat())
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::INTERNAL_SERVER_ERROR));
+        let ResBody::Error(error) = response.take_body() else {
+            panic!("expected an error response body");
+        };
+        assert_eq!(error.code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error.cause.as_ref().map(ToString::to_string).as_deref(), Some("tower service not ready"));
+    }
+
+    #[tokio::test]
+    async fn test_tower_service_compat_call_error_renders_consistent_message() {
+        let mut response = TestClient::get("http://127.0.0.1:8698")
+            .send(FailingService.compat())
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::INTERNAL_SERVER_ERROR));
+        let ResBody::Error(error) = response.take_body() else {
+            panic!("expected an error response body");
+        };
+        assert_eq!(error.code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            error.cause.as_ref().map(ToString::to_string).as_deref(),
+            Some("call tower service failed: boom")
+        );
+    }
+}

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -656,6 +656,7 @@ mod tests {
     use salvo_core::conn::{Acceptor, Listener};
     use salvo_core::http::header::*;
     use salvo_core::prelude::*;
+    use salvo_core::test::{ResponseExt, TestClient};
     use salvo_core::rt::tokio::TokioIo;
 
     use super::*;
@@ -751,6 +752,45 @@ mod tests {
         let res = sender.send_request(req).await.unwrap();
 
         assert_eq!(res.status(), StatusCode::SWITCHING_PROTOCOLS);
+    }
+
+    #[tokio::test]
+    async fn test_websocket_missing_connection_upgrade_returns_consistent_message() {
+        let router = Router::new().goal(connect);
+
+        let mut response = TestClient::get("http://127.0.0.1:5801")
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert!(
+            response
+                .take_string()
+                .await
+                .unwrap()
+                .contains("missing connection upgrade")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_websocket_missing_sec_websocket_key_returns_consistent_message() {
+        let router = Router::new().goal(connect);
+
+        let mut response = TestClient::get("http://127.0.0.1:5801")
+            .add_header(UPGRADE, "websocket", true)
+            .add_header(CONNECTION, "Upgrade", true)
+            .add_header(SEC_WEBSOCKET_VERSION, "13", true)
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert!(
+            response
+                .take_string()
+                .await
+                .unwrap()
+                .contains("missing sec-websocket-key header")
+        );
     }
 
     #[tokio::test]
@@ -971,4 +1011,3 @@ mod tests {
         );
     }
 }
-

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -433,6 +433,15 @@ mod tests {
         }
     }
 
+    struct MissingIssuer;
+    impl RateIssuer for MissingIssuer {
+        type Key = String;
+
+        async fn issue(&self, _req: &mut Request, _depot: &Depot) -> Option<Self::Key> {
+            None
+        }
+    }
+
     #[handler]
     async fn limited() -> &'static str {
         "Limited page"
@@ -596,6 +605,31 @@ mod tests {
             .await;
         assert_eq!(response.status_code, Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
+    }
+
+    #[tokio::test]
+    async fn test_missing_identifier_renders_consistent_message() {
+        let limiter = RateLimiter::new(
+            FixedGuard::default(),
+            MokaStore::default(),
+            MissingIssuer,
+            BasicQuota::per_second(1),
+        );
+        let router = Router::new().push(Router::with_path("limited").hoop(limiter).get(limited));
+        let service = Service::new(router);
+
+        let mut response = TestClient::get("http://127.0.0.1:8698/limited")
+            .send(&service)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert!(
+            response
+                .take_string()
+                .await
+                .unwrap()
+                .contains("invalid identifier")
+        );
     }
 
     // Tests for RemoteIpIssuer


### PR DESCRIPTION
## Summary
- add a smoke integration test for salvo-craft
- cover websocket and tower compatibility error paths with message regression tests
- add a rate limiter regression test for missing identifiers

## Testing
- cargo test -p salvo-craft -p salvo_extra -p salvo-rate-limiter