### PR TITLE
Improve documentation examples

### DIFF
--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -17,17 +17,20 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
 //! use salvo_compression::{Compression, CompressionLevel};
 //! use salvo_core::prelude::*;
 //!
+//! #[handler]
+//! async fn hello() -> &'static str {
+//!     "hello"
+//! }
+//!
 //! let compression = Compression::new()
 //!     .enable_gzip(CompressionLevel::Default)
-//!     .min_length(1024);  // Only compress responses > 1KB
+//!     .min_length(1024); // Only compress responses > 1KB
 //!
-//! let router = Router::new()
-//!     .hoop(compression)
-//!     .get(my_handler);
+//! let _router = Router::new().hoop(compression).get(hello);
 //! ```
 //!
 //! # Algorithm Negotiation

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -16,10 +16,17 @@
 //!
 //! Add a default catcher to your service:
 //!
-//! ```ignore
+//! ```no_run
+//! use salvo_core::catcher::Catcher;
 //! use salvo_core::prelude::*;
 //!
-//! let service = Service::new(router).catcher(Catcher::default());
+//! #[handler]
+//! async fn hello() -> &'static str {
+//!     "hello"
+//! }
+//!
+//! let router = Router::new().get(hello);
+//! let _service = Service::new(router).catcher(Catcher::default());
 //! ```
 //!
 //! # Custom Error Handlers
@@ -31,28 +38,38 @@
 //! use salvo_core::prelude::*;
 //!
 //! #[handler]
-//! async fn handle404(&self, res: &mut Response, ctrl: &mut FlowCtrl) {
+//! async fn handle404(res: &mut Response, ctrl: &mut FlowCtrl) {
 //!     if let Some(StatusCode::NOT_FOUND) = res.status_code {
-//!         res.render("Custom 404 Error Page");
-//!         ctrl.skip_rest(); // Skip remaining handlers
+//!         res.render("custom 404 error page");
+//!         ctrl.skip_rest();
 //!     }
 //! }
 //!
-//! #[tokio::main]
-//! async fn main() {
-//!     Service::new(Router::new()).catcher(Catcher::default().hoop(handle404));
-//! }
+//! let _service = Service::new(Router::new()).catcher(Catcher::default().hoop(handle404));
 //! ```
 //!
 //! # Multiple Error Handlers
 //!
 //! Chain multiple handlers for different error types:
 //!
-//! ```ignore
+//! ```
+//! use salvo_core::catcher::Catcher;
+//! use salvo_core::prelude::*;
+//!
+//! #[handler]
+//! async fn handle404(_res: &mut Response) {}
+//!
+//! #[handler]
+//! async fn handle500(_res: &mut Response) {}
+//!
+//! #[handler]
+//! async fn handle_api_errors(_res: &mut Response) {}
+//!
 //! let catcher = Catcher::default()
 //!     .hoop(handle404)
 //!     .hoop(handle500)
 //!     .hoop(handle_api_errors);
+//! let _ = catcher;
 //! ```
 //!
 //! Handlers are called in order. Use [`FlowCtrl::skip_rest()`] to stop processing.

--- a/crates/craft/Cargo.toml
+++ b/crates/craft/Cargo.toml
@@ -21,5 +21,8 @@ authors = ["Andeya Lee <andeyalee@outlook.com>"]
 [dependencies]
 salvo-craft-macros = { workspace = true }
 
+[dev-dependencies]
+salvo = { path = "../salvo", default-features = false, features = ["oapi"] }
+
 [lints]
 workspace = true

--- a/crates/craft/examples/openapi.rs
+++ b/crates/craft/examples/openapi.rs
@@ -1,0 +1,41 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use salvo::oapi::OpenApi;
+use salvo::oapi::extract::QueryParam;
+use salvo::prelude::*;
+use salvo_craft::craft;
+
+#[derive(Clone, Debug)]
+pub struct Calculator {
+    base: i64,
+}
+
+#[craft]
+impl Calculator {
+    #[craft(handler)]
+    fn add(&self, left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (self.base + *left + *right).to_string()
+    }
+
+    #[craft(handler)]
+    fn add_with_arc(self: Arc<Self>, left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (self.base + *left + *right).to_string()
+    }
+
+    #[craft(endpoint)]
+    fn add_plain(left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (*left + *right).to_string()
+    }
+}
+
+fn main() {
+    let calculator = Arc::new(Calculator { base: 1 });
+    let router = Router::new()
+        .push(Router::with_path("add").get(calculator.add()))
+        .push(Router::with_path("add-arc").get(calculator.add_with_arc()))
+        .push(Router::with_path("add-plain").get(Calculator::add_plain()));
+
+    let _doc = OpenApi::new("Craft Example", "0.1.0").merge_router(&router);
+}

--- a/crates/craft/src/lib.rs
+++ b/crates/craft/src/lib.rs
@@ -10,32 +10,33 @@
 //! Instead of writing standalone handler functions, you can organize related
 //! handlers as methods on a struct, with shared state accessible via `self`:
 //!
-//! ```ignore
+//! ```
+//! use salvo::oapi::extract::PathParam;
 //! use salvo::prelude::*;
 //! use salvo_craft::craft;
 //!
-//! #[derive(Clone)]
+//! #[derive(Clone, Debug)]
 //! pub struct UserService {
-//!     db: DatabasePool,
+//!     prefix: &'static str,
 //! }
 //!
 //! #[craft]
 //! impl UserService {
-//!     fn new(db: DatabasePool) -> Self {
-//!         Self { db }
+//!     #[craft(handler)]
+//!     fn get_user(&self, id: PathParam<i64>) -> String {
+//!         format!("{} user {}", self.prefix, *id)
 //!     }
 //!
 //!     #[craft(handler)]
-//!     async fn get_user(&self, id: PathParam<i64>) -> Result<Json<User>, StatusError> {
-//!         let user = self.db.get_user(*id).await?;
-//!         Ok(Json(user))
-//!     }
-//!
-//!     #[craft(handler)]
-//!     async fn list_users(&self) -> Json<Vec<User>> {
-//!         Json(self.db.list_users().await)
+//!     fn list_users(&self) -> &'static str {
+//!         "listing users"
 //!     }
 //! }
+//!
+//! let service = UserService { prefix: "hello" };
+//! let _router = Router::new()
+//!     .push(Router::with_path("users").get(service.list_users()))
+//!     .push(Router::with_path("users/<id>").get(service.get_user()));
 //! ```
 //!
 //! # Usage
@@ -44,14 +45,23 @@
 //!
 //! Use `#[craft(handler)]` to mark a method as a handler:
 //!
-//! ```ignore
+//! ```
+//! use salvo::prelude::*;
+//! use salvo_craft::craft;
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct MyService;
+//!
 //! #[craft]
 //! impl MyService {
 //!     #[craft(handler)]
 //!     fn hello(&self) -> &'static str {
-//!         "Hello, World!"
+//!         "hello, world"
 //!     }
 //! }
+//!
+//! let service = MyService;
+//! let _router = Router::new().get(service.hello());
 //! ```
 //!
 //! ## With OpenAPI Support
@@ -59,14 +69,26 @@
 //! Use `#[craft(endpoint(...))]` for handlers that should be included in
 //! OpenAPI documentation:
 //!
-//! ```ignore
+//! ```
+//! use salvo::oapi::OpenApi;
+//! use salvo::oapi::extract::QueryParam;
+//! use salvo::prelude::*;
+//! use salvo_craft::craft;
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct MyService;
+//!
 //! #[craft]
 //! impl MyService {
 //!     #[craft(endpoint(tags("users"), status_codes(200, 404)))]
-//!     async fn get_user(&self, id: PathParam<i64>) -> Result<Json<User>, StatusError> {
-//!         // ...
+//!     fn get_user(&self, id: QueryParam<i64>) -> String {
+//!         format!("user {}", *id)
 //!     }
 //! }
+//!
+//! let service = MyService;
+//! let router = Router::new().push(Router::with_path("users").get(service.get_user()));
+//! let _doc = OpenApi::new("Craft Example", "0.1.0").merge_router(&router);
 //! ```
 //!
 //! # Method Receivers
@@ -81,36 +103,75 @@
 //!
 //! ## Examples
 //!
-//! ```ignore
-//! #[derive(Clone)]
-//! pub struct Service { /* ... */ }
+//! ```
+//! use std::sync::Arc;
+//!
+//! use salvo::oapi::extract::QueryParam;
+//! use salvo::prelude::*;
+//! use salvo_craft::craft;
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct Service {
+//!     base: i64,
+//! }
 //!
 //! #[craft]
 //! impl Service {
-//!     // Uses &self - Service must be Clone
 //!     #[craft(handler)]
-//!     fn with_ref(&self) -> String { /* ... */ }
+//!     fn with_ref(&self, value: QueryParam<i64>) -> String {
+//!         (self.base + *value).to_string()
+//!     }
 //!
-//!     // Uses Arc<Self> - explicit shared ownership
 //!     #[craft(handler)]
-//!     fn with_arc(self: Arc<Self>) -> String { /* ... */ }
+//!     fn with_arc(self: Arc<Self>, value: QueryParam<i64>) -> String {
+//!         (self.base + *value).to_string()
+//!     }
 //!
-//!     // Static method - no self
 //!     #[craft(handler)]
-//!     fn static_handler() -> String { /* ... */ }
+//!     fn static_handler(value: QueryParam<i64>) -> String {
+//!         value.to_string()
+//!     }
 //! }
+//!
+//! let service = Arc::new(Service { base: 1 });
+//! let _router = Router::new()
+//!     .push(Router::with_path("with-ref").get(service.with_ref()))
+//!     .push(Router::with_path("with-arc").get(service.with_arc()))
+//!     .push(Router::with_path("static").get(Service::static_handler()));
 //! ```
 //!
 //! # Router Integration
 //!
 //! Craft handlers are used with routers just like regular handlers:
 //!
-//! ```ignore
-//! let service = UserService::new(db_pool);
-//!
-//! let router = Router::new()
-//!     .push(Router::with_path("users/<id>").get(service.get_user()))
-//!     .push(Router::with_path("users").get(service.list_users()));
 //! ```
+//! use salvo::prelude::*;
+//! use salvo_craft::craft;
+//!
+//! #[derive(Clone, Debug)]
+//! pub struct UserService;
+//!
+//! #[craft]
+//! impl UserService {
+//!     #[craft(handler)]
+//!     fn list_users(&self) -> &'static str {
+//!         "listing users"
+//!     }
+//!
+//!     #[craft(handler)]
+//!     fn health() -> &'static str {
+//!         "ok"
+//!     }
+//! }
+//!
+//! let service = UserService;
+//! let router = Router::new()
+//!     .push(Router::with_path("users").get(service.list_users()))
+//!     .push(Router::with_path("health").get(UserService::health()));
+//! let _ = router;
+//! ```
+//!
+//! For a complete runnable example with OpenAPI integration, see
+//! `crates/craft/examples/openapi.rs`.
 
 pub use salvo_craft_macros::*;


### PR DESCRIPTION
## Summary
- convert high-value craft, compression, and catcher docs into compile-checked examples
- add a minimal salvo-craft OpenAPI example covering &self, Arc<Self>, and static handlers
- keep the examples aligned with the current API surface instead of placeholder snippets

## Testing
- cargo test -p salvo-craft --doc
- cargo test -p salvo-compression -p salvo_core --doc
- cargo check -p salvo-craft --examples