### PR TITLE
Document message style and doctest checks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,6 +92,9 @@ jobs:
       - name: check release build
         run: cargo check --all --bins --examples --tests --release
 
+      - name: check doctests
+        run: cargo test --workspace --doc
+
       - name: Cargo test
         timeout-minutes: 40
         run: cargo test --all --all-features --no-fail-fast -- --nocapture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Run these commands before opening a pull request:
 cargo +nightly fmt --all -- --check
 cargo check --all --bins --examples --tests
 cargo test --all --all-features --no-fail-fast
+cargo test --workspace --doc
 ```
 
 Nightly-only checks used in CI:
@@ -56,6 +57,14 @@ cargo check --all --bins --examples --tests
 - Add or update tests when behavior changes.
 - Update README files, crate docs, or examples when user-facing behavior changes.
 - Keep feature-gated code compile-tested for both enabled and disabled states.
+
+## Documentation And Message Style
+
+- Prefer compile-checked examples over `ignore` blocks. Use `no_run` when the snippet needs a real network listener or other runtime setup but should still compile.
+- Keep examples aligned with the current API surface. If an example needs too much placeholder context, simplify it instead of leaving stale code in docs.
+- Write custom error, log, `panic!`, and `expect!` messages in the same style used across the Rust ecosystem: sentence starts lowercase and normally has no trailing period.
+- Prefer direct, grammatical wording that explains what is missing or why the operation failed.
+- Do not mechanically rewrite standardized protocol text such as HTTP reason phrases, RFC terms, or other externally defined wire-format strings.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- add a short contributor guideline for diagnostic message wording and compile-checked docs
- include cargo test --workspace --doc in the local check list
- add an explicit doctest step to the Linux CI workflow

## Testing
- cargo test --workspace --doc