### PR TITLE
Add path filter handling for invalid patterns and try_with_path method

### DIFF
--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -132,9 +132,22 @@ pub fn port(port: u16) -> PortFilter {
 }
 
 /// Filter request use `PathFilter`.
+///
+/// Invalid path patterns are logged and converted into a filter that never matches.
+/// Use [`try_path`] to handle malformed patterns explicitly.
 #[inline]
 pub fn path(path: impl Into<String>) -> PathFilter {
     PathFilter::new(path)
+}
+
+/// Try building a `PathFilter`.
+///
+/// # Errors
+///
+/// Returns an error when the path pattern is malformed.
+#[inline]
+pub fn try_path(path: impl Into<String>) -> Result<PathFilter, String> {
+    PathFilter::try_new(path)
 }
 /// Filter request, only allow get method.
 #[inline]

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -42,6 +42,8 @@ static WISP_BUILDERS: LazyLock<WispBuilderMap> = LazyLock::new(|| {
     map.insert("hex".into(), Arc::new(CharsWispBuilder::new(is_hex)));
     RwLock::new(map)
 });
+static NEVER_MATCH_PATH_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("^$").expect("path filter fallback regex should compile"));
 
 #[inline]
 fn is_num(ch: char) -> bool {
@@ -1024,10 +1026,8 @@ impl Filter for PathFilter {
     }
 }
 impl PathFilter {
-    /// Create new `PathFilter`.
     #[inline]
-    pub fn new(value: impl Into<String>) -> Self {
-        let raw_value = value.into();
+    fn parse(raw_value: String) -> Result<Self, String> {
         if raw_value.is_empty() {
             tracing::warn!("you should not add empty string as path filter");
         } else if raw_value == "/" {
@@ -1037,14 +1037,55 @@ impl PathFilter {
         let path_wisps = match parser.parse() {
             Ok(path_wisps) => path_wisps,
             Err(e) => {
-                panic!("{e}, raw_value: {raw_value}");
+                return Err(format!("{e}, raw_value: {raw_value}"));
             }
         };
-        Self {
+        Ok(Self {
             raw_value,
             path_wisps,
+        })
+    }
+
+    #[inline]
+    fn invalid(raw_value: String) -> Self {
+        Self {
+            raw_value,
+            path_wisps: vec![
+                RegexWisp {
+                    name: "__salvo_invalid_path_filter".into(),
+                    regex: NEVER_MATCH_PATH_REGEX.clone(),
+                }
+                .into(),
+            ],
         }
     }
+
+    /// Create new `PathFilter`.
+    ///
+    /// Invalid path patterns are logged and converted into a filter that never matches.
+    /// Use [`PathFilter::try_new`] to handle malformed patterns explicitly.
+    #[inline]
+    pub fn new(value: impl Into<String>) -> Self {
+        let raw_value = value.into();
+        match Self::parse(raw_value.clone()) {
+            Ok(filter) => filter,
+            Err(error) => {
+                tracing::error!(error = %error, "invalid path filter pattern");
+                Self::invalid(raw_value)
+            }
+        }
+    }
+
+    /// Try creating new `PathFilter`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the path pattern is malformed.
+    #[inline]
+    pub fn try_new(value: impl Into<String>) -> Result<Self, String> {
+        Self::parse(value.into())
+    }
+
     /// Register new path wisp builder.
     #[inline]
     pub fn register_wisp_builder<B>(name: impl Into<String>, builder: B)
@@ -1407,5 +1448,30 @@ mod tests {
             state.matched_parts,
             vec!["users".to_owned(), "{id}".to_owned(), "{*?rest}".to_owned()]
         );
+    }
+
+    #[test]
+    fn test_try_new_invalid_pattern_returns_err() {
+        let payload = [
+            0x2f, 0x75, 0x73, 0xe5, 0x72, 0x73, 0x2f, 0x3c, 0x01, 0x00, 0x7d, 0x06, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x0a,
+        ];
+        let pattern = String::from_utf8_lossy(&payload);
+        let error = PathFilter::try_new(pattern.as_ref()).unwrap_err();
+        assert!(error.contains("const part is empty string"));
+    }
+
+    #[test]
+    fn test_new_invalid_pattern_never_matches() {
+        let payload = [
+            0x2f, 0x75, 0x73, 0xe5, 0x72, 0x73, 0x2f, 0x3c, 0x01, 0x00, 0x7d, 0x06, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x0a,
+        ];
+        let pattern = String::from_utf8_lossy(&payload);
+        let filter = std::panic::catch_unwind(|| PathFilter::new(pattern.as_ref()))
+            .expect("PathFilter::new should not panic on malformed patterns");
+
+        let mut state = PathState::new("/users/29/emails");
+        assert!(!filter.detect(&mut state));
     }
 }

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -214,24 +214,42 @@ impl Router {
 
     /// Create a new router and set path filter.
     ///
-    /// # Panics
-    ///
-    /// Panics if path value is not in correct format.
+    /// Invalid path patterns are logged and converted into a filter that never matches.
+    /// Use [`Router::try_with_path`] to handle malformed patterns explicitly.
     #[inline]
     #[must_use]
     pub fn with_path(path: impl Into<String>) -> Self {
         Self::with_filter(PathFilter::new(path))
     }
 
+    /// Try creating a new router and set path filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the path pattern is malformed.
+    #[inline]
+    pub fn try_with_path(path: impl Into<String>) -> Result<Self, String> {
+        Ok(Self::with_filter(PathFilter::try_new(path)?))
+    }
+
     /// Create a new path filter for current router.
     ///
-    /// # Panics
-    ///
-    /// Panics if path value is not in correct format.
+    /// Invalid path patterns are logged and converted into a filter that never matches.
+    /// Use [`Router::try_path`] to handle malformed patterns explicitly.
     #[inline]
     #[must_use]
     pub fn path(self, path: impl Into<String>) -> Self {
         self.filter(PathFilter::new(path))
+    }
+
+    /// Try creating a new path filter for current router.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the path pattern is malformed.
+    #[inline]
+    pub fn try_path(self, path: impl Into<String>) -> Result<Self, String> {
+        Ok(self.filter(PathFilter::try_new(path)?))
     }
 
     /// Create a new router and set filter.


### PR DESCRIPTION
This pull request improves how invalid path patterns are handled in routing filters, making the API safer and preventing panics from malformed patterns. Now, invalid patterns are logged and result in filters that never match, and new `try_*` methods allow explicit error handling. Additional tests ensure the new behavior works as intended.

**Path filter error handling improvements:**

* `PathFilter::new` no longer panics on malformed patterns; instead, it logs the error and creates a filter that never matches.
* Added `PathFilter::try_new`, which returns a `Result` and allows callers to handle errors explicitly.
* Introduced a static regex (`NEVER_MATCH_PATH_REGEX`) to ensure invalid filters never match any path.
* Updated documentation and API for `path` filter functions to reflect the new error handling and provide `try_path` variants. [[1]](diffhunk://#diff-ccc992b1685481a3114133644c6d0a74649f55c715e8a3b79fc729112182ed72R135-R151) [[2]](diffhunk://#diff-46b67cf6c72d84b8760f8d6056b087be4ae83605f8ec0c471226b3b2ebb0ec00L217-R254)

**Router API enhancements:**

* Added `Router::try_with_path` and `Router::try_path` methods for explicit error handling when setting path filters.

**Testing:**

* Added tests to verify that invalid patterns return errors with `try_new` and that `new` produces a filter that never matches instead of panicking.