### PR TITLE
fix: require OIDC issuer and audience validation

### DIFF
--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -213,6 +213,11 @@ pub enum JwtAuthError {
     #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
     #[error("Failed to load native root certificates for OIDC HTTP client: {0}")]
     NativeRootCerts(String),
+    /// OIDC audience must be configured.
+    #[cfg(feature = "oidc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
+    #[error("OIDC audience must be configured")]
+    MissingOidcAudience,
     /// Decoding of JWKS error
     #[error("Decoding of JWKS error")]
     DecodeError(#[from] base64::DecodeError),

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -164,13 +164,14 @@ where
                 validation,
                 audiences,
             } = self;
-            let issuer = issuer.as_ref().trim_end_matches('/').to_owned();
+            let raw_issuer = issuer.as_ref();
 
             //Create an empty JWKS to initialize our Cache
             let jwks = JwkSet { keys: Vec::new() };
 
             let validation =
-                configure_oidc_validation(validation.unwrap_or_default(), &issuer, audiences)?;
+                configure_oidc_validation(validation.unwrap_or_default(), raw_issuer, audiences)?;
+            let issuer = raw_issuer.trim_end_matches('/').to_owned();
             let cache = Arc::new(RwLock::new(JwkSetStore::new(
                 jwks,
                 CachePolicy::default(),
@@ -563,5 +564,28 @@ mod tests {
         );
         assert!(validation.required_spec_claims.contains("iss"));
         assert!(validation.required_spec_claims.contains("aud"));
+    }
+
+    #[test]
+    fn test_oidc_validation_preserves_trailing_slash_issuer() {
+        let validation = configure_oidc_validation(
+            Validation::default(),
+            "https://issuer.example/",
+            Some(vec!["client-id".to_owned()]),
+        )
+        .unwrap();
+
+        assert!(
+            validation
+                .iss
+                .as_ref()
+                .is_some_and(|iss| iss.contains("https://issuer.example/"))
+        );
+        assert!(
+            validation
+                .iss
+                .as_ref()
+                .is_some_and(|iss| !iss.contains("https://issuer.example"))
+        );
     }
 }

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -98,12 +98,15 @@ where
     pub http_client: Option<HyperClient>,
     /// The validation options for the decoder.
     pub validation: Option<Validation>,
+    /// The expected OIDC token audiences.
+    pub audiences: Option<Vec<String>>,
 }
 impl<T: AsRef<str>> Debug for DecoderBuilder<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("DecoderBuilder")
             .field("http_client", &self.http_client)
             .field("validation", &self.validation)
+            .field("audiences", &self.audiences)
             .finish()
     }
 }
@@ -118,6 +121,7 @@ where
             issuer,
             http_client: None,
             validation: None,
+            audiences: None,
         }
     }
     /// Set the http client for the decoder.
@@ -133,6 +137,24 @@ where
         self
     }
 
+    /// Set the expected OIDC token audience.
+    #[must_use]
+    pub fn audience(mut self, audience: impl Into<String>) -> Self {
+        self.audiences = Some(vec![audience.into()]);
+        self
+    }
+
+    /// Set the expected OIDC token audiences.
+    #[must_use]
+    pub fn audiences<I, S>(mut self, audiences: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.audiences = Some(audiences.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Build a `OidcDecoder`.
     pub fn build(self) -> impl Future<Output = Result<OidcDecoder, JwtAuthError>> {
         async move {
@@ -140,13 +162,15 @@ where
                 issuer,
                 http_client,
                 validation,
+                audiences,
             } = self;
             let issuer = issuer.as_ref().trim_end_matches('/').to_owned();
 
             //Create an empty JWKS to initialize our Cache
             let jwks = JwkSet { keys: Vec::new() };
 
-            let validation = validation.unwrap_or_default();
+            let validation =
+                configure_oidc_validation(validation.unwrap_or_default(), &issuer, audiences)?;
             let cache = Arc::new(RwLock::new(JwkSetStore::new(
                 jwks,
                 CachePolicy::default(),
@@ -169,8 +193,11 @@ where
 
 impl OidcDecoder {
     /// Create a new `OidcDecoder`.
-    pub fn new(issuer: impl AsRef<str>) -> impl Future<Output = Result<Self, JwtAuthError>> {
-        Self::builder(issuer).build()
+    pub fn new(
+        issuer: impl AsRef<str>,
+        audience: impl Into<String>,
+    ) -> impl Future<Output = Result<Self, JwtAuthError>> {
+        Self::builder(issuer).audience(audience).build()
     }
 
     /// Create a new `DecoderBuilder`.
@@ -328,6 +355,33 @@ impl OidcDecoder {
     }
 }
 
+fn configure_oidc_validation(
+    mut validation: Validation,
+    issuer: &str,
+    audiences: Option<Vec<String>>,
+) -> Result<Validation, JwtAuthError> {
+    if validation.iss.is_none() {
+        validation.set_issuer(&[issuer]);
+    }
+    validation.required_spec_claims.insert("iss".to_owned());
+
+    if let Some(audiences) = audiences {
+        if audiences.is_empty() {
+            return Err(JwtAuthError::MissingOidcAudience);
+        }
+        validation.set_audience(&audiences);
+        validation.validate_aud = true;
+    }
+    if validation.validate_aud {
+        if validation.aud.is_none() {
+            return Err(JwtAuthError::MissingOidcAudience);
+        }
+        validation.required_spec_claims.insert("aud".to_owned());
+    }
+
+    Ok(validation)
+}
+
 /// Struct used to store the computed information needed to decode a JWT
 /// Intended to be cached inside of [`JwkSetStore`] to prevent decoding information about the same JWK more than once
 pub struct DecodingInfo {
@@ -350,11 +404,14 @@ impl DecodingInfo {
         validation.aud.clone_from(&validation_settings.aud);
         validation.iss.clone_from(&validation_settings.iss);
         validation.leeway = validation_settings.leeway;
+        validation.reject_tokens_expiring_in_less_than =
+            validation_settings.reject_tokens_expiring_in_less_than;
         validation
             .required_spec_claims
             .clone_from(&validation_settings.required_spec_claims);
 
         validation.sub.clone_from(&validation_settings.sub);
+        validation.validate_aud = validation_settings.validate_aud;
         validation.validate_exp = validation_settings.validate_exp;
         validation.validate_nbf = validation_settings.validate_nbf;
 
@@ -452,10 +509,11 @@ mod tests {
 
     #[test]
     fn test_uses_provided_http_client_without_building_default_client() {
-        let resolved = resolve_or_else(Some("provided-client"), || -> Result<&str, JwtAuthError> {
-            panic!("default HTTP client should not be built when a custom client is supplied")
-        })
-        .unwrap();
+        let resolved =
+            resolve_or_else(Some("provided-client"), || -> Result<&str, JwtAuthError> {
+                panic!("default HTTP client should not be built when a custom client is supplied")
+            })
+            .unwrap();
 
         assert_eq!(resolved, "provided-client");
     }
@@ -472,5 +530,38 @@ mod tests {
         let validation = Validation::new(Algorithm::RS256);
         let result = decode_jwk(&jwk, &validation);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_oidc_validation_requires_audience() {
+        let result =
+            configure_oidc_validation(Validation::default(), "https://issuer.example", None);
+
+        assert!(matches!(result, Err(JwtAuthError::MissingOidcAudience)));
+    }
+
+    #[test]
+    fn test_oidc_validation_sets_issuer_and_audience_claims() {
+        let validation = configure_oidc_validation(
+            Validation::default(),
+            "https://issuer.example",
+            Some(vec!["client-id".to_owned()]),
+        )
+        .unwrap();
+
+        assert!(
+            validation
+                .iss
+                .as_ref()
+                .is_some_and(|iss| iss.contains("https://issuer.example"))
+        );
+        assert!(
+            validation
+                .aud
+                .as_ref()
+                .is_some_and(|aud| aud.contains("client-id"))
+        );
+        assert!(validation.required_spec_claims.contains("iss"));
+        assert!(validation.required_spec_claims.contains("aud"));
     }
 }

--- a/examples/jwt-oidc-clerk/README.md
+++ b/examples/jwt-oidc-clerk/README.md
@@ -13,6 +13,6 @@ This repository shows how to use [Clerk](https://clerk.dev?utm_source=github&utm
 echo "VITE_CLERK_PUBLISHABLE_KEY=CLERK_PUBLISHABLE_KEY" >> app/.env.local
 ```
 
-5. Run `cargo run`
-6. Run the app: `cd app && npm run dev`
-
+5. Set `CLERK_JWT_AUDIENCE` to the audience configured for the Clerk JWT template.
+6. Run `cargo run`
+7. Run the app: `cd app && npm run dev`

--- a/examples/jwt-oidc-clerk/src/main.rs
+++ b/examples/jwt-oidc-clerk/src/main.rs
@@ -5,6 +5,7 @@ use salvo::proxy::HyperClient;
 use serde::{Deserialize, Serialize};
 
 const ISSUER_URL: &str = "https://coherent-gopher-0.clerk.accounts.dev";
+const AUDIENCE_ENV: &str = "CLERK_JWT_AUDIENCE";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct JwtClaims {
@@ -17,7 +18,11 @@ pub struct JwtClaims {
 async fn main() {
     tracing_subscriber::fmt().init();
 
-    let decoder = OidcDecoder::new(ISSUER_URL.to_owned()).await.unwrap();
+    let audience =
+        std::env::var(AUDIENCE_ENV).expect("CLERK_JWT_AUDIENCE must match the JWT audience");
+    let decoder = OidcDecoder::new(ISSUER_URL.to_owned(), audience)
+        .await
+        .unwrap();
     let auth_handler: JwtAuth<JwtClaims, OidcDecoder> = JwtAuth::new(decoder)
         .finders(vec![Box::new(HeaderFinder::new())])
         .force_passed(true);


### PR DESCRIPTION
This pull request introduces support for configuring and validating OIDC token audiences in the JWT authentication library, improves error handling for missing audience configuration, and updates the Clerk OIDC example to require explicit audience configuration. The changes ensure that OIDC validation is more robust and that consumers of the library are guided to provide the necessary audience claim for secure JWT validation.

**OIDC Audience Configuration and Validation:**

- Added an `audiences` field to the `DecoderBuilder` and provided new builder methods (`audience`, `audiences`) to set expected OIDC token audiences. The builder now enforces that an audience is provided when constructing an `OidcDecoder`. [[1]](diffhunk://#diff-7523910f6929585f78c3f1fbff5544ab46a3a1e97988f7f6a8504571c6c5a3d1R101-R109) [[2]](diffhunk://#diff-7523910f6929585f78c3f1fbff5544ab46a3a1e97988f7f6a8504571c6c5a3d1R140-R173) [[3]](diffhunk://#diff-7523910f6929585f78c3f1fbff5544ab46a3a1e97988f7f6a8504571c6c5a3d1L172-R200)
- Introduced the `configure_oidc_validation` function to centralize audience and issuer claim validation logic, ensuring that the audience claim is required and properly set.
- Added a new error variant `MissingOidcAudience` to `JwtAuthError` to provide clear error messages when the audience is not configured.

**Example and Documentation Updates:**

- Updated the Clerk OIDC example (`examples/jwt-oidc-clerk`) to require the `CLERK_JWT_AUDIENCE` environment variable and to pass the audience to `OidcDecoder::new`, ensuring correct configuration in example usage. [[1]](diffhunk://#diff-f8d3daf9ed8962e87c8971f2b983cb8ad6b846f393781f7bc8fc779d711c17d8R8) [[2]](diffhunk://#diff-f8d3daf9ed8962e87c8971f2b983cb8ad6b846f393781f7bc8fc779d711c17d8L20-R25) [[3]](diffhunk://#diff-5b81485f5e0f3c51520b51e004aaf699ddb99125581d7ca2eb4bbc62d220b94bL16-R18)

**Testing Improvements:**

- Added tests for audience validation logic, including checks for missing and correctly set audience and issuer claims.