### PR TITLE
feat: implement atomic guard verification in MokaStore

### DIFF
--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -262,15 +262,40 @@ pub trait RateGuard: Clone + Send + Sync + 'static {
     fn limit(&self, quota: &Self::Quota) -> impl Future<Output = usize> + Send;
 }
 
+/// Result of a rate limit verification.
+#[derive(Debug, Clone)]
+pub struct RateLimitState<G> {
+    /// Whether the current request is allowed.
+    pub allowed: bool,
+    /// The guard state after verification.
+    pub guard: G,
+}
+
 /// `RateStore` is used to store rate limit data.
 pub trait RateStore: Send + Sync + 'static {
     /// Error type for RateStore.
     type Error: StdError;
     /// Key
-    type Key: Hash + Eq + Send + Clone + 'static;
+    type Key: Hash + Eq + Send + Sync + Clone + 'static;
     /// Saved guard.
-    type Guard;
+    type Guard: RateGuard;
+
+    /// Atomically verify and update the guard for the given key.
+    ///
+    /// Store implementations should keep loading the current guard, calling
+    /// [`RateGuard::verify`], and saving the updated guard in the same atomic
+    /// domain for each key.
+    fn verify_guard(
+        &self,
+        key: Self::Key,
+        refer: &Self::Guard,
+        quota: &<Self::Guard as RateGuard>::Quota,
+    ) -> impl Future<Output = Result<RateLimitState<Self::Guard>, Self::Error>> + Send;
+
     /// Get the guard from the store.
+    ///
+    /// This is a low-level operation. Quota enforcement should use
+    /// [`RateStore::verify_guard`] so verification and update can be atomic.
     fn load_guard<Q>(
         &self,
         key: &Q,
@@ -280,6 +305,9 @@ pub trait RateStore: Send + Sync + 'static {
         Self::Key: Borrow<Q>,
         Q: Hash + Eq + Sync;
     /// Save the guard from the store.
+    ///
+    /// This is a low-level operation. Quota enforcement should use
+    /// [`RateStore::verify_guard`] so verification and update can be atomic.
     fn save_guard(
         &self,
         key: Self::Key,
@@ -379,8 +407,8 @@ where
                 return;
             }
         };
-        let mut guard = match self.store.load_guard(&key, &self.guard).await {
-            Ok(guard) => guard,
+        let state = match self.store.verify_guard(key, &self.guard, &quota).await {
+            Ok(state) => state,
             Err(e) => {
                 tracing::error!(error = ?e, "rate limiter error: {}", e);
                 res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
@@ -388,7 +416,8 @@ where
                 return;
             }
         };
-        let verified = guard.verify(&quota).await;
+        let guard = state.guard;
+        let verified = state.allowed;
 
         if self.add_headers {
             res.headers_mut().insert(
@@ -407,9 +436,6 @@ where
         if !verified {
             res.status_code(StatusCode::TOO_MANY_REQUESTS);
             ctrl.skip_rest();
-        }
-        if let Err(e) = self.store.save_guard(key, guard).await {
-            tracing::error!(error = ?e, "rate limiter save guard failed");
         }
     }
 }

--- a/crates/rate-limiter/src/moka_store.rs
+++ b/crates/rate-limiter/src/moka_store.rs
@@ -1,10 +1,13 @@
 use std::borrow::Borrow;
 use std::convert::Infallible;
 use std::hash::Hash;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use moka::future::Cache as MokaCache;
+use moka::ops::compute;
 
-use super::{RateGuard, RateStore};
+use super::{RateGuard, RateLimitState, RateStore};
 
 /// A simple in-memory store for rate limiter.
 #[derive(Debug)]
@@ -46,6 +49,36 @@ where
     type Key = K;
     type Guard = G;
 
+    async fn verify_guard(
+        &self,
+        key: Self::Key,
+        refer: &Self::Guard,
+        quota: &<Self::Guard as RateGuard>::Quota,
+    ) -> Result<RateLimitState<Self::Guard>, Self::Error> {
+        let allowed = Arc::new(AtomicBool::new(false));
+        let allowed_in_compute = Arc::clone(&allowed);
+        let refer = refer.clone();
+
+        let result = self
+            .inner
+            .entry(key)
+            .and_compute_with(|entry| async move {
+                let mut guard = entry.map_or(refer, |entry| entry.into_value());
+                let verified = guard.verify(quota).await;
+                allowed_in_compute.store(verified, Ordering::Relaxed);
+                compute::Op::Put(guard)
+            })
+            .await;
+
+        let Some(entry) = result.into_entry() else {
+            unreachable!("MokaStore verify_guard always stores an updated guard");
+        };
+        Ok(RateLimitState {
+            allowed: allowed.load(Ordering::Relaxed),
+            guard: entry.into_value(),
+        })
+    }
+
     async fn load_guard<Q>(&self, key: &Q, refer: &Self::Guard) -> Result<Self::Guard, Self::Error>
     where
         Self::Key: Borrow<Q>,
@@ -62,5 +95,45 @@ where
     async fn save_guard(&self, key: Self::Key, guard: Self::Guard) -> Result<(), Self::Error> {
         self.inner.insert(key, guard).await;
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "fixed-guard"))]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::{BasicQuota, FixedGuard};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn verify_guard_enforces_fixed_limit_concurrently() {
+        let store = Arc::new(MokaStore::<String, FixedGuard>::default());
+        let quota = Arc::new(BasicQuota::per_second(10));
+        let refer = Arc::new(FixedGuard::new());
+        let allowed_count = Arc::new(AtomicUsize::new(0));
+        let key = "shared_client".to_owned();
+
+        let mut handles = Vec::new();
+        for _ in 0..30 {
+            let store = Arc::clone(&store);
+            let quota = Arc::clone(&quota);
+            let refer = Arc::clone(&refer);
+            let allowed_count = Arc::clone(&allowed_count);
+            let key = key.clone();
+
+            handles.push(tokio::spawn(async move {
+                let state = store.verify_guard(key, &refer, &quota).await.unwrap();
+                if state.allowed {
+                    allowed_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(allowed_count.load(Ordering::SeqCst), 10);
     }
 }


### PR DESCRIPTION
This pull request introduces an atomic rate limit verification API to the rate limiter subsystem, ensuring that rate limit checks and updates are performed atomically within the store implementation. The main changes include the addition of a new `verify_guard` method to the `RateStore` trait, a new result type for verification, and a refactor of the Moka-based in-memory store to support atomic verification. Tests are also added to verify correct concurrent behavior.

**API and Trait Changes:**

* Added a new struct `RateLimitState<G>` to represent the result of a rate limit verification, including whether the request is allowed and the updated guard state.
* Extended the `RateStore` trait with a new `verify_guard` method, which atomically verifies and updates the guard for a given key, and updated trait bounds to require `RateGuard` for the guard type. Documentation was added to clarify the atomicity requirements.
* Marked `load_guard` and `save_guard` as low-level operations, recommending `verify_guard` for quota enforcement to ensure atomicity.

**Implementation Changes:**

* Refactored the main rate limiter logic to use the new `verify_guard` API, simplifying the control flow and ensuring atomic verification and update of the guard. [[1]](diffhunk://#diff-940cf38f866420a8f0ad1ff1d176eeb14d325b9a01dcb0884d4bf0fd3e42e5d5L382-R420) [[2]](diffhunk://#diff-940cf38f866420a8f0ad1ff1d176eeb14d325b9a01dcb0884d4bf0fd3e42e5d5L411-L413)
* Updated the `MokaStore` implementation to provide an atomic `verify_guard` method using Moka's `and_compute_with` API, ensuring correct concurrent behavior.

**Testing:**

* Added a concurrent test for the `verify_guard` method in `MokaStore` to ensure that the rate limit is enforced correctly under concurrent access.