### PR TITLE
Fix tus disk store path validation

### DIFF
--- a/crates/tus/Cargo.toml
+++ b/crates/tus/Cargo.toml
@@ -33,5 +33,6 @@ chrono        = { workspace = true }
 tracing       = { workspace = true }
 
 [dev-dependencies]
+salvo_core    = { workspace = true, features = ["test"] }
 tempfile      = { workspace = true }
 tokio         = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -115,7 +115,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         }
     };
     if !is_safe_upload_id(&upload_id) {
-        res.status_code = Some(TusError::GenerateIdError.status());
+        res.status_code = Some(TusError::FileIdError.status());
         return;
     }
 

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -7,7 +7,7 @@ use salvo_core::{Depot, Request, Response, Router, handler};
 use crate::error::{ProtocolError, TusError};
 use crate::handlers::{Metadata, apply_common_headers};
 use crate::stores::{Extension, UploadInfo};
-use crate::utils::{check_tus_version, parse_u64};
+use crate::utils::{check_tus_version, is_safe_upload_id, parse_u64};
 use crate::{
     CT_OFFSET_OCTET_STREAM, CancellationContext, H_CONTENT_LENGTH, H_CONTENT_TYPE, H_TUS_RESUMABLE,
     H_TUS_VERSION, H_UPLOAD_CONCAT, H_UPLOAD_DEFER_LENGTH, H_UPLOAD_EXPIRES, H_UPLOAD_LENGTH,
@@ -114,6 +114,10 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             return;
         }
     };
+    if !is_safe_upload_id(&upload_id) {
+        res.status_code = Some(TusError::GenerateIdError.status());
+        return;
+    }
 
     let upload_length_value = match upload_length {
         Some(value) => match value.to_str() {

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -613,6 +613,27 @@ mod tests {
         assert_eq!(result.unwrap(), "custom-id");
     }
 
+    #[tokio::test]
+    async fn test_tus_rejects_unsafe_generated_upload_id_as_bad_request() {
+        use salvo_core::Service;
+        use salvo_core::http::StatusCode;
+        use salvo_core::test::TestClient;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let tus = Tus::new()
+            .with_store(stores::DiskStore::new().disk_root(temp_dir.path()))
+            .with_upload_id_naming_function(|_req, _meta| async move { Ok("file.txt".to_owned()) });
+        let service = Service::new(tus.into_router());
+
+        let response = TestClient::post("http://localhost/tus-files")
+            .add_header(H_TUS_RESUMABLE, TUS_VERSION, true)
+            .add_header(H_UPLOAD_LENGTH, "0", true)
+            .send(&service)
+            .await;
+
+        assert_eq!(response.status_code.unwrap(), StatusCode::BAD_REQUEST);
+    }
+
     #[test]
     fn test_tus_with_generate_url_function() {
         let tus = Tus::new().with_generate_url_function(|_req, ctx| {

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -11,6 +11,7 @@ use crate::error::{TusError, TusResult};
 use crate::handlers::{GenerateUrlCtx, HostProto, Metadata};
 use crate::lockers::{LockGuard, Locker, memory_locker};
 use crate::stores::UploadInfo;
+use crate::utils::is_safe_upload_id;
 
 pub type UploadId = Option<String>;
 
@@ -159,6 +160,7 @@ impl TusOptions {
         re.captures(path)
             .and_then(|caps| caps.get(1))
             .map(|m| m.as_str().to_owned())
+            .filter(|id| is_safe_upload_id(id))
             .ok_or(TusError::FileIdError)
     }
 
@@ -415,6 +417,26 @@ mod tests {
         // Single segment
         let captures = re.captures("/simple").unwrap();
         assert_eq!(captures.get(1).unwrap().as_str(), "simple");
+    }
+
+    #[test]
+    fn test_get_file_id_from_request_rejects_unsafe_id() {
+        let options = TusOptions::default();
+        let mut req = Request::default();
+        *req.uri_mut() = "/uploads/file.txt".parse().unwrap();
+
+        let result = options.get_file_id_from_request(&req);
+        assert!(matches!(result, Err(TusError::FileIdError)));
+    }
+
+    #[test]
+    fn test_get_file_id_from_request_accepts_safe_id() {
+        let options = TusOptions::default();
+        let mut req = Request::default();
+        *req.uri_mut() = "/uploads/abc-123_DEF".parse().unwrap();
+
+        let result = options.get_file_id_from_request(&req).unwrap();
+        assert_eq!(result, "abc-123_DEF");
     }
 
     #[test]

--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use salvo_core::async_trait;
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ use crate::handlers::Metadata;
 use crate::stores::{
     ByteStream, DataStore, Extension, StoreInfo, UploadInfo, is_upload_size_limit_error,
 };
-use crate::utils::sanitize_path_component;
+use crate::utils::{is_safe_upload_id, sanitize_path_component};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MetaStoreInfo {
@@ -113,11 +113,113 @@ impl DiskStore {
         self.root.join(format!("{id}.json.tmp"))
     }
 
+    fn ensure_safe_upload_id(id: &str) -> TusResult<()> {
+        if is_safe_upload_id(id) {
+            Ok(())
+        } else {
+            Err(TusError::FileIdError)
+        }
+    }
+
+    fn absolute_normalized_path(path: &Path) -> Option<PathBuf> {
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+                Component::RootDir => normalized.push(component.as_os_str()),
+                Component::CurDir => {}
+                Component::Normal(part) => normalized.push(part),
+                Component::ParentDir => {
+                    if !normalized.pop() {
+                        return None;
+                    }
+                }
+            }
+        }
+        Some(normalized)
+    }
+
+    fn path_is_within_root(&self, path: &Path) -> bool {
+        let Some(root) = Self::absolute_normalized_path(&self.root) else {
+            return false;
+        };
+        let Some(path) = Self::absolute_normalized_path(path) else {
+            return false;
+        };
+        path.starts_with(root)
+    }
+
     fn resolve_data_path(&self, id: &str, storage: &Option<MetaStoreInfo>) -> PathBuf {
-        storage
+        if let Some(path) = storage
             .as_ref()
             .map(|info| PathBuf::from(&info.path))
-            .unwrap_or_else(|| self.data_path(id))
+            .filter(|path| self.path_is_within_root(path))
+        {
+            path
+        } else {
+            if storage.is_some() {
+                warn!("ignored unsafe tus disk storage path: id={id}");
+            }
+            self.data_path(id)
+        }
+    }
+
+    async fn existing_path_is_within_root(&self, path: &Path) -> bool {
+        if !self.path_is_within_root(path) {
+            return false;
+        }
+
+        let metadata = match fs::symlink_metadata(path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return true,
+            Err(_) => return false,
+        };
+        if metadata.file_type().is_symlink() {
+            return false;
+        }
+
+        let Ok(root) = fs::canonicalize(&self.root).await else {
+            return false;
+        };
+        let Ok(path) = fs::canonicalize(path).await else {
+            return false;
+        };
+        path.starts_with(root)
+    }
+
+    async fn resolve_existing_data_path(
+        &self,
+        id: &str,
+        storage: &Option<MetaStoreInfo>,
+    ) -> TusResult<PathBuf> {
+        let path = self.resolve_data_path(id, storage);
+        if self.existing_path_is_within_root(&path).await {
+            return Ok(path);
+        }
+
+        let fallback = self.data_path(id);
+        if fallback != path && self.existing_path_is_within_root(&fallback).await {
+            warn!("fell back from unsafe tus disk storage path: id={id}");
+            return Ok(fallback);
+        }
+
+        Err(TusError::Internal("unsafe disk storage path".into()))
+    }
+
+    async fn resolve_meta_data_path(&self, meta: &mut MetaUpload) -> TusResult<PathBuf> {
+        let path = self
+            .resolve_existing_data_path(&meta.id, &meta.storage)
+            .await?;
+        if let Some(storage) = &mut meta.storage {
+            storage.path = path.to_string_lossy().into_owned();
+        }
+        Ok(path)
     }
 
     fn metadata_value(meta: &MetaUpload, key: &str) -> Option<String> {
@@ -191,7 +293,16 @@ impl DiskStore {
             return;
         };
 
-        let current_path = self.resolve_data_path(&meta.id, &meta.storage);
+        let current_path = match self.resolve_meta_data_path(meta).await {
+            Ok(path) => path,
+            Err(err) => {
+                warn!(
+                    "finalize upload path validation failed: id={}, error={}",
+                    meta.id, err
+                );
+                return;
+            }
+        };
         let dir = current_path.parent().unwrap_or(self.root.as_path());
         let mut target_path = dir.join(&file_name);
         if target_path == current_path {
@@ -271,18 +382,17 @@ impl DataStore for DiskStore {
     }
 
     async fn create(&self, file: UploadInfo) -> TusResult<UploadInfo> {
+        Self::ensure_safe_upload_id(&file.id)?;
         self.ensure_root().await?;
 
-        let mut file = file;
-        if file.storage.is_none() {
-            file.storage = Some(StoreInfo {
-                type_name: "file".to_owned(),
-                path: self.data_path(&file.id).to_string_lossy().into_owned(),
-                bucket: None,
-            });
-        }
-
         let data_path = self.data_path(&file.id);
+        let mut file = file;
+        file.storage = Some(StoreInfo {
+            type_name: "file".to_owned(),
+            path: data_path.to_string_lossy().into_owned(),
+            bucket: None,
+        });
+
         fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -301,11 +411,12 @@ impl DataStore for DiskStore {
     }
 
     async fn remove(&self, id: &str) -> TusResult<()> {
+        Self::ensure_safe_upload_id(id)?;
         self.ensure_root().await?;
 
-        let meta = self.read_meta(id).await.ok();
-        let data_path = match &meta {
-            Some(meta) => self.resolve_data_path(id, &meta.storage),
+        let mut meta = self.read_meta(id).await.ok();
+        let data_path = match &mut meta {
+            Some(meta) => self.resolve_meta_data_path(meta).await?,
             None => self.data_path(id),
         };
         let meta_path = self.meta_path(id);
@@ -335,6 +446,7 @@ impl DataStore for DiskStore {
 
         use futures_util::StreamExt;
 
+        Self::ensure_safe_upload_id(id)?;
         self.ensure_root().await?;
 
         let mut meta = self.read_meta(id).await?;
@@ -345,7 +457,7 @@ impl DataStore for DiskStore {
             });
         }
 
-        let path = self.resolve_data_path(id, &meta.storage);
+        let path = self.resolve_meta_data_path(&mut meta).await?;
         let mut file = fs::OpenOptions::new()
             .write(true)
             .open(path)
@@ -395,12 +507,15 @@ impl DataStore for DiskStore {
     }
 
     async fn get_upload_file_info(&self, id: &str) -> TusResult<UploadInfo> {
+        Self::ensure_safe_upload_id(id)?;
         self.ensure_root().await?;
-        let meta = self.read_meta(id).await?;
+        let mut meta = self.read_meta(id).await?;
+        self.resolve_meta_data_path(&mut meta).await?;
         Ok(meta.into())
     }
 
     async fn declare_upload_length(&self, id: &str, length: u64) -> TusResult<()> {
+        Self::ensure_safe_upload_id(id)?;
         self.ensure_root().await?;
         let mut meta = self.read_meta(id).await?;
 
@@ -747,14 +862,29 @@ mod tests {
 
     #[test]
     fn test_resolve_data_path_with_storage() {
-        let store = DiskStore::new().disk_root("/uploads");
+        let (store, temp_dir) = create_test_store();
+        let stored_path = temp_dir.path().join("file.bin");
         let storage = Some(MetaStoreInfo {
             type_name: "file".to_owned(),
-            path: "/custom/path/file.bin".to_owned(),
+            path: stored_path.to_string_lossy().into_owned(),
             bucket: None,
         });
         let path = store.resolve_data_path("test-id", &storage);
-        assert_eq!(path, PathBuf::from("/custom/path/file.bin"));
+        assert_eq!(path, stored_path);
+    }
+
+    #[test]
+    fn test_resolve_data_path_rejects_storage_outside_root() {
+        let (store, outside_dir) = create_test_store();
+        let outside_path = outside_dir.path().join("..").join("outside.bin");
+        let storage = Some(MetaStoreInfo {
+            type_name: "file".to_owned(),
+            path: outside_path.to_string_lossy().into_owned(),
+            bucket: None,
+        });
+
+        let path = store.resolve_data_path("test-id", &storage);
+        assert_eq!(path, store.data_path("test-id"));
     }
 
     #[test]
@@ -852,6 +982,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_disk_store_create_overwrites_custom_storage_path() {
+        let (store, _temp_dir) = create_test_store();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_path = outside_dir.path().join("outside.bin");
+        let id = "test-create-storage";
+        let mut upload_info = create_test_upload_info(id);
+        upload_info.storage = Some(StoreInfo {
+            type_name: "file".to_owned(),
+            path: outside_path.to_string_lossy().into_owned(),
+            bucket: None,
+        });
+
+        let created = store.create(upload_info).await.unwrap();
+        assert_eq!(
+            created.storage.unwrap().path,
+            store.data_path(id).to_string_lossy().into_owned()
+        );
+
+        let meta = store.read_meta(id).await.unwrap();
+        assert_eq!(
+            meta.storage.unwrap().path,
+            store.data_path(id).to_string_lossy().into_owned()
+        );
+    }
+
+    #[tokio::test]
     async fn test_disk_store_create_with_deferred_size() {
         let (store, _temp_dir) = create_test_store();
         let upload_info = UploadInfo {
@@ -888,6 +1044,98 @@ mod tests {
         let result = store.remove("non-existent").await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), TusError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn test_disk_store_create_rejects_unsafe_upload_id() {
+        let (store, _temp_dir) = create_test_store();
+        let upload_info = create_test_upload_info("../escape");
+
+        let result = store.create(upload_info).await;
+        assert!(matches!(result, Err(TusError::FileIdError)));
+    }
+
+    #[tokio::test]
+    async fn test_disk_store_get_info_sanitizes_tampered_storage_path() {
+        let (store, _temp_dir) = create_test_store();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_path = outside_dir.path().join("outside.bin");
+        fs::write(&outside_path, b"outside").await.unwrap();
+
+        let id = "test-tamper-info";
+        store.create(create_test_upload_info(id)).await.unwrap();
+        let mut meta = store.read_meta(id).await.unwrap();
+        meta.storage.as_mut().unwrap().path = outside_path.to_string_lossy().into_owned();
+        store.write_meta_atomic(&meta).await.unwrap();
+
+        let info = store.get_upload_file_info(id).await.unwrap();
+        assert_eq!(
+            info.storage.unwrap().path,
+            store.data_path(id).to_string_lossy().into_owned()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_disk_store_write_ignores_tampered_storage_path() {
+        use bytes::Bytes;
+        use futures_util::stream;
+
+        let (store, _temp_dir) = create_test_store();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_path = outside_dir.path().join("outside.bin");
+        fs::write(&outside_path, b"outside").await.unwrap();
+
+        let id = "test-tamper-write";
+        let mut upload_info = create_test_upload_info(id);
+        upload_info.size = Some(5);
+        store.create(upload_info).await.unwrap();
+
+        let mut meta = store.read_meta(id).await.unwrap();
+        meta.storage.as_mut().unwrap().path = outside_path.to_string_lossy().into_owned();
+        store.write_meta_atomic(&meta).await.unwrap();
+
+        let data = Bytes::from_static(b"hello");
+        let stream: ByteStream =
+            Box::pin(stream::once(async move { Ok::<_, std::io::Error>(data) }));
+        store.write(id, 0, stream).await.unwrap();
+
+        assert_eq!(
+            fs::read(&outside_path).await.unwrap().as_slice(),
+            b"outside"
+        );
+        assert_eq!(
+            fs::read(store.data_path(id)).await.unwrap().as_slice(),
+            b"hello"
+        );
+
+        let meta = store.read_meta(id).await.unwrap();
+        assert_eq!(
+            meta.storage.unwrap().path,
+            store.data_path(id).to_string_lossy().into_owned()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_disk_store_remove_ignores_tampered_storage_path() {
+        let (store, _temp_dir) = create_test_store();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_path = outside_dir.path().join("outside.bin");
+        fs::write(&outside_path, b"outside").await.unwrap();
+
+        let id = "test-tamper-remove";
+        store.create(create_test_upload_info(id)).await.unwrap();
+
+        let mut meta = store.read_meta(id).await.unwrap();
+        meta.storage.as_mut().unwrap().path = outside_path.to_string_lossy().into_owned();
+        store.write_meta_atomic(&meta).await.unwrap();
+
+        store.remove(id).await.unwrap();
+
+        assert_eq!(
+            fs::read(&outside_path).await.unwrap().as_slice(),
+            b"outside"
+        );
+        assert!(!store.data_path(id).exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
This pull request introduces comprehensive security improvements to the TUS file upload backend, primarily focused on validating and sanitizing upload IDs and file paths to prevent directory traversal and unsafe file operations. The changes ensure that only safe upload IDs are accepted and that all file paths used for storage are strictly contained within the configured root directory, effectively mitigating a range of potential security vulnerabilities.

**Security and Validation Enhancements:**

* Added a new `is_safe_upload_id` utility function and integrated it throughout the codebase to validate upload IDs in all entry points, including API handlers and the `DiskStore` implementation. This prevents unsafe or malicious IDs from being used. [[1]](diffhunk://#diff-925d563892282a40816a0fc54b4c3f6902364dfe7c596b9756a0162c5a833d25L10-R10) [[2]](diffhunk://#diff-925d563892282a40816a0fc54b4c3f6902364dfe7c596b9756a0162c5a833d25R117-R120) [[3]](diffhunk://#diff-564e67b0a621c629fa19d178fc0bc92324e11e18775b93f65b0097275d21138cR14) [[4]](diffhunk://#diff-564e67b0a621c629fa19d178fc0bc92324e11e18775b93f65b0097275d21138cR163) [[5]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1L15-R15) [[6]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R116-R222) [[7]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R385-L285) [[8]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R414-R419) [[9]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R449) [[10]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1L348-R460) [[11]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R510-R518)

* Introduced robust path normalization and validation logic in `DiskStore` to ensure that all file operations (create, read, write, remove) are restricted to paths within the configured root directory, rejecting or correcting any storage path that attempts to escape this root. This includes new helper methods such as `absolute_normalized_path`, `path_is_within_root`, and `resolve_meta_data_path`. [[1]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R116-R222) [[2]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1L194-R305) [[3]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R385-L285) [[4]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R414-R419) [[5]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R449) [[6]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1L348-R460) [[7]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R510-R518)

**Testing Improvements:**

* Added and extended tests to verify that unsafe upload IDs are rejected, that storage paths outside the root are ignored or corrected, and that tampering with storage paths does not result in unsafe file operations. These tests cover creation, reading, writing, and removal of uploads, ensuring the new security checks are effective. [[1]](diffhunk://#diff-564e67b0a621c629fa19d178fc0bc92324e11e18775b93f65b0097275d21138cR422-R441) [[2]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1L750-R887) [[3]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R984-R1009) [[4]](diffhunk://#diff-b27febdd67a9a23be6a837cf8deaffa78ce0f2900bf0cd7622f729fdb8d238c1R1049-R1140)

These changes significantly harden the file upload system against path traversal and related attacks, ensuring safer handling of user-supplied data and storage paths.