### PR TITLE
Harden limits and cache controls

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -95,6 +95,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use bytes::Bytes;
 use salvo_core::handler::Skipper;
+use salvo_core::http::header::{AUTHORIZATION, CACHE_CONTROL, COOKIE, SET_COOKIE, VARY};
 use salvo_core::http::{HeaderMap, ResBody, StatusCode};
 use salvo_core::{Depot, Error, FlowCtrl, Handler, Request, Response, async_trait};
 use tokio::sync::Notify;
@@ -477,6 +478,7 @@ where
     pub issuer: I,
     /// Skipper.
     pub skipper: Box<dyn Skipper>,
+    cache_private: bool,
     in_flight: Arc<InFlight<S::Key>>,
 }
 impl<S, I> Debug for Cache<S, I>
@@ -505,6 +507,7 @@ where
             store,
             issuer,
             skipper: Box::new(skipper),
+            cache_private: false,
             in_flight: Arc::new(InFlight::default()),
         }
     }
@@ -515,11 +518,23 @@ where
         self.skipper = Box::new(skipper);
         self
     }
+
+    /// Allow caching requests or responses that contain private-user cache signals.
+    ///
+    /// By default, requests with `Authorization` or `Cookie`, and responses with `Set-Cookie`,
+    /// `Vary`, or `Cache-Control: private/no-store`, are not cached.
+    #[inline]
+    #[must_use]
+    pub fn cache_private(mut self, cache_private: bool) -> Self {
+        self.cache_private = cache_private;
+        self
+    }
 }
 
 async fn call_next_and_cache<S>(
     store: &S,
     key: S::Key,
+    cache_private: bool,
     req: &mut Request,
     depot: &mut Depot,
     res: &mut Response,
@@ -529,15 +544,18 @@ where
     S: CacheStore,
 {
     ctrl.call_next(req, depot, res).await;
-    let cached_data = cached_response(res)?;
+    let cached_data = cached_response(res, cache_private)?;
     if let Err(e) = store.save_entry(key, cached_data.clone()).await {
         tracing::error!(error = ?e, "cache failed");
     }
     Some(cached_data)
 }
 
-fn cached_response(res: &Response) -> Option<CachedEntry> {
+fn cached_response(res: &Response, cache_private: bool) -> Option<CachedEntry> {
     if res.body.is_stream() || res.body.is_error() {
+        return None;
+    }
+    if !cache_private && response_has_private_cache_headers(res.headers()) {
         return None;
     }
     let headers = res.headers().clone();
@@ -549,6 +567,31 @@ fn cached_response(res: &Response) -> Option<CachedEntry> {
         }
     };
     Some(CachedEntry::new(res.status_code, headers, body))
+}
+
+fn request_has_private_cache_headers(req: &Request) -> bool {
+    req.headers().contains_key(AUTHORIZATION) || req.headers().contains_key(COOKIE)
+}
+
+fn response_has_private_cache_headers(headers: &HeaderMap) -> bool {
+    headers.contains_key(SET_COOKIE)
+        || headers.contains_key(VARY)
+        || cache_control_contains(headers, "private")
+        || cache_control_contains(headers, "no-store")
+}
+
+fn cache_control_contains(headers: &HeaderMap, directive: &str) -> bool {
+    headers.get_all(CACHE_CONTROL).iter().any(|value| {
+        value.to_str().ok().is_some_and(|value| {
+            value.split(',').any(|part| {
+                let part = part.trim();
+                part.eq_ignore_ascii_case(directive)
+                    || part
+                        .split_once('=')
+                        .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case(directive))
+            })
+        })
+    })
 }
 
 #[async_trait]
@@ -565,7 +608,9 @@ where
         res: &mut Response,
         ctrl: &mut FlowCtrl,
     ) {
-        if self.skipper.skipped(req, depot) {
+        if self.skipper.skipped(req, depot)
+            || (!self.cache_private && request_has_private_cache_headers(req))
+        {
             ctrl.call_next(req, depot, res).await;
             return;
         }
@@ -575,8 +620,16 @@ where
         let Some(cache) = self.store.load_entry(&key).await else {
             match self.in_flight.enter(key.clone()) {
                 FlightPermit::Leader(guard) => {
-                    let cached_data =
-                        call_next_and_cache(&self.store, key, req, depot, res, ctrl).await;
+                    let cached_data = call_next_and_cache(
+                        &self.store,
+                        key,
+                        self.cache_private,
+                        req,
+                        depot,
+                        res,
+                        ctrl,
+                    )
+                    .await;
                     guard.finish(cached_data);
                 }
                 FlightPermit::Follower(flight) => {
@@ -585,7 +638,16 @@ where
                         respond_from_cache(res, cache);
                         ctrl.skip_rest();
                     } else {
-                        call_next_and_cache(&self.store, key, req, depot, res, ctrl).await;
+                        call_next_and_cache(
+                            &self.store,
+                            key,
+                            self.cache_private,
+                            req,
+                            depot,
+                            res,
+                            ctrl,
+                        )
+                        .await;
                     }
                 }
             }
@@ -926,6 +988,47 @@ mod tests {
     fn test_cache_new() {
         let cache = Cache::new(MokaStore::<String>::new(100), RequestIssuer::default());
         assert!(format!("{cache:?}").contains("Cache"));
+    }
+
+    #[test]
+    fn cached_response_skips_private_cache_headers_by_default() {
+        for (name, value) in [
+            (SET_COOKIE, "sid=abc"),
+            (VARY, "accept-language"),
+            (CACHE_CONTROL, "private"),
+            (CACHE_CONTROL, "max-age=60, no-store"),
+        ] {
+            let mut res = Response::new();
+            res.body(ResBody::Once(Bytes::from_static(b"cached")));
+            res.headers_mut().insert(name, value.parse().unwrap());
+            assert!(cached_response(&res, false).is_none());
+            assert!(cached_response(&res, true).is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn authorization_requests_are_not_cached_by_default() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let cache = Cache::new(
+            MokaStore::builder()
+                .time_to_live(std::time::Duration::from_secs(60))
+                .build(),
+            RequestIssuer::default(),
+        );
+        let router = Arc::new(Router::new().hoop(cache).goal(SlowCached {
+            calls: calls.clone(),
+        }));
+
+        for _ in 0..2 {
+            let mut res = TestClient::get("http://127.0.0.1:5801")
+                .add_header(AUTHORIZATION, "Bearer token", true)
+                .send(router.clone())
+                .await;
+            assert_eq!(res.status_code, Some(StatusCode::OK));
+            let _ = res.take_string().await.unwrap();
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -626,6 +626,26 @@ impl Request {
         self.secure_max_size = Some(size);
     }
 
+    /// Wraps the request body in a streaming size limit and also sets the
+    /// request's secure max size.
+    ///
+    /// This is useful for middleware that must enforce the limit even when a
+    /// downstream handler reads the body stream directly instead of using
+    /// [`payload()`](Request::payload) or [`form_data()`](Request::form_data).
+    #[inline]
+    pub fn limit_body(&mut self, max_size: usize) {
+        self.set_secure_max_size(max_size);
+        if self.body.is_none() {
+            return;
+        }
+
+        let body = self.take_body();
+        self.replace_body(ReqBody::Boxed {
+            inner: Box::pin(Limited::new(body, max_size)),
+            fusewire: None,
+        });
+    }
+
     /// Returns the maximum allowed body size for this request.
     ///
     /// Returns the request-specific limit if set via

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -1138,7 +1138,7 @@ impl Request {
             .get_or_try_init(|| async {
                 let limited = Limited::new(body, max_size);
                 let collected = limited.collect().await.map_err(|e| {
-                    if e.is::<http_body_util::LengthLimitError>() {
+                    if is_length_limit_error(e.as_ref()) {
                         ParseError::PayloadTooLarge
                     } else {
                         ParseError::other(e)
@@ -1462,6 +1462,26 @@ impl Request {
         }
         Err(ParseError::InvalidContentType)
     }
+}
+
+fn is_length_limit_error(error: &(dyn StdError + 'static)) -> bool {
+    if error.is::<http_body_util::LengthLimitError>() {
+        return true;
+    }
+    if let Some(error) = error.downcast_ref::<std::io::Error>()
+        && let Some(inner) = error.get_ref()
+        && is_length_limit_error(inner)
+    {
+        return true;
+    }
+    let mut source = error.source();
+    while let Some(error) = source {
+        if error.is::<http_body_util::LengthLimitError>() {
+            return true;
+        }
+        source = error.source();
+    }
+    false
 }
 
 #[cfg(test)]

--- a/crates/extra/src/concurrency_limiter.rs
+++ b/crates/extra/src/concurrency_limiter.rs
@@ -91,7 +91,7 @@ impl Handler for MaxConcurrency {
         ctrl: &mut FlowCtrl,
     ) {
         match self.semaphore.try_acquire() {
-            Ok(_) => {
+            Ok(_permit) => {
                 ctrl.call_next(req, depot, res).await;
             }
             Err(e) => match e {
@@ -118,3 +118,63 @@ impl Handler for MaxConcurrency {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::Notify;
+
+    use salvo_core::http::StatusCode;
+    use salvo_core::prelude::*;
+    use salvo_core::test::TestClient;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct BlockingHandler {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Handler for BlockingHandler {
+        async fn handle(
+            &self,
+            _req: &mut Request,
+            _depot: &mut Depot,
+            res: &mut Response,
+            _ctrl: &mut FlowCtrl,
+        ) {
+            self.started.notify_one();
+            self.release.notified().await;
+            res.render("done");
+        }
+    }
+
+    #[tokio::test]
+    async fn max_concurrency_holds_permit_until_next_handler_finishes() {
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let router = Arc::new(Router::new().hoop(max_concurrency(1)).get(BlockingHandler {
+            started: started.clone(),
+            release: release.clone(),
+        }));
+
+        let first_router = router.clone();
+        let first = tokio::spawn(async move {
+            TestClient::get("http://127.0.0.1:5801")
+                .send(first_router)
+                .await
+        });
+        started.notified().await;
+
+        let second = TestClient::get("http://127.0.0.1:5801")
+            .send(router)
+            .await;
+        assert_eq!(second.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+
+        release.notify_one();
+        let first = first.await.unwrap();
+        assert_eq!(first.status_code, Some(StatusCode::OK));
+    }
+}

--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -105,6 +105,12 @@ impl Handler for MaxSize {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use salvo_core::BoxedError;
+    use salvo_core::http::body::{Frame, ReqBody, SizeHint};
+    use salvo_core::http::ParseError;
     use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
@@ -113,6 +119,45 @@ mod tests {
     #[handler]
     async fn hello() -> &'static str {
         "hello"
+    }
+
+    struct UnknownSizeBody {
+        frame: Option<Frame<salvo_core::hyper::body::Bytes>>,
+    }
+
+    impl UnknownSizeBody {
+        fn new(bytes: &'static [u8]) -> Self {
+            Self {
+                frame: Some(Frame::data(salvo_core::hyper::body::Bytes::from_static(
+                    bytes,
+                ))),
+            }
+        }
+    }
+
+    impl Body for UnknownSizeBody {
+        type Data = salvo_core::hyper::body::Bytes;
+        type Error = BoxedError;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            Poll::Ready(self.frame.take().map(Ok))
+        }
+
+        fn size_hint(&self) -> SizeHint {
+            SizeHint::new()
+        }
+    }
+
+    #[handler]
+    async fn read_payload(req: &mut Request, res: &mut Response) {
+        match req.payload().await {
+            Ok(_) => res.render("ok"),
+            Err(ParseError::PayloadTooLarge) => res.render(StatusError::payload_too_large()),
+            Err(error) => res.render(StatusError::bad_request().brief(error.to_string())),
+        }
     }
 
     #[tokio::test]
@@ -136,6 +181,26 @@ mod tests {
             .text("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
             .send(&service)
             .await;
+        assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_size_limiter_limits_unknown_length_streaming_body() {
+        let limit_handler = MaxSize(4);
+        let router = Router::new()
+            .hoop(limit_handler)
+            .push(Router::with_path("upload").post(read_payload));
+        let service = Service::new(router);
+        let body = ReqBody::Boxed {
+            inner: Box::pin(UnknownSizeBody::new(b"too large")),
+            fusewire: None,
+        };
+
+        let res = TestClient::post("http://127.0.0.1:5801/upload")
+            .body(body)
+            .send(&service)
+            .await;
+
         assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -69,7 +69,7 @@
 //! </html>
 //! "#;
 //! ```
-use salvo_core::http::StatusError;
+use salvo_core::http::{StatusCode, StatusError};
 use salvo_core::http::{Body, Request, Response};
 use salvo_core::{async_trait, Depot, FlowCtrl, Handler};
 
@@ -79,18 +79,22 @@ pub struct MaxSize(pub u64);
 #[async_trait]
 impl Handler for MaxSize {
     async fn handle(&self, req: &mut Request, depot: &mut Depot, res: &mut Response, ctrl: &mut FlowCtrl) {
-        let size_hint = req.body().size_hint().upper();
-        if let Some(upper) = size_hint {
-            if upper > self.0 {
-                res.render(StatusError::payload_too_large());
-                ctrl.skip_rest();
-            } else {
-                ctrl.call_next(req, depot, res).await;
-            }
-        } else {
-            res.render(StatusError::bad_request().brief("request body size is unknown"));
+        if let Some(upper) = req.body().size_hint().upper()
+            && upper > self.0
+        {
+            res.render(StatusError::payload_too_large());
             ctrl.skip_rest();
+            return;
         }
+
+        let Ok(max_size) = usize::try_from(self.0) else {
+            res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
+            ctrl.skip_rest();
+            return;
+        };
+
+        req.limit_body(max_size);
+        ctrl.call_next(req, depot, res).await;
     }
 }
 /// Create a new `MaxSize`.
@@ -135,4 +139,3 @@ mod tests {
         assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }
-

--- a/crates/rate-limiter/src/moka_store.rs
+++ b/crates/rate-limiter/src/moka_store.rs
@@ -3,11 +3,15 @@ use std::convert::Infallible;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use moka::future::Cache as MokaCache;
 use moka::ops::compute;
 
 use super::{RateGuard, RateLimitState, RateStore};
+
+const DEFAULT_MAX_CAPACITY: u64 = 100_000;
+const DEFAULT_TIME_TO_IDLE: Duration = Duration::from_secs(60 * 60);
 
 /// A simple in-memory store for rate limiter.
 #[derive(Debug)]
@@ -34,6 +38,32 @@ where
 {
     /// Create a new `MokaStore`.
     #[must_use] pub fn new() -> Self {
+        Self::with_capacity_and_time_to_idle(DEFAULT_MAX_CAPACITY, DEFAULT_TIME_TO_IDLE)
+    }
+
+    /// Create a new `MokaStore` with a maximum number of identifiers.
+    #[must_use]
+    pub fn with_max_capacity(max_capacity: u64) -> Self {
+        Self::with_capacity_and_time_to_idle(max_capacity, DEFAULT_TIME_TO_IDLE)
+    }
+
+    /// Create a new `MokaStore` with a maximum number of identifiers and idle eviction.
+    #[must_use]
+    pub fn with_capacity_and_time_to_idle(max_capacity: u64, time_to_idle: Duration) -> Self {
+        Self {
+            inner: MokaCache::builder()
+                .max_capacity(max_capacity)
+                .time_to_idle(time_to_idle)
+                .build(),
+        }
+    }
+
+    /// Create an unbounded `MokaStore`.
+    ///
+    /// Prefer [`MokaStore::new`] or [`MokaStore::with_max_capacity`] for public services where
+    /// attackers can create high-cardinality identifiers.
+    #[must_use]
+    pub fn unbounded() -> Self {
         Self {
             inner: MokaCache::new(u64::MAX),
         }
@@ -135,5 +165,11 @@ mod tests {
         }
 
         assert_eq!(allowed_count.load(Ordering::SeqCst), 10);
+    }
+
+    #[test]
+    fn new_uses_bounded_cache_defaults() {
+        let store = MokaStore::<String, FixedGuard>::new();
+        assert_eq!(store.inner.policy().max_capacity(), Some(DEFAULT_MAX_CAPACITY));
     }
 }


### PR DESCRIPTION
## Summary

Harden the request limiting and cache-related security behavior found in the security review.

- Keep concurrency limiter permits alive until downstream handlers finish.
- Enforce request body size limits with a streaming body wrapper, not only `size_hint`.
- Avoid caching authenticated or cookie-bearing requests by default.
- Avoid caching private response headers by default.
- Give the Moka-backed rate limiter store bounded defaults while keeping an explicit unbounded opt-in.

## Review follow-up

- Preserve `PayloadTooLarge` classification when a nested streaming limit fails through `ReqBody::Boxed`/`io::Error` wrapping.
- Add coverage for unknown-length streaming bodies so chunked/no-`Content-Length` requests are accepted but still limited when read.

## Validation

- `cargo test -p salvo-cache --lib`
- `cargo test -p salvo_extra --features concurrency-limiter,size-limiter,salvo_core/aws-lc-rs --lib`
- `cargo test -p salvo-rate-limiter --lib`
- `cargo check -p salvo_core`
- `cargo test -p salvo_extra --features size-limiter,salvo_core/aws-lc-rs test_size_limiter --lib`
- `git diff --check`