### PR TITLE
Harden auth and secure cookie handling

### DIFF
--- a/crates/csrf/src/cookie_store.rs
+++ b/crates/csrf/src/cookie_store.rs
@@ -19,6 +19,8 @@ pub struct CookieStore {
     pub path: String,
     /// CSRF cookie domain.
     pub domain: Option<String>,
+    /// Forced secure cookie attribute. If None, infer from request URI scheme.
+    pub secure: Option<bool>,
 }
 impl Default for CookieStore {
     #[inline]
@@ -36,6 +38,7 @@ impl CookieStore {
             name: "salvo.csrf".into(),
             path: "/".into(),
             domain: None,
+            secure: None,
         }
     }
     /// Sets cookie name.
@@ -65,6 +68,16 @@ impl CookieStore {
         self.domain = Some(domain.into());
         self
     }
+
+    /// Forces the `Secure` attribute for CSRF cookies.
+    ///
+    /// By default this is detected from the request URI scheme. Use this option in
+    /// production when TLS is terminated before the Salvo application.
+    #[must_use]
+    pub fn secure(mut self, secure: bool) -> Self {
+        self.secure = Some(secure);
+        self
+    }
 }
 impl CsrfStore for CookieStore {
     type Error = Error;
@@ -92,7 +105,9 @@ impl CsrfStore for CookieStore {
         token: &str,
         proof: &str,
     ) -> Result<(), Self::Error> {
-        let secure = req.uri().scheme() == Some(&Scheme::HTTPS);
+        let secure = self
+            .secure
+            .unwrap_or_else(|| req.uri().scheme() == Some(&Scheme::HTTPS));
         let expires = cookie::time::OffsetDateTime::now_utc() + self.ttl;
         let cookie_builder = Cookie::build((self.name.clone(), format!("{token}.{proof}")))
             .http_only(true)
@@ -123,14 +138,16 @@ mod tests {
             .name("test_cookie")
             .ttl(Duration::days(1))
             .path("/test")
-            .domain("example.com");
+            .domain("example.com")
+            .secure(true);
 
         assert_eq!(cookie_store.name, "test_cookie");
         assert_eq!(cookie_store.ttl, Duration::days(1));
         assert_eq!(cookie_store.path, "/test");
         assert_eq!(cookie_store.domain.as_deref(), Some("example.com"));
+        assert_eq!(cookie_store.secure, Some(true));
 
-        let mut req = TestClient::get("https://example.com/test").build();
+        let mut req = TestClient::get("http://example.com/test").build();
         let mut depot = Depot::new();
         let mut res = Response::new();
 

--- a/crates/csrf/src/cookie_store.rs
+++ b/crates/csrf/src/cookie_store.rs
@@ -170,4 +170,22 @@ mod tests {
         let loaded = cookie_store.load(&mut req, &mut depot, &cipher).await;
         assert_eq!(loaded, Some((token, proof)));
     }
+
+    #[tokio::test]
+    async fn test_cookie_store_infers_secure_from_https_scheme() {
+        let cipher = BcryptCipher::new();
+        let cookie_store = CookieStore::new().name("test_cookie");
+        let mut req = TestClient::get("https://example.com/test").build();
+        let mut depot = Depot::new();
+        let mut res = Response::new();
+
+        let (token, proof) = cipher.generate();
+        cookie_store
+            .save(&mut req, &mut depot, &mut res, &token, &proof)
+            .await
+            .unwrap();
+
+        let cookie = res.cookies().get("test_cookie").unwrap();
+        assert_eq!(cookie.secure(), Some(true));
+    }
 }

--- a/crates/jwt-auth/src/finder.rs
+++ b/crates/jwt-auth/src/finder.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use salvo_core::async_trait;
-use salvo_core::http::header::{AUTHORIZATION, HeaderName, PROXY_AUTHORIZATION};
+use salvo_core::http::header::{AUTHORIZATION, HeaderName};
 use salvo_core::http::{Method, Request};
 
 use super::ALL_METHODS;
@@ -24,7 +24,9 @@ pub trait JwtTokenFinder: Send + Sync {
 /// Extracts JWT tokens from HTTP request headers.
 ///
 /// By default, this finder looks for Bearer tokens in the `Authorization`
-/// and `Proxy-Authorization` headers for all HTTP methods.
+/// header for all HTTP methods. Add `Proxy-Authorization` explicitly with
+/// [`HeaderFinder::header_names`] if your deployment really uses it for origin
+/// application authentication.
 ///
 /// # Example
 ///
@@ -55,7 +57,7 @@ impl HeaderFinder {
     pub fn new() -> Self {
         Self {
             cared_methods: ALL_METHODS.to_vec(),
-            header_names: vec![AUTHORIZATION, PROXY_AUTHORIZATION],
+            header_names: vec![AUTHORIZATION],
         }
     }
 

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -143,7 +143,7 @@ use std::marker::PhantomData;
 pub use jsonwebtoken::{
     Algorithm, DecodingKey, TokenData, Validation, decode, errors::Error as JwtError,
 };
-use salvo_core::http::{Method, Request, Response, StatusError};
+use salvo_core::http::{Method, Request, Response, StatusCode, StatusError};
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -213,6 +213,26 @@ pub enum JwtAuthError {
     #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
     #[error("Failed to load native root certificates for OIDC HTTP client: {0}")]
     NativeRootCerts(String),
+    /// OIDC endpoint returned a non-success HTTP status.
+    #[cfg(feature = "oidc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
+    #[error("OIDC endpoint returned non-success status: {0}")]
+    OidcHttpStatus(StatusCode),
+    /// OIDC endpoint took too long to respond.
+    #[cfg(feature = "oidc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
+    #[error("OIDC endpoint request timed out")]
+    OidcHttpTimeout,
+    /// OIDC response body could not be read.
+    #[cfg(feature = "oidc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
+    #[error("OIDC response body read failed: {0}")]
+    OidcBodyRead(String),
+    /// OIDC response body exceeded the configured limit.
+    #[cfg(feature = "oidc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
+    #[error("OIDC response exceeded {0} bytes")]
+    OidcResponseTooLarge(usize),
     /// OIDC audience must be configured.
     #[cfg(feature = "oidc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
@@ -545,7 +565,7 @@ mod tests {
     fn test_header_finder_new() {
         let finder = HeaderFinder::new();
         assert_eq!(finder.cared_methods.len(), 9); // All methods
-        assert_eq!(finder.header_names.len(), 2); // Authorization + Proxy-Authorization
+        assert_eq!(finder.header_names.len(), 1); // Authorization
     }
 
     #[test]
@@ -938,7 +958,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_jwt_auth_proxy_authorization_header() {
+    async fn test_jwt_auth_proxy_authorization_header_requires_explicit_opt_in() {
+        use salvo_core::http::header::{AUTHORIZATION, PROXY_AUTHORIZATION};
+
         let auth_handler: JwtAuth<JwtClaims, ConstDecoder> =
             JwtAuth::new(ConstDecoder::from_secret(b"SECRET"));
 
@@ -962,6 +984,24 @@ mod tests {
             &EncodingKey::from_secret(b"SECRET"),
         )
         .unwrap();
+
+        let content = TestClient::get("http://127.0.0.1:5801/hello")
+            .add_header("Proxy-Authorization", format!("Bearer {token}"), true)
+            .send(&service)
+            .await
+            .take_string()
+            .await
+            .unwrap();
+        assert!(content.contains("Unauthorized"));
+
+        let auth_handler: JwtAuth<JwtClaims, ConstDecoder> =
+            JwtAuth::new(ConstDecoder::from_secret(b"SECRET")).finders(vec![Box::new(
+                HeaderFinder::new().header_names(vec![AUTHORIZATION, PROXY_AUTHORIZATION]),
+            )]);
+        let router = Router::new()
+            .hoop(auth_handler)
+            .push(Router::with_path("hello").get(hello));
+        let service = Service::new(router);
 
         let content = TestClient::get("http://127.0.0.1:5801/hello")
             .add_header("Proxy-Authorization", format!("Bearer {token}"), true)

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -471,13 +471,16 @@ async fn collect_limited_body(
     max_size: usize,
 ) -> Result<Bytes, JwtAuthError> {
     let limited = Limited::new(body, max_size);
-    let collected = limited.collect().await.map_err(|error| {
-        if error.is::<http_body_util::LengthLimitError>() {
-            JwtAuthError::OidcResponseTooLarge(max_size)
-        } else {
-            JwtAuthError::OidcBodyRead(error.to_string())
-        }
-    })?;
+    let collected = timeout(OIDC_HTTP_TIMEOUT, limited.collect())
+        .await
+        .map_err(|_| JwtAuthError::OidcHttpTimeout)?
+        .map_err(|error| {
+            if error.is::<http_body_util::LengthLimitError>() {
+                JwtAuthError::OidcResponseTooLarge(max_size)
+            } else {
+                JwtAuthError::OidcBodyRead(error.to_string())
+            }
+        })?;
     Ok(collected.to_bytes())
 }
 

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -3,13 +3,12 @@
 use std::fmt::{self, Debug, Formatter};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, Limited};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
@@ -20,6 +19,7 @@ use salvo_core::http::{header::CACHE_CONTROL, uri::Uri};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::{Notify, RwLock};
+use tokio::time::timeout;
 
 use super::{JwtAuthDecoder, JwtAuthError};
 
@@ -28,6 +28,10 @@ mod cache;
 pub use cache::{CachePolicy, CacheState, JwkSetStore, UpdateAction};
 
 pub(super) type HyperClient = Client<HttpsConnector<HttpConnector>, Full<Bytes>>;
+
+const OIDC_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const OIDC_CONFIG_MAX_BYTES: usize = 64 * 1024;
+const OIDC_JWKS_MAX_BYTES: usize = 1024 * 1024;
 
 fn default_http_client() -> Result<HyperClient, JwtAuthError> {
     let https = HttpsConnectorBuilder::new()
@@ -213,11 +217,16 @@ impl OidcDecoder {
         format!("{}/.well-known/openid-configuration", &self.issuer)
     }
     async fn get_config(&self) -> Result<OidcConfig, JwtAuthError> {
-        let res = self
-            .http_client
-            .get(self.config_url().parse::<Uri>()?)
-            .await?;
-        let body = res.into_body().collect().await?.to_bytes();
+        let res = timeout(
+            OIDC_HTTP_TIMEOUT,
+            self.http_client.get(self.config_url().parse::<Uri>()?),
+        )
+        .await
+        .map_err(|_| JwtAuthError::OidcHttpTimeout)??;
+        if !res.status().is_success() {
+            return Err(JwtAuthError::OidcHttpStatus(res.status()));
+        }
+        let body = collect_limited_body(res.into_body(), OIDC_CONFIG_MAX_BYTES).await?;
         let config = serde_json::from_slice(&body)?;
         Ok(config)
     }
@@ -230,7 +239,12 @@ impl OidcDecoder {
         let uri = self.jwks_uri().await?.parse::<Uri>()?;
         // Get the jwks endpoint
         tracing::debug!("Requesting JWKS From Uri: {uri}");
-        let res = self.http_client.get(uri).await?;
+        let res = timeout(OIDC_HTTP_TIMEOUT, self.http_client.get(uri))
+            .await
+            .map_err(|_| JwtAuthError::OidcHttpTimeout)??;
+        if !res.status().is_success() {
+            return Err(JwtAuthError::OidcHttpStatus(res.status()));
+        }
 
         let cache_policy = {
             // Determine it from the cache_control header
@@ -238,7 +252,7 @@ impl OidcDecoder {
             let cache_policy = CachePolicy::from_header_val(cache_control);
             Some(cache_policy)
         };
-        let jwks = res.into_body().collect().await?.to_bytes();
+        let jwks = collect_limited_body(res.into_body(), OIDC_JWKS_MAX_BYTES).await?;
 
         let fetched_at = current_time();
         Ok(JwkSetFetch {
@@ -431,7 +445,7 @@ impl DecodingInfo {
         match jsonwebtoken::decode::<T>(token, &self.key, &self.validation) {
             Ok(data) => Ok(data),
             Err(e) => {
-                tracing::error!(error = ?e, token, "error decoding jwt token");
+                tracing::error!(error = ?e, "error decoding jwt token");
                 Err(JwtAuthError::from(e))
             }
         }
@@ -450,6 +464,21 @@ pub(crate) struct JwkSetFetch {
 #[derive(Debug, Deserialize)]
 struct OidcConfig {
     jwks_uri: String,
+}
+
+async fn collect_limited_body(
+    body: salvo_core::hyper::body::Incoming,
+    max_size: usize,
+) -> Result<Bytes, JwtAuthError> {
+    let limited = Limited::new(body, max_size);
+    let collected = limited.collect().await.map_err(|error| {
+        if error.is::<http_body_util::LengthLimitError>() {
+            JwtAuthError::OidcResponseTooLarge(max_size)
+        } else {
+            JwtAuthError::OidcBodyRead(error.to_string())
+        }
+    })?;
+    Ok(collected.to_bytes())
 }
 
 pub(crate) fn decode_jwk(

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -120,6 +120,7 @@ pub struct HandlerBuilder<S> {
     session_ttl: Option<Duration>,
     save_unchanged: bool,
     same_site_policy: SameSite,
+    secure_cookie: Option<bool>,
     key: Key,
     fallback_keys: Vec<Key>,
 }
@@ -135,6 +136,7 @@ where
             .field("cookie_domain", &self.cookie_domain)
             .field("session_ttl", &self.session_ttl)
             .field("same_site_policy", &self.same_site_policy)
+            .field("secure_cookie", &self.secure_cookie)
             .field("key", &"..")
             .field("fallback_keys", &"..")
             .field("save_unchanged", &self.save_unchanged)
@@ -187,6 +189,7 @@ where
             cookie_name: "salvo.session.id".into(),
             cookie_domain: None,
             same_site_policy: SameSite::Lax,
+            secure_cookie: None,
             session_ttl: Some(Duration::from_secs(24 * 60 * 60)),
             key,
             fallback_keys: vec![],
@@ -254,6 +257,17 @@ where
         self
     }
 
+    /// Forces the `Secure` attribute for session cookies.
+    ///
+    /// By default this is detected from the request URI scheme. Use this option in
+    /// production when TLS is terminated before the Salvo application.
+    #[inline]
+    #[must_use]
+    pub fn secure_cookie(mut self, secure: bool) -> Self {
+        self.secure_cookie = Some(secure);
+        self
+    }
+
     /// Sets the domain of the cookie.
     #[inline]
     #[must_use]
@@ -287,6 +301,7 @@ where
             cookie_domain,
             session_ttl,
             same_site_policy,
+            secure_cookie,
             key,
             fallback_keys,
         } = self;
@@ -305,6 +320,7 @@ where
             cookie_domain,
             session_ttl,
             same_site_policy,
+            secure_cookie,
             hmac,
             fallback_hmacs,
         })
@@ -320,6 +336,7 @@ pub struct SessionHandler<S> {
     session_ttl: Option<Duration>,
     save_unchanged: bool,
     same_site_policy: SameSite,
+    secure_cookie: Option<bool>,
     hmac: Hmac<Sha256>,
     fallback_hmacs: Vec<Hmac<Sha256>>,
 }
@@ -336,6 +353,7 @@ where
             .field("cookie_domain", &self.cookie_domain)
             .field("session_ttl", &self.session_ttl)
             .field("same_site_policy", &self.same_site_policy)
+            .field("secure_cookie", &self.secure_cookie)
             .field("key", &"..")
             .field("fallback_keys", &"..")
             .field("save_unchanged", &self.save_unchanged)
@@ -380,7 +398,9 @@ where
             match self.store.store_session(session).await {
                 Ok(cookie_value) => {
                     if let Some(cookie_value) = cookie_value {
-                        let secure_cookie = req.uri().scheme() == Some(&Scheme::HTTPS);
+                        let secure_cookie = self
+                            .secure_cookie
+                            .unwrap_or_else(|| req.uri().scheme() == Some(&Scheme::HTTPS));
                         let cookie = self.build_cookie(secure_cookie, cookie_value);
                         res.add_cookie(cookie);
                     }
@@ -731,6 +751,7 @@ mod tests {
         .session_ttl(Some(Duration::from_secs(7200)))
         .save_unchanged(false)
         .same_site_policy(SameSite::Strict)
+        .secure_cookie(true)
         .build()
         .unwrap();
 
@@ -740,6 +761,7 @@ mod tests {
         assert_eq!(handler.session_ttl, Some(Duration::from_secs(7200)));
         assert!(!handler.save_unchanged);
         assert_eq!(handler.same_site_policy, SameSite::Strict);
+        assert_eq!(handler.secure_cookie, Some(true));
     }
 
     // Tests for SessionHandler
@@ -836,6 +858,36 @@ mod tests {
             .send(&service)
             .await;
         assert_eq!(response.status_code, Some(StatusCode::OK));
+    }
+
+    #[tokio::test]
+    async fn test_session_can_force_secure_cookie_behind_tls_terminator() {
+        #[handler]
+        pub async fn index() -> &'static str {
+            "ok"
+        }
+
+        let session_handler = SessionHandler::builder(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .secure_cookie(true)
+        .build()
+        .unwrap();
+
+        let router = Router::new().hoop(session_handler).get(index);
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:8698/")
+            .send(&service)
+            .await;
+        let cookie = response
+            .headers()
+            .get(SET_COOKIE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cookie.contains("Secure"));
     }
 
     // Tests for session with save_unchanged = false


### PR DESCRIPTION
## Summary

Harden authentication and cookie handling issues from the security review.

- Stop treating `Proxy-Authorization` as a default JWT bearer token source.
- Keep `Proxy-Authorization` available only through explicit opt-in configuration.
- Bound OIDC configuration/JWKS fetches with timeouts, status checks, and response size limits.
- Remove token value logging during OIDC decode.
- Add explicit secure-cookie overrides for session and CSRF cookie stores for TLS-terminator deployments.

## Review follow-up

- Apply the OIDC timeout to limited body collection as well as the initial HTTP response future.
- Add coverage for default CSRF secure-cookie inference from HTTPS request schemes.

## Validation

- `cargo test -p salvo-jwt-auth --features full --lib`
- `cargo test -p salvo-session --lib`
- `cargo test -p salvo-csrf --features cookie-store --lib`
- `cargo test -p salvo-jwt-auth --features oidc --lib`
- `cargo test -p salvo-csrf --features cookie-store test_cookie_store --lib`
- `git diff --check`