### PR TITLE
Harden static and generated output

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -393,10 +393,17 @@ fn build_content_disposition(
                 .into(),
         };
         let quoted_filename = escape_quoted_filename(&attached_name);
-        let encoded_filename = utf8_percent_encode(&attached_name, RFC5987_ATTR_CHAR_ENCODE_SET);
-        format!(r#"attachment; filename="{quoted_filename}"; filename*=UTF-8''{encoded_filename}"#)
-            .parse::<HeaderValue>()
-            .map_err(Error::other)?
+        if quoted_filename == attached_name {
+            format!(r#"attachment; filename="{quoted_filename}""#)
+        } else {
+            let encoded_filename =
+                utf8_percent_encode(&attached_name, RFC5987_ATTR_CHAR_ENCODE_SET);
+            format!(
+                r#"attachment; filename="{quoted_filename}"; filename*=UTF-8''{encoded_filename}"#
+            )
+        }
+        .parse::<HeaderValue>()
+        .map_err(Error::other)?
     } else {
         disposition_type
             .parse::<HeaderValue>()

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use enumflags2::{BitFlags, bitflags};
 use headers::*;
 use mime::Mime;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use tokio::fs::File;
 #[allow(unused_imports)]
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -26,6 +27,28 @@ use crate::http::{HttpRange, Request, Response, StatusCode, StatusError};
 use crate::{Depot, Error, Result, Writer, async_trait};
 
 const CHUNK_SIZE: u64 = 1024 * 1024;
+const RFC5987_ATTR_CHAR_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'%')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'{')
+    .add(b'}');
 
 #[bitflags(default = Etag | LastModified | ContentDisposition)]
 #[repr(u8)]
@@ -369,7 +392,9 @@ fn build_content_disposition(
                 .unwrap_or_else(|| "file".into())
                 .into(),
         };
-        format!(r#"attachment; filename="{attached_name}""#)
+        let quoted_filename = escape_quoted_filename(&attached_name);
+        let encoded_filename = utf8_percent_encode(&attached_name, RFC5987_ATTR_CHAR_ENCODE_SET);
+        format!(r#"attachment; filename="{quoted_filename}"; filename*=UTF-8''{encoded_filename}"#)
             .parse::<HeaderValue>()
             .map_err(Error::other)?
     } else {
@@ -378,6 +403,22 @@ fn build_content_disposition(
             .map_err(Error::other)?
     };
     Ok(content_disposition)
+}
+
+fn escape_quoted_filename(filename: &str) -> String {
+    let mut escaped = String::with_capacity(filename.len());
+    for ch in filename.chars() {
+        match ch {
+            '"' | '\\' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            '\t' => escaped.push(' '),
+            ch if ch.is_ascii_control() || !ch.is_ascii() => escaped.push('_'),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
 }
 impl NamedFile {
     /// Create new [`NamedFileBuilder`].
@@ -740,5 +781,42 @@ fn none_match(etag: Option<&ETag>, req_headers: &HeaderMap) -> bool {
                 true
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_disposition_escapes_quoted_filename() {
+        let value = build_content_disposition(
+            "ignored.txt",
+            &mime::APPLICATION_OCTET_STREAM,
+            None,
+            Some("report\"\\\r\n.txt"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            value.to_str().unwrap(),
+            r#"attachment; filename="report\"\\__.txt"; filename*=UTF-8''report%22%5C%0D%0A.txt"#
+        );
+    }
+
+    #[test]
+    fn content_disposition_preserves_non_ascii_with_filename_star() {
+        let value = build_content_disposition(
+            "ignored.txt",
+            &mime::APPLICATION_OCTET_STREAM,
+            None,
+            Some("报告.csv"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            value.to_str().unwrap(),
+            "attachment; filename=\"__.csv\"; filename*=UTF-8''%E6%8A%A5%E5%91%8A.csv"
+        );
     }
 }

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -56,6 +56,7 @@ use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 #[derive(Default)]
 pub struct ForceHttps {
     https_port: Option<u16>,
+    canonical_host: Option<String>,
     skipper: Option<Box<dyn Skipper>>,
 }
 
@@ -63,6 +64,7 @@ impl Debug for ForceHttps {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ForceHttps")
             .field("https_port", &self.https_port)
+            .field("canonical_host", &self.canonical_host)
             .finish()
     }
 }
@@ -79,6 +81,15 @@ impl ForceHttps {
     pub fn https_port(self, port: u16) -> Self {
         Self {
             https_port: Some(port),
+            ..self
+        }
+    }
+
+    /// Specify the public host used in redirect locations.
+    #[must_use]
+    pub fn canonical_host(self, host: impl Into<String>) -> Self {
+        Self {
+            canonical_host: Some(host.into()),
             ..self
         }
     }
@@ -111,7 +122,13 @@ impl Handler for ForceHttps {
         {
             return;
         }
-        if let Some(host) = req.header::<String>(header::HOST) {
+        let redirect_base_host = self
+            .canonical_host
+            .as_deref()
+            .map(Cow::Borrowed)
+            .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned));
+
+        if let Some(host) = redirect_base_host {
             let host = redirect_host(&host, self.https_port);
             let uri_parts = std::mem::take(req.uri_mut()).into_parts();
             let mut builder = Uri::builder().scheme(Scheme::HTTPS).authority(&*host);
@@ -170,6 +187,22 @@ mod tests {
         assert_eq!(
             response.headers().get(LOCATION),
             Some(&"https://127.0.0.1:1234/".parse().unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redirect_handler_uses_canonical_host() {
+        let router = Router::with_hoop(ForceHttps::new().canonical_host("public.example.com"))
+            .goal(hello);
+        let response = TestClient::get("http://127.0.0.1:8698/")
+            .add_header(HOST, "attacker.example", true)
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::PERMANENT_REDIRECT));
+        assert_eq!(
+            response.headers().get(LOCATION),
+            Some(&"https://public.example.com/".parse().unwrap())
         );
     }
 }

--- a/crates/oapi/src/html.rs
+++ b/crates/oapi/src/html.rs
@@ -14,7 +14,13 @@ pub(crate) fn escape_html(value: &str) -> String {
 }
 
 pub(crate) fn json_string(value: &str) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned())
+    serde_json::to_string(value)
+        .unwrap_or_else(|_| "\"\"".to_owned())
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029")
 }
 
 pub(crate) fn keywords_meta(value: &str) -> String {
@@ -52,7 +58,11 @@ mod tests {
 
     #[test]
     fn test_json_string() {
-        assert_eq!(json_string(r#""</script>"#), r#""\"</script>""#);
+        assert_eq!(json_string(r#"""#), r#""\"""#);
+        assert_eq!(
+            json_string("</script>&\u{2028}\u{2029}"),
+            r#""\u003c/script\u003e\u0026\u2028\u2029""#
+        );
     }
 
     #[test]

--- a/crates/oapi/src/html.rs
+++ b/crates/oapi/src/html.rs
@@ -1,0 +1,65 @@
+pub(crate) fn escape_html(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#x27;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+pub(crate) fn json_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned())
+}
+
+pub(crate) fn keywords_meta(value: &str) -> String {
+    let keywords = value
+        .split(',')
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(",");
+    meta_tag("keywords", &keywords)
+}
+
+pub(crate) fn description_meta(value: &str) -> String {
+    meta_tag("description", value)
+}
+
+fn meta_tag(name: &str, value: &str) -> String {
+    format!(
+        "<meta name=\"{}\" content=\"{}\">",
+        escape_html(name),
+        escape_html(value)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_html() {
+        assert_eq!(
+            escape_html(r#"<script a="b">'&</script>"#),
+            "&lt;script a=&quot;b&quot;&gt;&#x27;&amp;&lt;/script&gt;"
+        );
+    }
+
+    #[test]
+    fn test_json_string() {
+        assert_eq!(json_string(r#""</script>"#), r#""\"</script>""#);
+    }
+
+    #[test]
+    fn test_keywords_meta_escapes_content() {
+        assert_eq!(
+            keywords_meta("a,<b>"),
+            r#"<meta name="keywords" content="a,&lt;b&gt;">"#
+        );
+    }
+}

--- a/crates/oapi/src/html.rs
+++ b/crates/oapi/src/html.rs
@@ -23,6 +23,10 @@ pub(crate) fn json_string(value: &str) -> String {
         .replace('\u{2029}', "\\u2029")
 }
 
+pub(crate) fn style_text(value: &str) -> String {
+    value.replace("</", "<\\/")
+}
+
 pub(crate) fn keywords_meta(value: &str) -> String {
     let keywords = value
         .split(',')
@@ -62,6 +66,14 @@ mod tests {
         assert_eq!(
             json_string("</script>&\u{2028}\u{2029}"),
             r#""\u003c/script\u003e\u0026\u2028\u2029""#
+        );
+    }
+
+    #[test]
+    fn test_style_text_breaks_end_tags() {
+        assert_eq!(
+            style_text("body{color:red}</style><script>alert(1)</script>"),
+            "body{color:red}<\\/style><script>alert(1)<\\/script>"
         );
     }
 

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 mod cfg;
 
+mod html;
 mod openapi;
 pub use openapi::*;
 

--- a/crates/oapi/src/rapidoc.rs
+++ b/crates/oapi/src/rapidoc.rs
@@ -9,6 +9,8 @@ use std::borrow::Cow;
 use salvo_core::writing::Text;
 use salvo_core::{async_trait, Depot, FlowCtrl, Handler, Request, Response, Router};
 
+use crate::html::{description_meta, escape_html, keywords_meta};
+
 const INDEX_TMPL: &str = r#"
 <!doctype html>
 <html>
@@ -103,24 +105,19 @@ impl Handler for RapiDoc {
         let keywords = self
             .keywords
             .as_ref()
-            .map(|s| {
-                format!(
-                    "<meta name=\"keywords\" content=\"{}\">",
-                    s.split(',').map(|s| s.trim()).collect::<Vec<_>>().join(",")
-                )
-            })
+            .map(|s| keywords_meta(s))
             .unwrap_or_default();
         let description = self
             .description
             .as_ref()
-            .map(|s| format!("<meta name=\"description\" content=\"{s}\">"))
+            .map(|s| description_meta(s))
             .unwrap_or_default();
         let html = INDEX_TMPL
-            .replacen("{{spec_url}}", &self.spec_url, 1)
-            .replacen("{{lib_url}}", &self.lib_url, 1)
+            .replacen("{{spec_url}}", &escape_html(&self.spec_url), 1)
+            .replacen("{{lib_url}}", &escape_html(&self.lib_url), 1)
             .replacen("{{description}}", &description, 1)
             .replacen("{{keywords}}", &keywords, 1)
-            .replacen("{{title}}", &self.title, 1);
+            .replacen("{{title}}", &escape_html(&self.title), 1);
         res.render(Text::Html(html));
     }
 }

--- a/crates/oapi/src/redoc.rs
+++ b/crates/oapi/src/redoc.rs
@@ -8,6 +8,8 @@ use salvo_core::writing::Text;
 use salvo_core::{async_trait, Depot, FlowCtrl, Handler, Request, Response, Router};
 use std::borrow::Cow;
 
+use crate::html::{description_meta, escape_html, json_string, keywords_meta};
+
 const INDEX_TMPL: &str = r#"
 <!DOCTYPE html>
 <html>
@@ -30,7 +32,7 @@ const INDEX_TMPL: &str = r#"
     <script src="{{lib_url}}"></script>
     <script>
       Redoc.init(
-        "{{spec_url}}",
+        {{spec_url}},
         {},
         document.getElementById("redoc-container")
       );
@@ -118,24 +120,19 @@ impl Handler for ReDoc {
         let keywords = self
             .keywords
             .as_ref()
-            .map(|s| {
-                format!(
-                    "<meta name=\"keywords\" content=\"{}\">",
-                    s.split(',').map(|s| s.trim()).collect::<Vec<_>>().join(",")
-                )
-            })
+            .map(|s| keywords_meta(s))
             .unwrap_or_default();
         let description = self
             .description
             .as_ref()
-            .map(|s| format!("<meta name=\"description\" content=\"{s}\">"))
+            .map(|s| description_meta(s))
             .unwrap_or_default();
         let html = INDEX_TMPL
-            .replacen("{{spec_url}}", &self.spec_url, 1)
-            .replacen("{{lib_url}}", &self.lib_url, 1)
+            .replacen("{{spec_url}}", &json_string(&self.spec_url), 1)
+            .replacen("{{lib_url}}", &escape_html(&self.lib_url), 1)
             .replacen("{{description}}", &description, 1)
             .replacen("{{keywords}}", &keywords, 1)
-            .replacen("{{title}}", &self.title, 1);
+            .replacen("{{title}}", &escape_html(&self.title), 1);
         res.render(Text::Html(html));
     }
 }

--- a/crates/oapi/src/scalar.rs
+++ b/crates/oapi/src/scalar.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use salvo_core::writing::Text;
 use salvo_core::{async_trait, Depot, FlowCtrl, Handler, Request, Response, Router};
 
-use crate::html::{description_meta, escape_html, keywords_meta};
+use crate::html::{description_meta, escape_html, keywords_meta, style_text};
 
 const INDEX_TMPL: &str = r#"
 <!DOCTYPE html>
@@ -125,17 +125,44 @@ impl Handler for Scalar {
         let style = self
             .style
             .as_ref()
-            .map(|s| s.as_ref())
+            .map(|s| style_text(s))
             .unwrap_or_default();
+        let header = self.header.as_deref().map(escape_html).unwrap_or_default();
         let html = INDEX_TMPL
             .replacen("{{lib_url}}", &escape_html(&self.lib_url), 1)
             .replacen("{{spec_url}}", &escape_html(&self.spec_url), 1)
-            .replacen("{{header}}", self.header.as_deref().unwrap_or_default(), 1)
-            .replacen("{{style}}", style, 1)
+            .replacen("{{header}}", &header, 1)
+            .replacen("{{style}}", &style, 1)
             .replacen("{{description}}", &description, 1)
             .replacen("{{keywords}}", &keywords, 1)
             .replacen("{{title}}", &escape_html(&self.title), 1);
         res.render(Text::Html(html));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salvo_core::test::{ResponseExt, TestClient};
+
+    #[tokio::test]
+    async fn scalar_escapes_header_and_style_end_tags() {
+        let mut scalar = Scalar::new("/openapi.json");
+        scalar.header = Some(r#"<img src=x onerror=alert(1)>"#.into());
+        scalar.style = Some("body{color:red}</style><script>alert(1)</script>".into());
+        let router = Router::new().get(scalar);
+
+        let html = TestClient::get("http://127.0.0.1:5801/")
+            .send(router)
+            .await
+            .take_string()
+            .await
+            .unwrap();
+
+        assert!(html.contains("&lt;img src=x onerror=alert(1)&gt;"));
+        assert!(html.contains("<\\/style><script>alert(1)<\\/script>"));
+        assert!(!html.contains(r#"<img src=x onerror=alert(1)>"#));
+        assert!(!html.contains("</style><script>alert(1)</script>"));
     }
 }
 

--- a/crates/oapi/src/scalar.rs
+++ b/crates/oapi/src/scalar.rs
@@ -9,6 +9,8 @@ use std::borrow::Cow;
 use salvo_core::writing::Text;
 use salvo_core::{async_trait, Depot, FlowCtrl, Handler, Request, Response, Router};
 
+use crate::html::{description_meta, escape_html, keywords_meta};
+
 const INDEX_TMPL: &str = r#"
 <!DOCTYPE html>
 <html>
@@ -113,31 +115,26 @@ impl Handler for Scalar {
         let keywords = self
             .keywords
             .as_ref()
-            .map(|s| {
-                format!(
-                    "<meta name=\"keywords\" content=\"{}\">",
-                    s.split(',').map(|s| s.trim()).collect::<Vec<_>>().join(",")
-                )
-            })
+            .map(|s| keywords_meta(s))
             .unwrap_or_default();
         let description = self
             .description
             .as_ref()
-            .map(|s| format!("<meta name=\"description\" content=\"{s}\">"))
+            .map(|s| description_meta(s))
             .unwrap_or_default();
         let style = self
             .style
             .as_ref()
-            .map(|s| format!("<style>{s}</style>"))
+            .map(|s| s.as_ref())
             .unwrap_or_default();
         let html = INDEX_TMPL
-            .replacen("{{lib_url}}", &self.lib_url, 1)
-            .replacen("{{spec_url}}", &self.spec_url, 1)
+            .replacen("{{lib_url}}", &escape_html(&self.lib_url), 1)
+            .replacen("{{spec_url}}", &escape_html(&self.spec_url), 1)
             .replacen("{{header}}", self.header.as_deref().unwrap_or_default(), 1)
-            .replacen("{{style}}", &style, 1)
+            .replacen("{{style}}", style, 1)
             .replacen("{{description}}", &description, 1)
             .replacen("{{keywords}}", &keywords, 1)
-            .replacen("{{title}}", &self.title, 1);
+            .replacen("{{title}}", &escape_html(&self.title), 1);
         res.render(Text::Html(html));
     }
 }

--- a/crates/oapi/src/swagger_ui.rs
+++ b/crates/oapi/src/swagger_ui.rs
@@ -16,6 +16,8 @@ use salvo_core::routing::redirect_to_dir_url;
 use salvo_core::{Depot, Error, FlowCtrl, Handler, Request, Response, Router, async_trait};
 use serde::Serialize;
 
+use crate::html::{description_meta, escape_html, keywords_meta};
+
 #[derive(RustEmbed)]
 #[folder = "src/swagger_ui/v5.32.4"]
 struct SwaggerUiDist;
@@ -223,17 +225,12 @@ impl Handler for SwaggerUi {
         let keywords = self
             .keywords
             .as_ref()
-            .map(|s| {
-                format!(
-                    "<meta name=\"keywords\" content=\"{}\">",
-                    s.split(',').map(|s| s.trim()).collect::<Vec<_>>().join(",")
-                )
-            })
+            .map(|s| keywords_meta(s))
             .unwrap_or_default();
         let description = self
             .description
             .as_ref()
-            .map(|s| format!("<meta name=\"description\" content=\"{s}\">"))
+            .map(|s| description_meta(s))
             .unwrap_or_default();
         match serve(path, &self.title, &keywords, &description, &self.config) {
             Ok(Some(file)) => {
@@ -387,7 +384,7 @@ pub fn serve<'a>(
             .replacen("{{config}}", &config_json, 1)
             .replacen("{{description}}", description, 1)
             .replacen("{{keywords}}", keywords, 1)
-            .replacen("{{title}}", title, 1);
+            .replacen("{{title}}", &escape_html(title), 1);
 
         if let Some(oauth) = &config.oauth {
             let oauth_json = serde_json::to_string(oauth)?;

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -403,6 +403,9 @@ impl Handler for StaticDir {
         if abs_path.is_none() && !fallback.is_empty() {
             for root in &self.roots {
                 let raw_path = join_path!(root, fallback);
+                if !Path::new(&raw_path).starts_with(root) {
+                    continue;
+                }
                 if self.exclude_filters.iter().any(|filter| filter(&raw_path)) {
                     continue;
                 }
@@ -556,7 +559,7 @@ fn list_xml(current: &CurrentInfo) -> String {
             let _ = write!(
                 ftxt,
                 "<dir><name>{}</name><modified>{}</modified><link>{}</link></dir>",
-                dir.name,
+                xml_escape(&dir.name),
                 dir.modified.format(&format).expect("format time failed"),
                 encode_url_path(&dir.name),
             );
@@ -565,7 +568,7 @@ fn list_xml(current: &CurrentInfo) -> String {
             let _ = write!(
                 ftxt,
                 "<file><name>{}</name><modified>{}</modified><size>{}</size><link>{}</link></file>",
-                file.name,
+                xml_escape(&file.name),
                 file.modified.format(&format).expect("format time failed"),
                 file.size,
                 encode_url_path(&file.name),
@@ -575,6 +578,22 @@ fn list_xml(current: &CurrentInfo) -> String {
     ftxt.push_str("</list>");
     ftxt
 }
+
+fn xml_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 fn human_size(bytes: u64) -> String {
     let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
     let mut index = 0;
@@ -725,7 +744,7 @@ const HOME_ICON: &str = r#"<svg aria-hidden="true" data-icon="home" viewBox="0 0
 
 #[cfg(test)]
 mod tests {
-    use crate::dir::human_size;
+    use crate::dir::{human_size, xml_escape};
 
     #[tokio::test]
     async fn test_convert_bytes_to_units() {
@@ -747,5 +766,13 @@ mod tests {
 
         assert_eq!("1 PB", human_size(unit * unit * unit * unit * unit));
         assert_eq!("1 PB", human_size(unit * unit * unit * unit * unit - 1));
+    }
+
+    #[test]
+    fn test_xml_escape() {
+        assert_eq!(
+            xml_escape(r#"<script a="b">'&</script>"#),
+            "&lt;script a=&quot;b&quot;&gt;&apos;&amp;&lt;/script&gt;"
+        );
     }
 }

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::fs::Metadata;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 use std::time::SystemTime;
 
@@ -400,7 +400,7 @@ impl Handler for StaticDir {
             }
         }
         let fallback = self.fallback.as_deref().unwrap_or_default();
-        if abs_path.is_none() && !fallback.is_empty() {
+        if abs_path.is_none() && !fallback.is_empty() && is_safe_relative_path(fallback) {
             for root in &self.roots {
                 let raw_path = join_path!(root, fallback);
                 if !Path::new(&raw_path).starts_with(root) {
@@ -579,6 +579,14 @@ fn list_xml(current: &CurrentInfo) -> String {
     ftxt
 }
 
+fn is_safe_relative_path(path: &str) -> bool {
+    let path = Path::new(path);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
 fn xml_escape(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
@@ -744,7 +752,7 @@ const HOME_ICON: &str = r#"<svg aria-hidden="true" data-icon="home" viewBox="0 0
 
 #[cfg(test)]
 mod tests {
-    use crate::dir::{human_size, xml_escape};
+    use crate::dir::{human_size, is_safe_relative_path, xml_escape};
 
     #[tokio::test]
     async fn test_convert_bytes_to_units() {
@@ -774,5 +782,14 @@ mod tests {
             xml_escape(r#"<script a="b">'&</script>"#),
             "&lt;script a=&quot;b&quot;&gt;&apos;&amp;&lt;/script&gt;"
         );
+    }
+
+    #[test]
+    fn test_fallback_path_must_stay_relative() {
+        assert!(is_safe_relative_path("index.html"));
+        assert!(is_safe_relative_path("./spa/index.html"));
+        assert!(!is_safe_relative_path("../secret.html"));
+        assert!(!is_safe_relative_path("spa/../../secret.html"));
+        assert!(!is_safe_relative_path("/var/www/index.html"));
     }
 }

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -233,6 +233,11 @@ impl Tus {
         self
     }
 
+    pub fn canonical_origin(mut self, origin: impl Into<String>) -> Self {
+        self.options.canonical_origin = Some(origin.into());
+        self
+    }
+
     pub fn allowed_origins<I, S>(mut self, origins: I) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -79,6 +79,9 @@ pub struct TusOptions {
     /// Return a relative URL as the `Location` header.
     pub relative_location: bool,
 
+    /// Canonical origin used for absolute `Location` headers.
+    pub canonical_origin: Option<String>,
+
     /// Allow forwarded headers override Location
     pub respect_forwarded_headers: bool,
 
@@ -211,6 +214,13 @@ impl TusOptions {
             return Ok(format!("{path}/{upload_id}"));
         }
 
+        if let Some(origin) = &self.canonical_origin {
+            return Ok(format!(
+                "{}{path}/{upload_id}",
+                origin.trim_end_matches('/')
+            ));
+        }
+
         Ok(format!("{proto}://{host}{path}/{upload_id}"))
     }
 
@@ -285,6 +295,7 @@ impl Default for TusOptions {
             path: "/tus-files".to_owned(),
             max_size: Some(MaxSize::Fixed(2 * 1024 * 1024 * 1024)), // Default max size 2GiB
             relative_location: true,
+            canonical_origin: None,
             respect_forwarded_headers: false,
             allowed_headers: vec![],
             exposed_headers: vec![],
@@ -464,6 +475,7 @@ mod tests {
 
         assert_eq!(options.path, "/tus-files");
         assert!(options.relative_location);
+        assert!(options.canonical_origin.is_none());
         assert!(!options.respect_forwarded_headers);
         assert!(options.allowed_headers.is_empty());
         assert!(options.exposed_headers.is_empty());
@@ -671,6 +683,22 @@ mod tests {
         let cloned = options.clone();
         assert_eq!(cloned.path, options.path);
         assert_eq!(cloned.relative_location, options.relative_location);
+    }
+
+    #[test]
+    fn test_generate_upload_url_uses_canonical_origin_for_absolute_locations() {
+        let options = TusOptions {
+            relative_location: false,
+            canonical_origin: Some("https://uploads.example.com/base/".to_owned()),
+            ..TusOptions::default()
+        };
+        let mut req = Request::default();
+        req.headers_mut()
+            .insert(header::HOST, "attacker.example".parse().unwrap());
+
+        let url = options.generate_upload_url(&mut req, "abc123").unwrap();
+
+        assert_eq!(url, "https://uploads.example.com/base/tus-files/abc123");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Harden generated output and location/header construction issues from the security review.

- Reject static fallback paths that escape the configured root.
- Escape static directory XML names.
- Generate safer `Content-Disposition` filenames with quoted-string escaping and `filename*` support.
- Add OAPI HTML/JS escaping helpers and apply them to Swagger UI, ReDoc, RapiDoc, and Scalar generated pages.
- Add canonical origin/host configuration for TUS `Location` and ForceHttps redirects.

## Review follow-up

- Escape Scalar `header` content before inserting it into the generated HTML body.
- Keep Scalar custom CSS inside the `<style>` raw-text context by breaking `</...` end tags.
- Reject absolute or parent-directory fallback paths before joining them with static roots.

## Validation

- `cargo test -p salvo_core content_disposition --lib`
- `cargo test -p salvo_extra --features salvo_core/aws-lc-rs test_redirect_handler_uses_canonical_host --lib`
- `cargo test -p salvo-tus --lib`
- `cargo test -p salvo-oapi --all-features --lib`
- `cargo test -p salvo-serve-static --lib`
- `cargo test -p salvo-oapi --all-features scalar_escapes_header_and_style_end_tags --lib`
- `cargo test -p salvo-serve-static test_fallback_path_must_stay_relative --lib`
- `git diff --check`