### PR TITLE
Reduce vulnerable dependency surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ opentelemetry-semantic-conventions = { version = "0.31", default-features = fals
 parking_lot = "0.12"
 path-slash = "0.2"
 percent-encoding = "2"
-paste = "1"
 pin-project = "1"
 proc-macro-crate = { version = ">= 2, <= 4" }
 proc-macro2-diagnostics = { version = "0.10", default-features = true }

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -34,7 +34,7 @@ ring = ["hyper-rustls?/ring"]
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true, optional = true }
-jsonwebtoken = { workspace = true, features = ["aws-lc-rs"] }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 http-body-util = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, optional = true, features = [
     "native-tokio",

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -34,7 +34,7 @@ ring = ["hyper-rustls?/ring"]
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true, optional = true }
-jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
+jsonwebtoken = { workspace = true, features = ["aws-lc-rs"] }
 http-body-util = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, optional = true, features = [
     "native-tokio",

--- a/crates/oapi-macros/Cargo.toml
+++ b/crates/oapi-macros/Cargo.toml
@@ -52,7 +52,6 @@ chrono = { workspace = true, features = ["serde"] }
 assert-json-diff = { workspace = true }
 time = { workspace = true, features = ["serde-human-readable"] }
 serde_with = { workspace = true }
-paste = { workspace = true }
 compact_str = { workspace = true, features = ["serde"] }
 
 [lints]


### PR DESCRIPTION
## Summary

Reduce the vulnerable dependency surface identified in the security review where the workspace can do so without waiting on upstream releases.

- Remove unused `paste` dev-dependency from `salvo-oapi-macros` and the workspace dependency table.
- Switch `salvo-jwt-auth` from `jsonwebtoken/rust_crypto` to `jsonwebtoken/aws-lc-rs`, removing `rsa` from the JWT auth dependency path.
- Leave the remaining `hickory-proto` and `rsa` audit findings isolated to `certon 0.1.3`, which currently constrains `hickory-resolver = ^0.25` and `rsa = ^0.9`.

## Compatibility notes

- `aws_lc_rs` may require native build tooling such as CMake and a working C/C++ toolchain in minimal containers or cross-compilation environments.

## Validation

- `cargo check -p salvo-oapi-macros --no-default-features`
- `cargo check -p salvo-jwt-auth --features full`
- `cargo tree -i rsa`
- `cargo audit` still reports remaining upstream-blocked `certon` advisories for `hickory-proto` and `rsa`.
- `git diff --check`