### PR TITLE
[codex] Clamp size limiter request limit

### DIFF
--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -87,16 +87,17 @@ impl Handler for MaxSize {
             return;
         }
 
-        let Ok(max_size) = usize::try_from(self.0) else {
-            res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
-            ctrl.skip_rest();
-            return;
-        };
-
+        let max_size = request_limit(self.0);
         req.limit_body(max_size);
         ctrl.call_next(req, depot, res).await;
     }
 }
+
+#[inline]
+fn request_limit(max_size: u64) -> usize {
+    max_size.min(usize::MAX as u64) as usize
+}
+
 /// Create a new `MaxSize`.
 #[inline]
 #[must_use] pub fn max_size(size: u64) -> MaxSize {
@@ -202,5 +203,11 @@ mod tests {
             .await;
 
         assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn test_request_limit_clamps_to_platform_usize() {
+        assert_eq!(request_limit(4), 4);
+        assert_eq!(request_limit(u64::MAX), usize::MAX);
     }
 }


### PR DESCRIPTION
## Summary

Clamp the request size limit used by `salvo_extra::size_limiter::MaxSize` to the platform `usize::MAX` instead of returning `500 INTERNAL_SERVER_ERROR` when the configured `u64` limit exceeds the current target's `usize` range.

## Why

PR #1439 introduced a `usize::try_from(self.0)` conversion in request handling. On 32-bit targets, configurations above `usize::MAX` would fail every request with a server error even though the intended behavior is simply to enforce the largest representable streaming limit on that platform.

## Impact

This keeps oversized `MaxSize` configurations from regressing into persistent 500s on 32-bit deployments while preserving the streaming size limiter behavior.

## Root Cause

The request path treated `u64 -> usize` conversion failure as an internal error instead of saturating the runtime limit to the platform maximum.

## Validation

Not run locally (not requested).
