### PR TITLE
fix(tus): make response headers panic-safe and reject invalid metadata keys

### DIFF
--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -95,25 +95,27 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             Some(TusError::Internal("Upload file's offset value not found!".into()).status());
         return;
     };
-    headers.insert(
-        "Upload-Offset",
-        HeaderValue::from_str(&offset.to_string()).unwrap(),
-    );
+    headers.insert("Upload-Offset", HeaderValue::from(*offset));
 
     if upload_info.get_size_is_deferred() {
         headers.insert("Upload-Defer-Length", HeaderValue::from_static("1"));
     } else if let Some(size) = &upload_info.size {
-        headers.insert(
-            "Upload-Length",
-            HeaderValue::from_str(&size.to_string()).unwrap(),
-        );
+        headers.insert("Upload-Length", HeaderValue::from(*size));
     }
 
     if let Some(metadata) = upload_info.metadata {
-        headers.insert(
-            "Upload-Metadata",
-            HeaderValue::from_str(&Metadata::stringify(metadata)).unwrap(),
-        );
+        match HeaderValue::from_str(&Metadata::stringify(metadata)) {
+            Ok(v) => {
+                headers.insert("Upload-Metadata", v);
+            }
+            Err(_) => {
+                res.status_code = Some(
+                    TusError::Internal("Stored Upload-Metadata is not a valid header".into())
+                        .status(),
+                );
+                return;
+            }
+        }
     }
 
     if let Some(expires_at) = expires_at {
@@ -123,10 +125,9 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         };
         if !is_finished {
             let expires_value = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-            headers.insert(
-                H_UPLOAD_EXPIRES,
-                HeaderValue::from_str(&expires_value).unwrap(),
-            );
+            if let Ok(v) = HeaderValue::from_str(&expires_value) {
+                headers.insert(H_UPLOAD_EXPIRES, v);
+            }
         }
     }
 }

--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -105,7 +105,9 @@ pub(crate) fn insert_joined_header(
     extra_values: &[String],
 ) {
     if extra_values.is_empty() {
-        headers.insert(name, HeaderValue::from_str(default_values).unwrap());
+        if let Ok(v) = HeaderValue::from_str(default_values) {
+            headers.insert(name, v);
+        }
         return;
     }
 
@@ -177,7 +179,14 @@ impl Metadata {
 }
 
 fn validate_key(key: &str) -> bool {
-    !key.is_empty() && !key.contains(' ') && !key.contains(',')
+    if key.is_empty() {
+        return false;
+    }
+    // The TUS spec requires Upload-Metadata keys to consist of ASCII characters,
+    // excluding spaces and commas. We additionally require visible ASCII so the
+    // value can be safely placed back into a response header without panics or
+    // header-injection (CR/LF/NUL/DEL/non-ASCII are rejected).
+    key.bytes().all(|b| (0x21..=0x7e).contains(&b) && b != b',')
 }
 
 fn validate_value(value: &str) -> bool {
@@ -285,6 +294,33 @@ mod tests {
     fn test_metadata_parse_key_with_space() {
         // Keys cannot contain spaces
         let result = Metadata::parse_metadata("file name dGVzdA==");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_metadata_parse_key_rejects_control_characters() {
+        // Keys with CR / LF / NUL / DEL must be rejected so they cannot later be
+        // round-tripped into a response `Upload-Metadata` header value (which
+        // would otherwise either panic during header construction or, if a
+        // future caller built the header without validation, allow header
+        // injection).
+        for raw in [
+            "foo\rbar dGVzdA==",
+            "foo\nbar dGVzdA==",
+            "foo\0bar dGVzdA==",
+            "foo\x7fbar dGVzdA==",
+            "foo\tbar dGVzdA==",
+        ] {
+            let result = Metadata::parse_metadata(raw);
+            assert!(result.is_err(), "expected reject for raw = {raw:?}");
+        }
+    }
+
+    #[test]
+    fn test_metadata_parse_key_rejects_non_ascii() {
+        // Non-ASCII keys are not valid header value bytes; reject at parse so
+        // we never try to re-emit them.
+        let result = Metadata::parse_metadata("名前 dGVzdA==");
         assert!(result.is_err());
     }
 

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -26,10 +26,7 @@ async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     if max_size > 0 {
-        headers.insert(
-            H_TUS_MAX_SIZE,
-            HeaderValue::from_str(max_size.to_string().as_str()).expect("invalid header value"),
-        );
+        headers.insert(H_TUS_MAX_SIZE, HeaderValue::from(max_size));
     }
 
     headers.insert(

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -246,10 +246,9 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
 
         if !is_finished {
             let expires_value = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-            res.headers.insert(
-                H_UPLOAD_EXPIRES,
-                HeaderValue::from_str(&expires_value).unwrap(),
-            );
+            if let Ok(v) = HeaderValue::from_str(&expires_value) {
+                res.headers.insert(H_UPLOAD_EXPIRES, v);
+            }
         }
     }
 
@@ -258,10 +257,8 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     // The new offset MUST be the sum of the offset before the PATCH request and the number of bytes
     // received and processed or stored during the current PATCH request.
     res.status_code = Some(StatusCode::NO_CONTENT);
-    res.headers.insert(
-        H_UPLOAD_OFFSET,
-        HeaderValue::from_str(&new_offset.to_string()).unwrap(),
-    );
+    res.headers
+        .insert(H_UPLOAD_OFFSET, HeaderValue::from(new_offset));
 }
 
 pub fn patch_handler() -> Router {

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -245,10 +245,8 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             };
 
             upload.offset = Some(written);
-            res.headers.insert(
-                H_UPLOAD_OFFSET,
-                HeaderValue::from_str(&written.to_string()).unwrap(),
-            );
+            res.headers
+                .insert(H_UPLOAD_OFFSET, HeaderValue::from(written));
         }
 
         upload.size.is_some_and(|x| x == 0) && !upload.get_size_is_deferred()
@@ -281,10 +279,9 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         {
             let expires = created_at.with_timezone(&chrono::Utc) + delta;
             let expires_value = expires.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-            res.headers.insert(
-                H_UPLOAD_EXPIRES,
-                HeaderValue::from_str(&expires_value).unwrap(),
-            );
+            if let Ok(v) = HeaderValue::from_str(&expires_value) {
+                res.headers.insert(H_UPLOAD_EXPIRES, v);
+            }
         }
     }
 
@@ -322,9 +319,21 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     // expires. If expiration is known at creation time, Upload-Expires header MUST be included
     // in the response
 
-    if res.status_code == Some(StatusCode::CREATED) || res.status_code.unwrap().is_redirection() {
-        res.headers
-            .insert("Location", HeaderValue::from_str(&url).unwrap());
+    let should_set_location = matches!(res.status_code, Some(StatusCode::CREATED))
+        || res.status_code.is_some_and(|s| s.is_redirection());
+    if should_set_location {
+        match HeaderValue::from_str(&url) {
+            Ok(v) => {
+                res.headers.insert("Location", v);
+            }
+            Err(_) => {
+                res.status_code = Some(
+                    TusError::Internal("Generated upload URL is not a valid header value".into())
+                        .status(),
+                );
+                return;
+            }
+        }
     }
 
     if res.body.is_none() {


### PR DESCRIPTION
## Summary

- The TUS handlers used `HeaderValue::from_str(...).unwrap()` / `.expect(...)` for response headers built from `Upload-Metadata`, generated `Location` URLs, expiry timestamps, and numeric offsets. The numeric and RFC 1123 timestamps are safe ASCII, but `Upload-Metadata` is round-tripped from client-supplied headers whose key validation only excluded space and comma. A POST that smuggled CR/LF/NUL/DEL bytes inside an `Upload-Metadata` key would either panic the request task on a subsequent HEAD/GET, or — if the panic ever stopped happening — allow header injection on the response.
- Tighten `validate_key` to require visible ASCII (`0x21..=0x7e` excluding `,`) so metadata can be safely re-emitted, and replace the unwraps in the head/patch/post/options/mod handlers with explicit error handling or zero-allocation `HeaderValue::from(u64)` for numeric values. The pattern guard around the `Location` header now also avoids `status_code.unwrap()` on the `is_redirection()` branch.
- Add unit tests covering CTL and non-ASCII keys.

## Test plan

- [x] `cargo check -p salvo-tus`
- [x] `cargo test -p salvo-tus --lib` (225 passed, 0 failed)
- [ ] Reviewer-run integration tests against a TUS client