### PR TITLE
fix: remove panic paths and oversharing in auth/otel/acme

### DIFF
--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -171,7 +171,13 @@ impl Handler for Http01Handler {
                 return;
             }
 
-            tracing::error!(token, "key not found for ACME challenge token");
+            // Log only the length, not the token itself, so log/APM/SIEM
+            // pipelines do not become a credential surface for the ACME
+            // challenge flow.
+            tracing::error!(
+                token_len = token.len(),
+                "key not found for ACME challenge token"
+            );
             res.render(token);
         } else {
             res.render(StatusError::not_found().brief("missing token"));

--- a/crates/extra/src/basic_auth.rs
+++ b/crates/extra/src/basic_auth.rs
@@ -33,7 +33,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use base64::engine::{Engine, general_purpose};
-use salvo_core::http::header::{AUTHORIZATION, HeaderName, PROXY_AUTHORIZATION};
+use salvo_core::http::header::{AUTHORIZATION, HeaderName, HeaderValue, PROXY_AUTHORIZATION};
 use salvo_core::http::{Request, Response, StatusCode};
 use salvo_core::{Depot, Error, FlowCtrl, Handler, async_trait};
 
@@ -146,12 +146,15 @@ where
 #[doc(hidden)]
 #[inline]
 pub fn ask_credentials(res: &mut Response, realm: impl AsRef<str>) {
-    res.headers_mut().insert(
-        "WWW-Authenticate",
-        format!("Basic realm={:?}", realm.as_ref())
-            .parse()
-            .expect("parse WWW-Authenticate failed"),
-    );
+    // `{:?}` already escapes CR/LF, but a realm carrying other bytes that
+    // are not legal `HeaderValue` characters (anything outside visible ASCII)
+    // would still cause the parse to fail. Fall back to a bare challenge in
+    // that case so the request resolves with a 401 instead of panicking the
+    // request task.
+    let challenge = format!("Basic realm={:?}", realm.as_ref());
+    let value = HeaderValue::try_from(challenge)
+        .unwrap_or_else(|_| HeaderValue::from_static("Basic"));
+    res.headers_mut().insert("WWW-Authenticate", value);
     res.status_code(StatusCode::UNAUTHORIZED);
 }
 

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -46,11 +46,19 @@ where
 
         // TODO: Will remove after opentelemetry_http updated
         let mut headers = HeaderMap::with_capacity(req.headers().len());
-        headers.extend(req.headers().into_iter().map(|(name, value)| {
-            let name = HeaderName::from_bytes(name.as_ref()).expect("invalid header name");
-            let value = HeaderValue::from_bytes(value.as_ref()).expect("invalid header value");
-            (name, value)
-        }));
+        for (name, value) in req.headers() {
+            // The names/values come from a `HeaderMap`, so they were already
+            // valid for `HeaderName`/`HeaderValue`. Skip silently in the
+            // unlikely event that round-tripping through bytes fails — losing
+            // a propagated header is preferable to panicking the request task.
+            let Ok(name) = HeaderName::from_bytes(name.as_ref()) else {
+                continue;
+            };
+            let Ok(value) = HeaderValue::from_bytes(value.as_ref()) else {
+                continue;
+            };
+            headers.insert(name, value);
+        }
 
         let parent_cx = global::get_text_map_propagator(|propagator| {
             propagator.extract(&HeaderExtractor(&headers))

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -57,7 +57,10 @@ where
             let Ok(value) = HeaderValue::from_bytes(value.as_ref()) else {
                 continue;
             };
-            headers.insert(name, value);
+            // Use `append` so multi-value headers (e.g. `baggage`) keep all
+            // their values; `insert` would collapse them to the last one and
+            // produce an incomplete parent context for `HeaderExtractor`.
+            headers.append(name, value);
         }
 
         let parent_cx = global::get_text_map_propagator(|propagator| {


### PR DESCRIPTION
## Summary

Three small hardening changes:

- **basic_auth**: `salvo_extra::basic_auth::ask_credentials` was building the `WWW-Authenticate` header by formatting the realm with `{:?}` and `.parse().expect(...)`. A realm carrying bytes that are not legal `HeaderValue` characters would panic the request task on every 401. Use `HeaderValue::try_from` and fall back to a bare `Basic` challenge on failure so the request still resolves with a 401.
- **otel**: `salvo-otel`'s tracing middleware copied incoming request headers into a fresh `HeaderMap` and called `expect(\"invalid header name\")` / `expect(\"invalid header value\")`. The values are already validated upstream so the panic is unreachable in practice, but the defensive-in-depth fix is to skip the offending header rather than abort the request.
- **acme**: `salvo-acme` logged the full ACME challenge token at error level when a lookup missed. Challenge tokens are public during validation but there is no reason to mirror them into log/APM pipelines as a credential surface; record only the length.

## Test plan

- [x] `cargo check -p salvo-otel -p salvo_extra -p salvo-acme --all-features`
- [x] `cargo test -p salvo_extra basic_auth -p salvo-otel -p salvo-acme --all-features --lib`