### PR TITLE
feat: preserve OIDC body-read error source and enrich Proxy Debug

### DIFF
--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -227,7 +227,7 @@ pub enum JwtAuthError {
     #[cfg(feature = "oidc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]
     #[error("OIDC response body read failed: {0}")]
-    OidcBodyRead(String),
+    OidcBodyRead(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// OIDC response body exceeded the configured limit.
     #[cfg(feature = "oidc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "oidc")))]

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -478,7 +478,7 @@ async fn collect_limited_body(
             if error.is::<http_body_util::LengthLimitError>() {
                 JwtAuthError::OidcResponseTooLarge(max_size)
             } else {
-                JwtAuthError::OidcBodyRead(error.to_string())
+                JwtAuthError::OidcBodyRead(error)
             }
         })?;
     Ok(collected.to_bytes())

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -316,7 +316,16 @@ where
     C: Client,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Proxy").finish()
+        f.debug_struct("Proxy")
+            .field(
+                "client_ip_forwarding_enabled",
+                &self.client_ip_forwarding_enabled,
+            )
+            .field(
+                "strict_path_normalization_enabled",
+                &self.strict_path_normalization_enabled,
+            )
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
## Summary

- **OIDC error chain**: `JwtAuthError::OidcBodyRead` was holding only the `Display` text of the underlying error, so callers walking `Error::source()` could not reach the original hyper/io error. Switch the variant to carry `Box<dyn std::error::Error + Send + Sync>` and mark it `#[source]`, letting consumers continue to chain through the body-read failure while keeping the existing `Display` output unchanged.
- **Proxy Debug**: `Proxy<U, C>`'s manual `Debug` impl previously printed an empty `Proxy {}`, hiding the very settings (client-IP forwarding, strict path normalization) that operators want to confirm at boot time. Print those flags and mark the struct non-exhaustive so future fields do not break the formatting contract.

## Compatibility note

The `OidcBodyRead` variant's tuple field type changes from `String` to `Box<dyn std::error::Error + Send + Sync>`. This is a breaking change for any downstream code that pattern-matches on the variant's payload; the `Display` text emitted via `#[error(\"...\")]` is unchanged, so log-only consumers are unaffected. Suggested for the next minor version bump.

## Test plan

- [x] `cargo check -p salvo-jwt-auth --all-features`
- [x] `cargo check -p salvo-proxy --all-features`
- [x] `cargo test -p salvo-jwt-auth -p salvo-proxy --all-features --lib`