### PR TITLE
refactor(routing): expose structured filter info instead of debug-string scraping

### DIFF
--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -18,6 +18,32 @@ use crate::http::uri::Scheme;
 use crate::http::{Method, Request};
 use crate::routing::PathState;
 
+/// Structured description of a [`Filter`], used by `Router`'s `Debug`
+/// implementation and by `salvo-oapi` to introspect a routing tree.
+///
+/// Each built-in filter overrides [`Filter::info`] to return the matching
+/// variant. Custom filters fall back to [`FilterInfo::Other`] with the
+/// implementing type's name. Returning structured data instead of relying on
+/// the `Debug` string format keeps consumers from breaking when a filter's
+/// `Debug` representation changes.
+#[derive(Clone, Debug)]
+pub enum FilterInfo {
+    /// Path pattern (raw, unparsed) of a [`PathFilter`].
+    Path(String),
+    /// HTTP method matched by a [`MethodFilter`].
+    Method(Method),
+    /// URI scheme matched by a [`SchemeFilter`].
+    Scheme(Scheme),
+    /// Host name matched by a [`HostFilter`].
+    Host(String),
+    /// Port matched by a [`PortFilter`].
+    Port(u16),
+    /// Catch-all for filter types that do not expose structured info — typically
+    /// composite filters (`And`, `Or`, `AndThen`, `OrElse`), `FnFilter`, or
+    /// user-defined filters. Carries the implementor's type name.
+    Other(&'static str),
+}
+
 /// Trait for filter request.
 ///
 /// View [module level documentation](../index.html) for more details.
@@ -31,6 +57,16 @@ pub trait Filter: Debug + Send + Sync + 'static {
     #[doc(hidden)]
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
+    }
+
+    /// Returns a structured description of what this filter matches.
+    ///
+    /// The default returns [`FilterInfo::Other`] with the implementing type's
+    /// name. Built-in filters override this to expose typed data so that
+    /// downstream code (router debug printing, OpenAPI introspection) does
+    /// not have to scrape the [`Debug`] output.
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Other(self.type_name())
     }
     /// Create a new filter use `And` filter.
     #[inline]

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Debug, Formatter};
 use crate::async_trait;
 use crate::http::uri::Scheme;
 use crate::http::{Method, Request};
-use crate::routing::{Filter, PathState};
+use crate::routing::{Filter, FilterInfo, PathState};
 
 /// Filter by request method
 #[derive(Clone, PartialEq, Eq)]
@@ -21,6 +21,10 @@ impl Filter for MethodFilter {
     #[inline]
     async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         req.method() == self.0
+    }
+    #[inline]
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Method(self.0.clone())
     }
 }
 impl Debug for MethodFilter {
@@ -64,6 +68,10 @@ impl Filter for SchemeFilter {
             .scheme()
             .map(|s| s == &self.scheme)
             .unwrap_or(self.lack)
+    }
+    #[inline]
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Scheme(self.scheme.clone())
     }
 }
 impl Debug for SchemeFilter {
@@ -123,6 +131,10 @@ impl Filter for HostFilter {
         .map(|h| h == self.host)
         .unwrap_or(self.lack)
     }
+    #[inline]
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Host(self.host.clone())
+    }
 }
 impl Debug for HostFilter {
     #[inline]
@@ -181,6 +193,10 @@ impl Filter for PortFilter {
         .and_then(|p| p.parse::<u16>().ok())
         .map(|p| p == self.port)
         .unwrap_or(self.lack)
+    }
+    #[inline]
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Port(self.port)
     }
 }
 impl Debug for PortFilter {

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 
 use crate::async_trait;
 use crate::http::Request;
-use crate::routing::{Filter, PathState};
+use crate::routing::{Filter, FilterInfo, PathState};
 
 /// PathWisp
 pub trait PathWisp: Send + Sync + fmt::Debug + 'static {
@@ -1029,6 +1029,10 @@ impl Filter for PathFilter {
     #[inline]
     async fn filter(&self, _req: &mut Request, state: &mut PathState) -> bool {
         self.detect(state)
+    }
+    #[inline]
+    fn info(&self) -> FilterInfo {
+        FilterInfo::Path(self.raw_value.clone())
     }
 }
 impl PathFilter {

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::filters::{self, FnFilter, PathFilter};
-use super::{DetectMatched, Filter, PathState};
+use super::{DetectMatched, Filter, FilterInfo, PathState};
 use crate::handler::{Handler, WhenHoop};
 use crate::http::uri::Scheme;
 use crate::{Depot, Request};
@@ -427,23 +427,19 @@ const SYMBOL_RIGHT: &str = "─";
 impl Debug for Router {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         fn print(f: &mut Formatter, prefix: &str, last: bool, router: &Router) -> fmt::Result {
-            let mut path = "".to_owned();
+            let mut path = String::new();
             let mut others = Vec::with_capacity(router.filters.len());
             if router.filters.is_empty() {
                 "!NULL!".clone_into(&mut path);
             } else {
                 for filter in &router.filters {
-                    let info = format!("{filter:?}");
-                    if info.starts_with("path:") {
-                        info.split_once(':')
-                            .expect("`split_once` get `None`")
-                            .1
-                            .clone_into(&mut path)
-                    } else {
-                        let mut parts = info.splitn(2, ':').collect::<Vec<_>>();
-                        if !parts.is_empty() {
-                            others.push(parts.pop().expect("part should exists.").to_owned());
-                        }
+                    match filter.info() {
+                        FilterInfo::Path(p) => path = p,
+                        FilterInfo::Method(m) => others.push(format!("{m:?}")),
+                        FilterInfo::Scheme(s) => others.push(format!("{s:?}")),
+                        FilterInfo::Host(h) => others.push(format!("{h:?}")),
+                        FilterInfo::Port(p) => others.push(format!("{p:?}")),
+                        FilterInfo::Other(_) => others.push(format!("{filter:?}")),
                     }
                 }
             }

--- a/crates/oapi/src/routing.rs
+++ b/crates/oapi/src/routing.rs
@@ -3,6 +3,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{LazyLock, RwLock};
 
 use salvo_core::Router;
+use salvo_core::http::Method;
+use salvo_core::routing::FilterInfo;
 
 use crate::SecurityRequirement;
 use crate::path::PathItemType;
@@ -103,30 +105,27 @@ impl NormNode {
         }
 
         for filter in router.filters() {
-            let info = format!("{filter:?}");
-            if info.starts_with("path:") {
-                let path = info
-                    .split_once(':')
-                    .expect("split once by ':' should not be get `None`")
-                    .1;
-                node.path = Some(normalize_oapi_path(path));
-            } else if info.starts_with("method:") {
-                match info
-                    .split_once(':')
-                    .expect("split once by ':' should not be get `None`.")
-                    .1
-                {
-                    "GET" => node.method = Some(PathItemType::Get),
-                    "POST" => node.method = Some(PathItemType::Post),
-                    "PUT" => node.method = Some(PathItemType::Put),
-                    "DELETE" => node.method = Some(PathItemType::Delete),
-                    "HEAD" => node.method = Some(PathItemType::Head),
-                    "OPTIONS" => node.method = Some(PathItemType::Options),
-                    "CONNECT" => node.method = Some(PathItemType::Connect),
-                    "TRACE" => node.method = Some(PathItemType::Trace),
-                    "PATCH" => node.method = Some(PathItemType::Patch),
-                    _ => {}
+            match filter.info() {
+                FilterInfo::Path(path) => {
+                    node.path = Some(normalize_oapi_path(&path));
                 }
+                FilterInfo::Method(method) => {
+                    node.method = match method {
+                        Method::GET => Some(PathItemType::Get),
+                        Method::POST => Some(PathItemType::Post),
+                        Method::PUT => Some(PathItemType::Put),
+                        Method::DELETE => Some(PathItemType::Delete),
+                        Method::HEAD => Some(PathItemType::Head),
+                        Method::OPTIONS => Some(PathItemType::Options),
+                        Method::CONNECT => Some(PathItemType::Connect),
+                        Method::TRACE => Some(PathItemType::Trace),
+                        Method::PATCH => Some(PathItemType::Patch),
+                        _ => None,
+                    };
+                }
+                // Other filter kinds (Scheme/Host/Port/Other) do not carry
+                // information that maps to OpenAPI path items.
+                _ => {}
             }
         }
         node.handler_type_id = router.goal.as_ref().map(|h| h.type_id());

--- a/crates/oapi/src/routing.rs
+++ b/crates/oapi/src/routing.rs
@@ -110,7 +110,13 @@ impl NormNode {
                     node.path = Some(normalize_oapi_path(&path));
                 }
                 FilterInfo::Method(method) => {
-                    node.method = match method {
+                    // Only overwrite when the method maps to a known
+                    // `PathItemType`; unknown/extension methods leave any
+                    // previously recognized value in place so combining a
+                    // standard method filter with a custom one does not erase
+                    // the standard mapping (the previous string-parsing path
+                    // had the same behavior via its `_ => {}` arm).
+                    let item = match method {
                         Method::GET => Some(PathItemType::Get),
                         Method::POST => Some(PathItemType::Post),
                         Method::PUT => Some(PathItemType::Put),
@@ -122,6 +128,9 @@ impl NormNode {
                         Method::PATCH => Some(PathItemType::Patch),
                         _ => None,
                     };
+                    if item.is_some() {
+                        node.method = item;
+                    }
                 }
                 // Other filter kinds (Scheme/Host/Port/Other) do not carry
                 // information that maps to OpenAPI path items.


### PR DESCRIPTION
## Summary

Both `Router`'s `Debug` impl and `salvo-oapi`'s `NormNode::new` previously reconstructed routing-tree information by formatting each filter through its `Debug` implementation and then string-parsing the result with `starts_with(\"path:\")` / `split_once(':').expect(...)`. This made the `Debug` text format a load-bearing wire protocol: any change to a filter's `Debug` representation silently broke OpenAPI generation, and the `expect` calls would panic outright on a format drift.

Add a structured `FilterInfo` enum on the `Filter` trait:

\`\`\`rust
pub enum FilterInfo {
    Path(String),
    Method(Method),
    Scheme(Scheme),
    Host(String),
    Port(u16),
    Other(&'static str),
}
\`\`\`

Built-in filters (`PathFilter`, `MethodFilter`, `SchemeFilter`, `HostFilter`, `PortFilter`) override `Filter::info()`. The default impl returns `Other(self.type_name())` so existing third-party `Filter` implementations keep compiling. Each filter's existing `Debug` impl is preserved; it is still useful for ad-hoc logging but is no longer the contract that downstream code relies on.

Both consumers were rewritten to match on `FilterInfo` directly. The `test_router_debug` golden output is unchanged because `Method::GET` debug-formats identically to what the previous `splitn(2, ':')` extraction produced.

## Compatibility

Adds a new method `Filter::info()` to a public trait, but with a default implementation. Downstream `Filter` implementors do not have to change anything; they simply continue to fall into the `FilterInfo::Other(type_name)` bucket, which is the same treatment they got before (which is to say, none).

## Test plan

- [x] `cargo test -p salvo_core --all-features --lib routing` — 58/58 pass (incl. `test_router_debug` golden output)
- [x] `cargo test -p salvo-oapi --all-features --lib` — 260/260 pass
- [x] `cargo check -p salvo_core -p salvo-oapi --all-features`