### PR TITLE
fix(oapi): correct three OpenAPI 3.1 spec deviations

### DIFF
--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -1,5 +1,6 @@
 //! Rust implementation of Openapi Spec V3.1.
 
+mod callback;
 mod components;
 mod content;
 mod encoding;
@@ -28,6 +29,7 @@ use salvo_core::{Depot, FlowCtrl, Handler, Router, async_trait, writing};
 use serde::de::{Error, Expected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+pub use self::callback::Callback;
 pub use self::components::Components;
 pub use self::content::Content;
 pub use self::encoding::Encoding;

--- a/crates/oapi/src/openapi/callback.rs
+++ b/crates/oapi/src/openapi/callback.rs
@@ -1,0 +1,119 @@
+//! Implements [OpenAPI Callback Object][callback] for operations.
+//!
+//! [callback]: https://spec.openapis.org/oas/latest.html#callback-object
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+
+use super::PathItem;
+use crate::PropMap;
+
+/// Implements [OpenAPI Callback Object][callback].
+///
+/// A map of possible out-of-band callbacks related to the parent operation. Each value in
+/// the map is a [`PathItem`] that describes a set of requests that may be initiated by the API
+/// provider and the expected responses. The key value used to identify the [`PathItem`] is an
+/// expression, evaluated at runtime, that identifies a URL to use for the callback operation.
+///
+/// See the OpenAPI spec for the [Callback Object][callback] for more details on the runtime
+/// [expression][expression] syntax used as keys.
+///
+/// [callback]: https://spec.openapis.org/oas/latest.html#callback-object
+/// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct Callback(pub PropMap<String, PathItem>);
+
+impl Callback {
+    /// Construct a new empty [`Callback`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` if the callback contains no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Insert a runtime expression to [`PathItem`] mapping and return `self`.
+    #[must_use]
+    pub fn path<S: Into<String>, P: Into<PathItem>>(mut self, expression: S, path_item: P) -> Self {
+        self.0.insert(expression.into(), path_item.into());
+        self
+    }
+
+    /// Insert a runtime expression to [`PathItem`] mapping into the callback.
+    pub fn insert<S: Into<String>, P: Into<PathItem>>(&mut self, expression: S, path_item: P) {
+        self.0.insert(expression.into(), path_item.into());
+    }
+}
+
+impl Deref for Callback {
+    type Target = PropMap<String, PathItem>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Callback {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for Callback {
+    type Item = (String, PathItem);
+    type IntoIter = <PropMap<String, PathItem> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<S, P> FromIterator<(S, P)> for Callback
+where
+    S: Into<String>,
+    P: Into<PathItem>,
+{
+    fn from_iter<I: IntoIterator<Item = (S, P)>>(iter: I) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    use super::*;
+    use crate::{Operation, PathItemType};
+
+    #[test]
+    fn callback_default_is_empty() {
+        let callback = Callback::default();
+        assert!(callback.is_empty());
+    }
+
+    #[test]
+    fn callback_serializes_as_map_of_path_items() {
+        let callback = Callback::new().path(
+            "{$request.body#/callbackUrl}",
+            PathItem::new(PathItemType::Post, Operation::new()),
+        );
+
+        assert_json_eq!(
+            callback,
+            json!({
+                "{$request.body#/callbackUrl}": {
+                    "post": { "responses": {} }
+                }
+            })
+        );
+    }
+}

--- a/crates/oapi/src/openapi/operation.rs
+++ b/crates/oapi/src/openapi/operation.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 
 use serde::{Deserialize, Serialize};
 
+use super::callback::Callback;
 use super::request_body::RequestBody;
 use super::response::{Response, Responses};
 use super::{Deprecated, ExternalDocs, RefOr, SecurityRequirement, Server};
@@ -146,9 +147,13 @@ pub struct Operation {
     /// List of possible responses returned by the [`Operation`].
     pub responses: Responses,
 
-    /// Callback information.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub callbacks: Option<String>,
+    /// Map of possible out-of-band callbacks related to this [`Operation`].
+    ///
+    /// The key is a unique identifier for the [`Callback`]; each value describes a set of
+    /// requests that may be initiated by the API provider. Callbacks may be inlined or
+    /// referenced via [`RefOr::Ref`] when reusable callbacks are defined elsewhere.
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub callbacks: PropMap<String, RefOr<Callback>>,
 
     /// Define whether the operation is deprecated or not and thus should be avoided consuming.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -297,6 +302,32 @@ impl Operation {
         self
     }
 
+    /// Replace the [`Operation`]'s callbacks map and return `Self`.
+    #[must_use]
+    pub fn callbacks<I, K, V>(mut self, callbacks: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<RefOr<Callback>>,
+    {
+        self.callbacks = callbacks
+            .into_iter()
+            .map(|(name, callback)| (name.into(), callback.into()))
+            .collect();
+        self
+    }
+
+    /// Append a single named [`Callback`] to the [`Operation`] callbacks map and return `Self`.
+    #[must_use]
+    pub fn add_callback<K: Into<String>, V: Into<RefOr<Callback>>>(
+        mut self,
+        name: K,
+        callback: V,
+    ) -> Self {
+        self.callbacks.insert(name.into(), callback.into());
+        self
+    }
+
     /// For easy chaining of operations.
     #[must_use]
     pub fn then<F>(self, func: F) -> Self
@@ -315,7 +346,9 @@ mod tests {
     use super::{Operation, Operations};
     use crate::security::SecurityRequirement;
     use crate::server::Server;
-    use crate::{Deprecated, Parameter, PathItemType, RequestBody, Responses};
+    use crate::{
+        Callback, Deprecated, Parameter, PathItem, PathItemType, RefOr, RequestBody, Responses,
+    };
 
     #[test]
     fn operation_new() {
@@ -329,7 +362,7 @@ mod tests {
         assert!(operation.parameters.is_empty());
         assert!(operation.request_body.is_none());
         assert!(operation.responses.is_empty());
-        assert!(operation.callbacks.is_none());
+        assert!(operation.callbacks.is_empty());
         assert!(operation.deprecated.is_none());
         assert!(operation.securities.is_empty());
         assert!(operation.servers.is_empty());
@@ -427,6 +460,37 @@ mod tests {
         assert_eq!((PathItemType::Get, Operation::new()), iter.next().unwrap());
         assert_eq!((PathItemType::Post, Operation::new()), iter.next().unwrap());
         assert_eq!((PathItemType::Head, Operation::new()), iter.next().unwrap());
+    }
+
+    #[test]
+    fn operation_callbacks_serialize_as_per_spec() {
+        let callback = Callback::new().path(
+            "{$request.body#/callbackUrl}",
+            PathItem::new(PathItemType::Post, Operation::new()),
+        );
+        let operation = Operation::new()
+            .add_callback("orderShipped", callback)
+            .add_callback(
+                "orderRefunded",
+                RefOr::Ref(crate::Ref::new("#/components/callbacks/RefundEvent")),
+            );
+
+        assert_json_eq!(
+            operation,
+            json!({
+                "responses": {},
+                "callbacks": {
+                    "orderShipped": {
+                        "{$request.body#/callbackUrl}": {
+                            "post": { "responses": {} }
+                        }
+                    },
+                    "orderRefunded": {
+                        "$ref": "#/components/callbacks/RefundEvent"
+                    }
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/oapi/src/openapi/path.rs
+++ b/crates/oapi/src/openapi/path.rs
@@ -104,8 +104,7 @@ pub struct PathItem {
     /// List of [`Parameter`]s common to all [`Operation`]s in this [`PathItem`]. Parameters cannot
     /// contain duplicate parameters. They can be overridden in [`Operation`] level but cannot be
     /// removed there.
-    #[serde(skip_serializing_if = "Parameters::is_empty")]
-    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Parameters::is_empty", default)]
     pub parameters: Parameters,
 
     /// Map of operations in this [`PathItem`]. Operations can hold only one operation
@@ -199,6 +198,12 @@ impl PathItem {
 }
 
 /// Path item operation type.
+///
+/// Mirrors the HTTP methods supported by the OpenAPI 3.1 [Path Item Object][path_item];
+/// note that the spec deliberately does not list `CONNECT`, so it is intentionally absent
+/// here as well.
+///
+/// [path_item]: https://spec.openapis.org/oas/latest.html#path-item-object
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum PathItemType {
@@ -218,8 +223,6 @@ pub enum PathItemType {
     Patch,
     /// Type mapping for HTTP _TRACE_ request.
     Trace,
-    /// Type mapping for HTTP _CONNECT_ request.
-    Connect,
 }
 
 #[cfg(test)]
@@ -248,6 +251,30 @@ mod tests {
                 }
             })
         )
+    }
+
+    #[test]
+    fn path_item_parameters_serialize_as_named_field() {
+        use crate::Parameter;
+
+        let path_item = PathItem::new(PathItemType::Get, Operation::new())
+            .parameters([Parameter::new("id").parameter_in(crate::ParameterIn::Path)]);
+
+        assert_json_eq!(
+            path_item,
+            json!({
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "get": {
+                    "responses": {}
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/oapi/src/routing.rs
+++ b/crates/oapi/src/routing.rs
@@ -116,6 +116,10 @@ impl NormNode {
                     // standard method filter with a custom one does not erase
                     // the standard mapping (the previous string-parsing path
                     // had the same behavior via its `_ => {}` arm).
+                    //
+                    // CONNECT is intentionally not mapped: OpenAPI 3.1 does
+                    // not define a `connect` operation under Path Item, so
+                    // emitting one would produce an invalid document.
                     let item = match method {
                         Method::GET => Some(PathItemType::Get),
                         Method::POST => Some(PathItemType::Post),
@@ -123,13 +127,17 @@ impl NormNode {
                         Method::DELETE => Some(PathItemType::Delete),
                         Method::HEAD => Some(PathItemType::Head),
                         Method::OPTIONS => Some(PathItemType::Options),
-                        Method::CONNECT => Some(PathItemType::Connect),
                         Method::TRACE => Some(PathItemType::Trace),
                         Method::PATCH => Some(PathItemType::Patch),
                         _ => None,
                     };
                     if item.is_some() {
                         node.method = item;
+                    } else if method == Method::CONNECT {
+                        tracing::warn!(
+                            "HTTP CONNECT has no OpenAPI 3.1 mapping; the route will be \
+                             omitted from the generated document"
+                        );
                     }
                 }
                 // Other filter kinds (Scheme/Host/Port/Other) do not carry


### PR DESCRIPTION
## Summary

Three independent fixes to bring `salvo-oapi` in line with [OpenAPI 3.1.0](https://spec.openapis.org/oas/v3.1.0):

1. **`Operation.callbacks` is now a real Callback Object map.** It was `Option<String>`, which can't represent the spec shape (`Map<String, RefOr<Callback>>` where `Callback = Map<RuntimeExpression, PathItem>`). A new `Callback` type is added under `crates/oapi/src/openapi/callback.rs`, plus `Operation::callbacks` / `Operation::add_callback` builders.
2. **Drop `#[serde(flatten)]` from `PathItem.parameters`.** Because `Parameters` is a `Vec<Parameter>` newtype, `flatten` cannot apply to it — non-empty `parameters` would error at serialization. Switched to a normal sub-field as the spec requires (`{"parameters": [...]}`). A regression test now exercises a populated value.
3. **Remove `PathItemType::Connect`.** OAS 3.1's Path Item Object only defines `get/put/post/delete/options/head/patch/trace`; emitting `connect` produced an invalid document. The variant is gone, and `routing.rs` no longer maps `Method::CONNECT` — it logs a warning and skips the route instead.

## Notes

- All three are minor breaking changes (public API shape changes on `Operation::callbacks` and `PathItemType`), but each was either unusable or actively producing invalid OpenAPI output, so a fix-track release seems warranted.
- This is the first slice of a broader OAS 3.1 compliance effort. Follow-up branches will cover `jsonSchemaDialect` naming, missing `webhooks`, missing `Components` fields, and Parameter completeness.

## Test plan

- [x] `cargo test -p salvo-oapi --lib` — 261 passing (two pre-existing failures on `main`, unrelated to this PR: `test_simple_document_with_security` and `test_openapi_schema_work_with_generics`, about `uint64`/`int64` schema-format mismatch)
- [x] `cargo test -p salvo-oapi --doc` — 125 passing
- [x] `cargo check --workspace --all-targets` — clean
- [x] New regression tests: `path_item_parameters_serialize_as_named_field`, `operation_callbacks_serialize_as_per_spec`