### PR TITLE
feat(oapi): complete Components Object with all OAS 3.1 reusable types

### DIFF
--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -37,6 +37,7 @@ pub use self::example::Example;
 pub use self::external_docs::ExternalDocs;
 pub use self::header::Header;
 pub use self::info::{Contact, Info, License};
+pub use self::link::Link;
 pub use self::operation::{Operation, Operations};
 pub use self::parameter::{Parameter, ParameterIn, ParameterStyle, Parameters};
 pub use self::path::{PathItem, PathItemType, Paths};

--- a/crates/oapi/src/openapi/components.rs
+++ b/crates/oapi/src/openapi/components.rs
@@ -1,10 +1,13 @@
-//! Implements [OpenAPI Schema Object][schema] types which can be
-//! used to define field properties, enum values, array or object types.
+//! Implements [OpenAPI Components Object][components] holding reusable parts of an OpenAPI
+//! document.
 //!
-//! [schema]: https://spec.openapis.org/oas/latest.html#schema-object
+//! [components]: https://spec.openapis.org/oas/latest.html#components-object
 use serde::{Deserialize, Serialize};
 
-use crate::{PropMap, RefOr, Response, Responses, Schema, Schemas, SecurityScheme};
+use crate::{
+    Callback, Example, Header, Link, Parameter, PathItem, PropMap, RefOr, RequestBody, Response,
+    Responses, Schema, Schemas, SecurityScheme,
+};
 
 /// Implements [OpenAPI Components Object][components] which holds supported
 /// reusable objects.
@@ -31,11 +34,54 @@ pub struct Components {
     #[serde(skip_serializing_if = "PropMap::is_empty", default)]
     pub responses: Responses,
 
+    /// Map of reusable [OpenAPI Parameter Object][parameter]s, indexed by name.
+    ///
+    /// [parameter]: https://spec.openapis.org/oas/latest.html#parameter-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub parameters: PropMap<String, RefOr<Parameter>>,
+
+    /// Map of reusable [OpenAPI Example Object][example]s, indexed by name.
+    ///
+    /// [example]: https://spec.openapis.org/oas/latest.html#example-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub examples: PropMap<String, RefOr<Example>>,
+
+    /// Map of reusable [OpenAPI Request Body Object][request_body]s, indexed by name.
+    ///
+    /// [request_body]: https://spec.openapis.org/oas/latest.html#request-body-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub request_bodies: PropMap<String, RefOr<RequestBody>>,
+
+    /// Map of reusable [OpenAPI Header Object][header]s, indexed by header name.
+    ///
+    /// [header]: https://spec.openapis.org/oas/latest.html#header-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub headers: PropMap<String, RefOr<Header>>,
+
     /// Map of reusable [OpenAPI Security Scheme Object][security_scheme]s.
     ///
     /// [security_scheme]: https://spec.openapis.org/oas/latest.html#security-scheme-object
     #[serde(skip_serializing_if = "PropMap::is_empty", default)]
     pub security_schemes: PropMap<String, SecurityScheme>,
+
+    /// Map of reusable [OpenAPI Link Object][link]s, indexed by name.
+    ///
+    /// [link]: https://spec.openapis.org/oas/latest.html#link-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub links: PropMap<String, RefOr<Link>>,
+
+    /// Map of reusable [OpenAPI Callback Object][callback]s, indexed by name.
+    ///
+    /// [callback]: https://spec.openapis.org/oas/latest.html#callback-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub callbacks: PropMap<String, RefOr<Callback>>,
+
+    /// Map of reusable [OpenAPI Path Item Object][path_item]s. Added in OpenAPI 3.1; entries
+    /// here can be referenced from `paths` or `webhooks` via [`RefOr::Ref`].
+    ///
+    /// [path_item]: https://spec.openapis.org/oas/v3.1.0#path-item-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub path_items: PropMap<String, RefOr<PathItem>>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -164,10 +210,86 @@ impl Components {
         self
     }
 
+    /// Insert a reusable [`Parameter`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_parameter<N: Into<String>, P: Into<RefOr<Parameter>>>(
+        mut self,
+        name: N,
+        parameter: P,
+    ) -> Self {
+        self.parameters.insert(name.into(), parameter.into());
+        self
+    }
+
+    /// Insert a reusable [`Example`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_example<N: Into<String>, E: Into<RefOr<Example>>>(
+        mut self,
+        name: N,
+        example: E,
+    ) -> Self {
+        self.examples.insert(name.into(), example.into());
+        self
+    }
+
+    /// Insert a reusable [`RequestBody`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_request_body<N: Into<String>, B: Into<RefOr<RequestBody>>>(
+        mut self,
+        name: N,
+        request_body: B,
+    ) -> Self {
+        self.request_bodies.insert(name.into(), request_body.into());
+        self
+    }
+
+    /// Insert a reusable [`Header`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_header<N: Into<String>, H: Into<RefOr<Header>>>(
+        mut self,
+        name: N,
+        header: H,
+    ) -> Self {
+        self.headers.insert(name.into(), header.into());
+        self
+    }
+
+    /// Insert a reusable [`Link`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_link<N: Into<String>, L: Into<RefOr<Link>>>(mut self, name: N, link: L) -> Self {
+        self.links.insert(name.into(), link.into());
+        self
+    }
+
+    /// Insert a reusable [`Callback`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    #[must_use]
+    pub fn add_callback<N: Into<String>, C: Into<RefOr<Callback>>>(
+        mut self,
+        name: N,
+        callback: C,
+    ) -> Self {
+        self.callbacks.insert(name.into(), callback.into());
+        self
+    }
+
+    /// Insert a reusable [`PathItem`] (or a [`Ref`](crate::Ref) to one) and return `self`.
+    ///
+    /// Path Item entries in `components.pathItems` were introduced in OpenAPI 3.1 to support
+    /// reusable webhooks and shared path operations.
+    #[must_use]
+    pub fn add_path_item<N: Into<String>, P: Into<RefOr<PathItem>>>(
+        mut self,
+        name: N,
+        path_item: P,
+    ) -> Self {
+        self.path_items.insert(name.into(), path_item.into());
+        self
+    }
+
     /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
-    /// If a key from `other` is already present in `self`, the respective
-    /// value from `self` will be overwritten with the respective value from `other`.
+    /// If a key from `other` is already present in `self`, the existing value is kept and
+    /// the duplicate from `other` is dropped.
     pub fn append(&mut self, other: &mut Self) {
         other
             .schemas
@@ -180,9 +302,42 @@ impl Components {
         self.responses.append(&mut other.responses);
 
         other
+            .parameters
+            .retain(|name, _| !self.parameters.contains_key(name));
+        self.parameters.append(&mut other.parameters);
+
+        other
+            .examples
+            .retain(|name, _| !self.examples.contains_key(name));
+        self.examples.append(&mut other.examples);
+
+        other
+            .request_bodies
+            .retain(|name, _| !self.request_bodies.contains_key(name));
+        self.request_bodies.append(&mut other.request_bodies);
+
+        other
+            .headers
+            .retain(|name, _| !self.headers.contains_key(name));
+        self.headers.append(&mut other.headers);
+
+        other
             .security_schemes
             .retain(|name, _| !self.security_schemes.contains_key(name));
         self.security_schemes.append(&mut other.security_schemes);
+
+        other.links.retain(|name, _| !self.links.contains_key(name));
+        self.links.append(&mut other.links);
+
+        other
+            .callbacks
+            .retain(|name, _| !self.callbacks.contains_key(name));
+        self.callbacks.append(&mut other.callbacks);
+
+        other
+            .path_items
+            .retain(|name, _| !self.path_items.contains_key(name));
+        self.path_items.append(&mut other.path_items);
 
         other
             .extensions
@@ -202,7 +357,125 @@ impl Components {
     pub fn is_empty(&self) -> bool {
         self.schemas.is_empty()
             && self.responses.is_empty()
+            && self.parameters.is_empty()
+            && self.examples.is_empty()
+            && self.request_bodies.is_empty()
+            && self.headers.is_empty()
             && self.security_schemes.is_empty()
+            && self.links.is_empty()
+            && self.callbacks.is_empty()
+            && self.path_items.is_empty()
             && self.extensions.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    use super::*;
+    use crate::{Operation, ParameterIn, PathItemType, Ref};
+
+    #[test]
+    fn empty_components_serializes_with_no_fields() {
+        assert_json_eq!(Components::new(), json!({}));
+        assert!(Components::new().is_empty());
+    }
+
+    #[test]
+    fn each_new_field_serializes_under_spec_name() {
+        let components = Components::new()
+            .add_parameter(
+                "PageParam",
+                Parameter::new("page").parameter_in(ParameterIn::Query),
+            )
+            .add_example(
+                "PetExample",
+                RefOr::Ref(Ref::new("#/components/examples/UpstreamPet")),
+            )
+            .add_request_body("PetBody", RequestBody::new())
+            .add_header("X-Rate-Limit", Header::default())
+            .add_link("GetPetLink", Link::default())
+            .add_callback(
+                "OrderShipped",
+                Callback::new().path(
+                    "{$request.body#/callbackUrl}",
+                    PathItem::new(PathItemType::Post, Operation::new()),
+                ),
+            )
+            .add_path_item(
+                "PingWebhook",
+                PathItem::new(PathItemType::Post, Operation::new()),
+            );
+
+        let value = serde_json::to_value(&components).expect("serialize");
+
+        assert!(value.get("parameters").is_some(), "expected parameters");
+        assert!(value.get("examples").is_some(), "expected examples");
+        assert!(
+            value.get("requestBodies").is_some(),
+            "expected requestBodies (camelCase)"
+        );
+        assert!(value.get("headers").is_some(), "expected headers");
+        assert!(value.get("links").is_some(), "expected links");
+        assert!(value.get("callbacks").is_some(), "expected callbacks");
+        assert!(
+            value.get("pathItems").is_some(),
+            "expected pathItems (camelCase, OAS 3.1)"
+        );
+    }
+
+    #[test]
+    fn is_empty_recognizes_each_new_field() {
+        // Adding any one of the new component maps should flip is_empty to false.
+        assert!(
+            !Components::new()
+                .add_parameter("p", Parameter::new("q"))
+                .is_empty()
+        );
+        assert!(
+            !Components::new()
+                .add_example("e", crate::Example::default())
+                .is_empty()
+        );
+        assert!(
+            !Components::new()
+                .add_request_body("rb", RequestBody::new())
+                .is_empty()
+        );
+        assert!(
+            !Components::new()
+                .add_header("h", Header::default())
+                .is_empty()
+        );
+        assert!(!Components::new().add_link("l", Link::default()).is_empty());
+        assert!(
+            !Components::new()
+                .add_callback("cb", Callback::new())
+                .is_empty()
+        );
+        assert!(
+            !Components::new()
+                .add_path_item("pi", PathItem::new(PathItemType::Get, Operation::new()))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn append_preserves_self_on_key_collision() {
+        let mut a = Components::new().add_parameter("dup", Parameter::new("a_param"));
+        let mut b = Components::new()
+            .add_parameter("dup", Parameter::new("b_param"))
+            .add_parameter("only_b", Parameter::new("b_only_param"));
+
+        a.append(&mut b);
+
+        let dup = a.parameters.get("dup").expect("dup retained");
+        match dup {
+            RefOr::Type(p) => assert_eq!(p.name, "a_param", "self's value should win on collision"),
+            RefOr::Ref(_) => panic!("unexpected ref"),
+        }
+        assert!(a.parameters.contains_key("only_b"));
     }
 }


### PR DESCRIPTION
## Summary

The `Components` object only exposed `schemas`, `responses`, and `securitySchemes`. OpenAPI 3.1 defines 10 reusable kinds. This PR fills in the seven missing ones — including `pathItems`, which was newly introduced in 3.1 and is required to document reusable webhook handlers and shared path operations.

## Changes

### New public fields on `Components`

| Field | Wire name | Type |
|---|---|---|
| `parameters` | `parameters` | `PropMap<String, RefOr<Parameter>>` |
| `examples` | `examples` | `PropMap<String, RefOr<Example>>` |
| `request_bodies` | `requestBodies` | `PropMap<String, RefOr<RequestBody>>` |
| `headers` | `headers` | `PropMap<String, RefOr<Header>>` |
| `links` | `links` | `PropMap<String, RefOr<Link>>` |
| `callbacks` | `callbacks` | `PropMap<String, RefOr<Callback>>` |
| `path_items` | `pathItems` | `PropMap<String, RefOr<PathItem>>` *(3.1 new)* |

Each uses `skip_serializing_if = is_empty` and the struct's existing `rename_all = camelCase`, so the wire shape matches the spec exactly and absent fields are omitted.

### Builder methods

`add_parameter`, `add_example`, `add_request_body`, `add_header`, `add_link`, `add_callback`, `add_path_item`. Each takes `Into<String>` for the key and `Into<RefOr<T>>` for the value, so an inline object or a `Ref` both work.

### Bookkeeping

- `Components::is_empty` now considers all 10 component kinds.
- `Components::append` extended to cover the new fields. The doc text on `append` was also corrected — the prior text claimed colliding keys would overwrite `self`, but the implementation always preserves `self`.
- `Link` is re-exported from the crate root so it can appear in the public signature.

### Tests

- Empty `Components` serializes to `{}`.
- Every new field appears under its camelCase wire name when populated.
- `is_empty` flips to `false` for each kind individually.
- `append` preserves `self`'s value on key collision and pulls in `other`'s unique keys.

## Notes

- Pure additive change: existing fields and methods are untouched.
- Independent of #1452 / #1453 / #1454.
- The `Callback` type (added in #1452) and `Link`/`Example`/`Header`/etc. (already present) are reused as-is.

## Test plan

- [x] `cargo test -p salvo-oapi --lib` — 267 passing
- [x] `cargo test -p salvo-oapi --doc` — 125 passing
- [x] `cargo check --workspace --all-targets` — clean