### PR TITLE
feat(oapi): support PathItem $ref per OpenAPI 3.1

### DIFF
--- a/crates/oapi/src/openapi/path.rs
+++ b/crates/oapi/src/openapi/path.rs
@@ -44,6 +44,9 @@ impl Paths {
         self.0
             .entry(key)
             .and_modify(|item| {
+                if value.ref_location.is_some() {
+                    item.ref_location = value.ref_location.take();
+                }
                 if value.summary.is_some() {
                     item.summary = value.summary.take();
                 }
@@ -87,6 +90,16 @@ impl Paths {
 #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PathItem {
+    /// External reference to a Path Item Object defined elsewhere.
+    ///
+    /// In OpenAPI 3.1 a Path Item Object can carry its own `$ref` field that delegates to
+    /// another Path Item definition. When set, sibling fields' behavior is undefined per
+    /// spec — most consumers resolve the reference and ignore them.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.1.0#path-item-object>.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none", default)]
+    pub ref_location: Option<String>,
+
     /// Optional summary intended to apply all operations in this [`PathItem`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
@@ -98,7 +111,7 @@ pub struct PathItem {
 
     /// Alternative [`Server`] array to serve all [`Operation`]s in this [`PathItem`] overriding
     /// the global server array.
-    #[serde(skip_serializing_if = "Servers::is_empty")]
+    #[serde(skip_serializing_if = "Servers::is_empty", default)]
     pub servers: Servers,
 
     /// List of [`Parameter`]s common to all [`Operation`]s in this [`PathItem`]. Parameters cannot
@@ -109,7 +122,7 @@ pub struct PathItem {
 
     /// Map of operations in this [`PathItem`]. Operations can hold only one operation
     /// per [`PathItemType`].
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     pub operations: Operations,
 
     /// Optional extensions "x-something"
@@ -127,6 +140,28 @@ impl PathItem {
             ..Default::default()
         }
     }
+
+    /// Construct a [`PathItem`] that is purely a reference to another Path Item, e.g. one
+    /// defined under `components.pathItems`.
+    ///
+    /// ```
+    /// # use salvo_oapi::PathItem;
+    /// let item = PathItem::from_ref("#/components/pathItems/PingWebhook");
+    /// ```
+    #[must_use]
+    pub fn from_ref<S: Into<String>>(ref_location: S) -> Self {
+        Self {
+            ref_location: Some(ref_location.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Set the `$ref` location for this [`PathItem`] and return `self`.
+    #[must_use]
+    pub fn ref_location<S: Into<String>>(mut self, ref_location: S) -> Self {
+        self.ref_location = Some(ref_location.into());
+        self
+    }
     /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
     /// If a key from `other` is already present in `self`, the respective
@@ -140,6 +175,9 @@ impl PathItem {
         }
         if other.summary.is_some() {
             self.summary = other.summary.take();
+        }
+        if other.ref_location.is_some() {
+            self.ref_location = other.ref_location.take();
         }
         other
             .extensions
@@ -251,6 +289,49 @@ mod tests {
                 }
             })
         )
+    }
+
+    #[test]
+    fn path_item_ref_serializes_as_dollar_ref() {
+        let item = PathItem::from_ref("#/components/pathItems/PingWebhook");
+        assert_json_eq!(
+            item,
+            json!({ "$ref": "#/components/pathItems/PingWebhook" })
+        );
+    }
+
+    #[test]
+    fn path_item_ref_round_trips_via_serde() {
+        let raw = json!({ "$ref": "#/components/pathItems/PingWebhook" });
+        let item: PathItem = serde_json::from_value(raw.clone()).expect("deserialize");
+        assert_eq!(
+            item.ref_location.as_deref(),
+            Some("#/components/pathItems/PingWebhook")
+        );
+        // Other fields are absent — sibling fields with $ref are spec-undefined, so we
+        // expect an otherwise empty PathItem.
+        assert!(item.summary.is_none());
+        assert!(item.operations.is_empty());
+
+        let reserialized = serde_json::to_value(&item).expect("serialize");
+        assert_eq!(reserialized, raw);
+    }
+
+    #[test]
+    fn path_item_ref_setter_overrides_plain_construction() {
+        let item = PathItem::new(PathItemType::Get, Operation::new())
+            .ref_location("#/components/pathItems/Other");
+
+        let value = serde_json::to_value(&item).expect("serialize");
+        assert_eq!(
+            value["$ref"],
+            json!("#/components/pathItems/Other"),
+            "$ref should serialize when set"
+        );
+        // The previously-attached operation is still there in this object form;
+        // consumers will resolve $ref and ignore siblings, but the type doesn't
+        // suppress them.
+        assert!(value.get("get").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0#path-item-object) the Path Item Object can carry its own `$ref` field that delegates to another Path Item definition — typically one stored under `components.pathItems`. The Rust `PathItem` struct had no place for that reference, so paths and webhooks couldn't share definitions through the spec-mandated mechanism.

This was the last big gap in the document model surfaced by the audit.

## Changes

- New field `PathItem::ref_location: Option<String>`, serialized as `$ref` and omitted when `None`.
- `PathItem::from_ref(loc)` constructor for ref-only entries.
- `PathItem::ref_location(loc)` builder.
- `Paths::insert` and `PathItem::append` now fold `ref_location` from `other`, so merging or re-inserting doesn't silently drop the reference.

### Bonus: ref-only PathItem now round-trips through serde

Added `#[serde(default)]` to the `servers` and `operations` fields. A ref-only PathItem on the wire is just `{\"\$ref\": \"...\"}` — every other field is missing — so deserialization needs `default` on those fields to succeed. This mirrors the `default` already present on `parameters` (added in #1452) and is a strict relaxation: the wire shape of any existing populated PathItem is unchanged.

## Why a `$ref` field rather than wrapping `Paths` value as `RefOr<PathItem>`?

The audit's original P2-B sketch suggested making `Paths` value `RefOr<PathItem>`. That turns out to be wrong for the spec: in OpenAPI 3.1 the Paths Object's values are still Path Item Objects, and a Path Item Object simply has its own optional `$ref` property. Putting `$ref` on `PathItem` directly is both more spec-aligned and less invasive than rewrapping `Paths`.

## Tests

- `path_item_ref_serializes_as_dollar_ref` — `from_ref(...)` produces exactly `{\"\$ref\": \"...\"}`.
- `path_item_ref_round_trips_via_serde` — `{\"\$ref\": \"...\"}` deserializes into a `PathItem` with only `ref_location` set, and re-serializing recovers the same JSON.
- `path_item_ref_setter_overrides_plain_construction` — `.ref_location(...)` on a PathItem with operations attaches `$ref` while leaving siblings in the object form (consumers resolve the ref and ignore them per spec).

## Notes

- Independent of #1452 / #1453 / #1454 / #1455 / #1456 / #1457.
- This completes the major OpenAPI 3.1 compliance gaps from the audit. The remaining item is JSON Schema 2020-12 keyword extensions (`const`, `prefixItems`, `dependentRequired`, etc.), which is a separate, much larger effort and can be tackled keyword-by-keyword in follow-up PRs.

## Test plan

- [x] `cargo test -p salvo-oapi --lib` — 266 passing
- [x] `cargo test -p salvo-oapi --doc` — 126 passing
- [x] `cargo check --workspace --all-targets` — clean