### PR TITLE
fix(proxy): compare Upgrade tokens case-insensitively on both sides

### DIFF
--- a/crates/proxy/src/hyper_client.rs
+++ b/crates/proxy/src/hyper_client.rs
@@ -106,7 +106,9 @@ where
 
         if response.status() == StatusCode::SWITCHING_PROTOCOLS {
             let response_upgrade_type = crate::get_upgrade_type(response.headers());
-            if request_upgrade_type == response_upgrade_type.map(|s| s.to_lowercase()) {
+            // RFC 7230 §6.7 makes Upgrade tokens case-insensitive (`websocket`,
+            // `WebSocket`, ... are all the same protocol). Compare without allocating.
+            if crate::upgrade_types_match(request_upgrade_type.as_deref(), response_upgrade_type) {
                 let response_upgraded = hyper::upgrade::on(&mut response).await?;
                 if let Some(request_upgraded) = request_upgraded {
                     tokio::spawn(async move {

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -643,6 +643,22 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<&str> {
     None
 }
 
+/// Compare two `Upgrade` token candidates from request and response.
+///
+/// Per RFC 7230 §6.7 the upgrade token is case-insensitive (`websocket`,
+/// `WebSocket`, `WEBSOCKET` are equivalent), so this helper compares with
+/// `eq_ignore_ascii_case`. Two missing tokens compare equal (the previous
+/// case-sensitive check matched too) so callers behave the same when neither
+/// side advertises an upgrade.
+#[inline]
+pub(crate) fn upgrade_types_match(request: Option<&str>, response: Option<&str>) -> bool {
+    match (request, response) {
+        (Some(req), Some(resp)) => req.eq_ignore_ascii_case(resp),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 // Unit tests for Proxy
 #[cfg(test)]
 mod tests {
@@ -693,6 +709,19 @@ mod tests {
         let path = "/test/path";
         let encoded_path = encode_url_path(path);
         assert_eq!(encoded_path, "/test/path");
+    }
+
+    #[test]
+    fn test_upgrade_types_match_is_case_insensitive() {
+        // RFC 7230 §6.7 — upgrade tokens are case-insensitive.
+        assert!(upgrade_types_match(Some("WebSocket"), Some("websocket")));
+        assert!(upgrade_types_match(Some("WEBSOCKET"), Some("WebSocket")));
+        assert!(upgrade_types_match(Some("h2c"), Some("h2c")));
+        assert!(upgrade_types_match(None, None));
+
+        assert!(!upgrade_types_match(Some("websocket"), Some("h2c")));
+        assert!(!upgrade_types_match(Some("websocket"), None));
+        assert!(!upgrade_types_match(None, Some("websocket")));
     }
 
     #[test]

--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -81,7 +81,7 @@ impl Client for ReqwestClient {
 
             // RFC 7230 §6.7 makes Upgrade tokens case-insensitive (`websocket`,
             // `WebSocket`, ... are all the same protocol). Compare without allocating.
-            if upgrade_types_match(request_upgrade_type.as_deref(), response_upgrade_type) {
+            if crate::upgrade_types_match(request_upgrade_type.as_deref(), response_upgrade_type) {
                 let mut response_upgraded = response.upgrade().await.map_err(|e| {
                     Error::other(format!("response does not have an upgrade extension. {e}"))
                 })?;

--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -79,7 +79,9 @@ impl Client for ReqwestClient {
         let mut hyper_response = if response.status() == StatusCode::SWITCHING_PROTOCOLS {
             let response_upgrade_type = crate::get_upgrade_type(response.headers());
 
-            if request_upgrade_type == response_upgrade_type.map(|s| s.to_lowercase()) {
+            // RFC 7230 §6.7 makes Upgrade tokens case-insensitive (`websocket`,
+            // `WebSocket`, ... are all the same protocol). Compare without allocating.
+            if upgrade_types_match(request_upgrade_type.as_deref(), response_upgrade_type) {
                 let mut response_upgraded = response.upgrade().await.map_err(|e| {
                     Error::other(format!("response does not have an upgrade extension. {e}"))
                 })?;


### PR DESCRIPTION
## Summary

`HyperClient::execute` and `ReqwestClient::execute` validate that the upstream response's `Upgrade` token matches what the request asked for. The previous code only lowercased the response side:

```rust
if request_upgrade_type == response_upgrade_type.map(|s| s.to_lowercase())
```

so a request carrying `Upgrade: WebSocket` (mixed case is valid per RFC 7230 §6.7) against an upstream advertising `Upgrade: websocket` mismatched and the proxy returned `upgrade type mismatch`. The same bug affected reqwest.

Replace the asymmetric comparison with a shared `upgrade_types_match` helper that uses `eq_ignore_ascii_case`, which also avoids allocating a second `String` per request. Behaviour for `(None, None)` is preserved (both clients treated that as a match).

Adds a unit test covering case folding and the surviving asymmetry.

## Test plan

- [x] `cargo test -p salvo-proxy --lib` (all 23 tests pass, including the new `test_upgrade_types_match_is_case_insensitive`)
- [ ] Reviewer to confirm the `(None, None)` fallthrough is the desired behaviour (kept identical to prior code; happy to switch to "reject" if preferred)