### PR TITLE
perf: drop per-request allocations in websocket upgrade and proxy path encoding

### DIFF
--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -295,11 +295,12 @@ impl WebSocketUpgrade {
             tracing::debug!("missing connection upgrade");
             return Err(StatusError::bad_request().brief("missing connection upgrade"));
         }
+        // Per RFC 7230 §6.7 the Upgrade token is case-insensitive. Use the byte-level
+        // ASCII compare so we don't allocate a fresh `String` on every request.
         let matched = req_headers
             .get(UPGRADE)
             .and_then(|v| v.to_str().ok())
-            .map(|v| v.to_lowercase() == "websocket")
-            .unwrap_or(false);
+            .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
         if !matched {
             tracing::debug!("missing upgrade header or it is not websocket");
             return Err(StatusError::bad_request()

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -103,12 +103,31 @@ const PATH_ENCODE_SET: &AsciiSet = &QUERY_ENCODE_SET
     .add(b'}');
 
 /// Encode url path. This can be used when build your custom url path getter.
+///
+/// Walks the segments separated by `/` and percent-encodes each one in place using
+/// [`PATH_ENCODE_SET`], without allocating an intermediate `Vec<String>` or a
+/// `String` per segment.
 #[inline]
 pub(crate) fn encode_url_path(path: &str) -> String {
-    path.split('/')
-        .map(|s| utf8_percent_encode(s, PATH_ENCODE_SET).to_string())
-        .collect::<Vec<_>>()
-        .join("/")
+    use std::fmt::Write as _;
+
+    let mut out = String::with_capacity(path.len());
+    let mut first = true;
+    for segment in path.split('/') {
+        if first {
+            first = false;
+        } else {
+            out.push('/');
+        }
+        // `Display` for `PercentEncode` writes directly into the formatter, so this
+        // does not allocate a temporary `String` per segment.
+        let _ = write!(
+            &mut out,
+            "{}",
+            utf8_percent_encode(segment, PATH_ENCODE_SET)
+        );
+    }
+    out
 }
 
 /// Client trait for implementing different HTTP clients for proxying.
@@ -722,6 +741,21 @@ mod tests {
         assert!(!upgrade_types_match(Some("websocket"), Some("h2c")));
         assert!(!upgrade_types_match(Some("websocket"), None));
         assert!(!upgrade_types_match(None, Some("websocket")));
+    }
+
+    #[test]
+    fn test_encode_url_path_preserves_segments_and_escapes_unsafe_chars() {
+        // Empty input round-trips.
+        assert_eq!(encode_url_path(""), "");
+
+        // Leading and trailing slashes survive (they become empty segments).
+        assert_eq!(encode_url_path("/"), "/");
+        assert_eq!(encode_url_path("//a//b//"), "//a//b//");
+
+        // Unsafe path characters in `PATH_ENCODE_SET` get percent-encoded per
+        // segment; the slash separator itself is left intact.
+        assert_eq!(encode_url_path("a b/c d"), "a%20b/c%20d");
+        assert_eq!(encode_url_path("a/{b}/c"), "a/%7Bb%7D/c");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two small hot-path cleanups surfaced by a follow-up code review:

- `WebSocketUpgrade::upgrade` was calling `v.to_lowercase() == \"websocket\"` on every incoming upgrade request, allocating a fresh `String` purely to fold case before comparing against a 9-byte literal. Replace with `v.eq_ignore_ascii_case(\"websocket\")` — same RFC 7230 §6.7 semantics, zero allocations.
- `proxy::encode_url_path` percent-encoded each path segment via `to_string()` and then `collect::<Vec<_>>().join(\"/\")`. Both the per-segment `String` and the intermediate `Vec` are unnecessary; the `Display` impl on `PercentEncode` writes straight into a formatter. Pre-size a single output `String`, walk segments with `split('/')`, and push to it directly. Behaviour is unchanged (covered by a new unit test).

## Test plan

- [x] `cargo test -p salvo-proxy --lib` (24 tests pass, including the new `test_encode_url_path_preserves_segments_and_escapes_unsafe_chars`)
- [x] `cargo check -p salvo_extra --features=\"websocket\" --no-default-features` is clean