### PR TITLE
[codex] fix security findings

### DIFF
--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -178,7 +178,7 @@ impl Handler for Http01Handler {
                 token_len = token.len(),
                 "key not found for ACME challenge token"
             );
-            res.render(token);
+            res.render(StatusError::not_found().brief("challenge token not found"));
         } else {
             res.render(StatusError::not_found().brief("missing token"));
         }
@@ -199,5 +199,45 @@ where
 {
     fn acme(self) -> AcmeListenerBuilder<Self> {
         AcmeListenerBuilder::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo_core::http::StatusCode;
+    use salvo_core::prelude::*;
+    use salvo_core::test::{ResponseExt, TestClient};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn http01_handler_serves_known_token() {
+        let keys = Arc::new(RwLock::new(HashMap::from([(
+            "known".to_owned(),
+            "key-authorization".to_owned(),
+        )])));
+        let handler = Http01Handler { keys };
+        let router = Router::with_path(format!("{WELL_KNOWN_PATH}/{{token}}")).goal(handler);
+
+        let mut response = TestClient::get("http://127.0.0.1/.well-known/acme-challenge/known")
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.take_string().await.unwrap(), "key-authorization");
+    }
+
+    #[tokio::test]
+    async fn http01_handler_rejects_unknown_token() {
+        let handler = Http01Handler {
+            keys: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let router = Router::with_path(format!("{WELL_KNOWN_PATH}/{{token}}")).goal(handler);
+
+        let response = TestClient::get("http://127.0.0.1/.well-known/acme-challenge/unknown")
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::NOT_FOUND));
     }
 }

--- a/crates/csrf/src/hmac_cipher.rs
+++ b/crates/csrf/src/hmac_cipher.rs
@@ -46,7 +46,7 @@ impl CsrfCipher for HmacCipher {
             URL_SAFE_NO_PAD.decode(token.as_bytes()),
             URL_SAFE_NO_PAD.decode(proof.as_bytes()),
         ) {
-            if proof.len() != self.token_size {
+            if token.len() != self.token_size {
                 false
             } else {
                 let mut hmac = self.hmac();
@@ -94,6 +94,16 @@ mod tests {
         let hmac_key = [0u8; 32];
         let hmac_cipher = HmacCipher::new(hmac_key);
         let (token, proof) = hmac_cipher.generate();
+        assert!(hmac_cipher.verify(&token, &proof));
+    }
+
+    #[test]
+    fn test_verify_custom_token_size() {
+        let hmac_key = [0u8; 32];
+        let hmac_cipher = HmacCipher::new(hmac_key).token_size(16);
+        let (token, proof) = hmac_cipher.generate();
+        assert_eq!(URL_SAFE_NO_PAD.decode(token.as_bytes()).unwrap().len(), 16);
+        assert_eq!(URL_SAFE_NO_PAD.decode(proof.as_bytes()).unwrap().len(), 32);
         assert!(hmac_cipher.verify(&token, &proof));
     }
 

--- a/crates/extra/src/basic_auth.rs
+++ b/crates/extra/src/basic_auth.rs
@@ -173,9 +173,13 @@ pub fn parse_credentials(
         }
     }
 
-    if authorization.starts_with("Basic")
-        && let Some((_, auth)) = authorization.split_once(' ')
+    if let Some((scheme, auth)) = authorization.split_once(' ')
+        && scheme.eq_ignore_ascii_case("Basic")
     {
+        let auth = auth.trim_start();
+        if auth.is_empty() {
+            return Err(Error::other("`authorization` has bad format"));
+        }
         let auth_bytes = general_purpose::STANDARD
             .decode(auth)
             .map_err(Error::other)?;
@@ -298,5 +302,28 @@ mod tests {
         let (username, password) = result.unwrap();
         assert_eq!(username, "用户");
         assert_eq!(password, "密码");
+    }
+
+    #[test]
+    fn test_parse_credentials_rejects_prefixed_scheme() {
+        let mut req = Request::new();
+        req.headers_mut().insert(
+            AUTHORIZATION,
+            "BasicX cm9vdDpwd2Q=".parse().unwrap(),
+        );
+
+        assert!(parse_credentials(&req, &[AUTHORIZATION]).is_err());
+    }
+
+    #[test]
+    fn test_parse_credentials_accepts_case_insensitive_scheme() {
+        let mut req = Request::new();
+        req.headers_mut()
+            .insert(AUTHORIZATION, "basic cm9vdDpwd2Q=".parse().unwrap());
+
+        assert_eq!(
+            parse_credentials(&req, &[AUTHORIZATION]).unwrap(),
+            ("root".to_owned(), "pwd".to_owned())
+        );
     }
 }

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -57,6 +57,7 @@ use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 pub struct ForceHttps {
     https_port: Option<u16>,
     canonical_host: Option<String>,
+    trust_host_header: bool,
     skipper: Option<Box<dyn Skipper>>,
 }
 
@@ -65,6 +66,7 @@ impl Debug for ForceHttps {
         f.debug_struct("ForceHttps")
             .field("https_port", &self.https_port)
             .field("canonical_host", &self.canonical_host)
+            .field("trust_host_header", &self.trust_host_header)
             .finish()
     }
 }
@@ -90,6 +92,19 @@ impl ForceHttps {
     pub fn canonical_host(self, host: impl Into<String>) -> Self {
         Self {
             canonical_host: Some(host.into()),
+            ..self
+        }
+    }
+
+    /// Trust the request `Host`/`:authority` value when building redirect locations.
+    ///
+    /// Prefer [`ForceHttps::canonical_host`] for public services. Enable this
+    /// only when a trusted proxy or edge layer validates and overwrites host
+    /// headers before requests reach the application.
+    #[must_use]
+    pub fn trust_host_header(self, trust: bool) -> Self {
+        Self {
+            trust_host_header: trust,
             ..self
         }
     }
@@ -126,7 +141,14 @@ impl Handler for ForceHttps {
             .canonical_host
             .as_deref()
             .map(Cow::Borrowed)
-            .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned));
+            .or_else(|| {
+                self.trust_host_header.then(|| {
+                    req.uri()
+                        .authority()
+                        .map(|authority| Cow::Owned(authority.as_str().to_owned()))
+                        .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned))
+                })?
+            });
 
         if let Some(host) = redirect_base_host {
             let host = redirect_host(&host, self.https_port);
@@ -156,7 +178,7 @@ fn redirect_host(host: &str, https_port: Option<u16>) -> Cow<'_, str> {
 mod tests {
     use salvo_core::http::header::{HOST, LOCATION};
     use salvo_core::prelude::*;
-    use salvo_core::test::TestClient;
+    use salvo_core::test::{ResponseExt, TestClient};
 
     use super::*;
 
@@ -178,7 +200,9 @@ mod tests {
     }
     #[tokio::test]
     async fn test_redirect_handler() {
-        let router = Router::with_hoop(ForceHttps::new().https_port(1234)).goal(hello);
+        let router =
+            Router::with_hoop(ForceHttps::new().https_port(1234).trust_host_header(true))
+                .goal(hello);
         let response = TestClient::get("http://127.0.0.1:8698/")
             .add_header(HOST, "127.0.0.1:8698", true)
             .send(router)
@@ -188,6 +212,19 @@ mod tests {
             response.headers().get(LOCATION),
             Some(&"https://127.0.0.1:1234/".parse().unwrap())
         );
+    }
+
+    #[tokio::test]
+    async fn test_redirect_handler_does_not_trust_host_by_default() {
+        let router = Router::with_hoop(ForceHttps::new()).goal(hello);
+        let mut response = TestClient::get("http://127.0.0.1:8698/")
+            .add_header(HOST, "attacker.example", true)
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.headers().get(LOCATION), None);
+        assert_eq!(response.take_string().await.unwrap(), "Hello World");
     }
 
     #[tokio::test]

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -142,10 +142,19 @@ impl Handler for ForceHttps {
         let redirect_base_host = if let Some(host) = self.canonical_host.as_deref() {
             Some(Cow::Borrowed(host))
         } else if self.trust_host_header {
-            req.uri()
-                .authority()
-                .map(|authority| Cow::Owned(authority.as_str().to_owned()))
-                .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned))
+            // Prefer the `Host` header: that is what trusted proxies validate
+            // and rewrite. Falling back to `req.uri().authority()` first would
+            // let an HTTP/1.1 absolute-form request like
+            // `GET http://evil.example/ HTTP/1.1` bypass a validated Host
+            // value and steer the redirect target. Fall back to `:authority`
+            // only when no `Host` header is present (HTTP/2 deployments).
+            req.header::<String>(header::HOST)
+                .map(Cow::Owned)
+                .or_else(|| {
+                    req.uri()
+                        .authority()
+                        .map(|authority| Cow::Owned(authority.as_str().to_owned()))
+                })
         } else {
             if !self.no_op_warned.swap(true, Ordering::Relaxed) {
                 tracing::warn!(
@@ -233,6 +242,26 @@ mod tests {
         assert_eq!(response.status_code, Some(StatusCode::OK));
         assert_eq!(response.headers().get(LOCATION), None);
         assert_eq!(response.take_string().await.unwrap(), "Hello World");
+    }
+
+    #[tokio::test]
+    async fn test_redirect_handler_prefers_host_over_uri_authority() {
+        // Simulate an HTTP/1.1 absolute-form request where the request-line
+        // authority points at an attacker-controlled host but the trusted
+        // proxy has validated/rewritten the `Host` header to a safe value.
+        // The redirect must follow the validated `Host`, not the URI.
+        let router =
+            Router::with_hoop(ForceHttps::new().trust_host_header(true)).goal(hello);
+        let response = TestClient::get("http://evil.example/")
+            .add_header(HOST, "public.example", true)
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::PERMANENT_REDIRECT));
+        assert_eq!(
+            response.headers().get(LOCATION),
+            Some(&"https://public.example/".parse().unwrap())
+        );
     }
 
     #[tokio::test]

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -44,6 +44,7 @@
 //! ```
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use salvo_core::handler::Skipper;
 use salvo_core::http::header;
@@ -59,6 +60,7 @@ pub struct ForceHttps {
     canonical_host: Option<String>,
     trust_host_header: bool,
     skipper: Option<Box<dyn Skipper>>,
+    no_op_warned: AtomicBool,
 }
 
 impl Debug for ForceHttps {
@@ -137,18 +139,24 @@ impl Handler for ForceHttps {
         {
             return;
         }
-        let redirect_base_host = self
-            .canonical_host
-            .as_deref()
-            .map(Cow::Borrowed)
-            .or_else(|| {
-                self.trust_host_header.then(|| {
-                    req.uri()
-                        .authority()
-                        .map(|authority| Cow::Owned(authority.as_str().to_owned()))
-                        .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned))
-                })?
-            });
+        let redirect_base_host = if let Some(host) = self.canonical_host.as_deref() {
+            Some(Cow::Borrowed(host))
+        } else if self.trust_host_header {
+            req.uri()
+                .authority()
+                .map(|authority| Cow::Owned(authority.as_str().to_owned()))
+                .or_else(|| req.header::<String>(header::HOST).map(Cow::Owned))
+        } else {
+            if !self.no_op_warned.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    "ForceHttps has neither `canonical_host(...)` nor `trust_host_header(true)` \
+                     configured; non-HTTPS requests will not be redirected. Set \
+                     `canonical_host(...)` for public services, or call `trust_host_header(true)` \
+                     only when a trusted proxy validates the Host/:authority header."
+                );
+            }
+            None
+        };
 
         if let Some(host) = redirect_base_host {
             let host = redirect_host(&host, self.https_port);

--- a/crates/flash/src/cookie_store.rs
+++ b/crates/flash/src/cookie_store.rs
@@ -1,11 +1,12 @@
+use std::fmt::{self, Debug, Formatter};
+
 use salvo_core::http::cookie::time::Duration;
-use salvo_core::http::cookie::{Cookie, SameSite};
+use salvo_core::http::cookie::{Cookie, CookieJar, Key, SameSite};
 use salvo_core::{Depot, Request, Response};
 
 use super::{Flash, FlashHandler, FlashStore};
 
 /// CookieStore is a `FlashStore` implementation that stores the flash messages in a cookie.
-#[derive(Debug)]
 #[non_exhaustive]
 pub struct CookieStore {
     /// The cookie max age.
@@ -18,6 +19,19 @@ pub struct CookieStore {
     pub path: String,
     /// The cookie name.
     pub name: String,
+    key: Key,
+}
+impl Debug for CookieStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CookieStore")
+            .field("max_age", &self.max_age)
+            .field("same_site", &self.same_site)
+            .field("http_only", &self.http_only)
+            .field("path", &self.path)
+            .field("name", &self.name)
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 impl Default for CookieStore {
     fn default() -> Self {
@@ -35,6 +49,7 @@ impl CookieStore {
             http_only: true,
             path: "/".into(),
             name: "salvo.flash".into(),
+            key: Key::generate(),
         }
     }
 
@@ -73,15 +88,33 @@ impl CookieStore {
         self
     }
 
+    /// Sets the key used to sign flash cookies.
+    ///
+    /// Use a stable key shared by all application instances when flash messages
+    /// must survive restarts or load-balancing across multiple processes.
+    #[must_use]
+    pub fn key(mut self, key: Key) -> Self {
+        self.key = key;
+        self
+    }
+
     /// Into `FlashHandler`.
     #[must_use]
     pub fn into_handler(self) -> FlashHandler<Self> {
         FlashHandler::new(self)
     }
+
+    fn sign_cookie(&self, cookie: Cookie<'static>) -> Cookie<'static> {
+        let mut jar = CookieJar::new();
+        jar.signed_mut(&self.key).add(cookie);
+        jar.get(&self.name)
+            .cloned()
+            .expect("signed cookie should be present in jar")
+    }
 }
 impl FlashStore for CookieStore {
     async fn load_flash(&self, req: &mut Request, _depot: &mut Depot) -> Option<Flash> {
-        match req.cookie(&self.name) {
+        match req.cookies().signed(&self.key).get(&self.name) {
             None => None,
             Some(cookie) => match serde_json::from_str(cookie.value()) {
                 Ok(flash) => Some(flash),
@@ -99,17 +132,14 @@ impl FlashStore for CookieStore {
         res: &mut Response,
         flash: Flash,
     ) {
-        res.add_cookie(
-            Cookie::build((
-                self.name.clone(),
-                serde_json::to_string(&flash).unwrap_or_default(),
-            ))
+        let value = serde_json::to_string(&flash).unwrap_or_default();
+        let cookie = Cookie::build((self.name.clone(), value))
             .max_age(self.max_age)
             .path(self.path.clone())
             .same_site(self.same_site)
             .http_only(self.http_only)
-            .build(),
-        );
+            .build();
+        res.add_cookie(self.sign_cookie(cookie));
     }
     async fn clear_flash(&self, _depot: &mut Depot, res: &mut Response) {
         res.add_cookie(
@@ -213,5 +243,42 @@ mod tests {
         assert!(debug_str.contains("http_only"));
         assert!(debug_str.contains("path"));
         assert!(debug_str.contains("name"));
+    }
+
+    #[tokio::test]
+    async fn test_cookie_store_loads_signed_flash() {
+        let store = CookieStore::new().key(Key::generate());
+        let mut req = Request::new();
+        let mut depot = Depot::new();
+        let mut res = Response::new();
+        let mut flash = Flash::default();
+        flash.success("saved");
+
+        store
+            .save_flash(&mut req, &mut depot, &mut res, flash)
+            .await;
+
+        let cookie = res.cookie(&store.name).unwrap().clone();
+        let mut next_req = Request::new();
+        next_req.cookies_mut().add(cookie);
+
+        let loaded = store.load_flash(&mut next_req, &mut depot).await.unwrap();
+        assert_eq!(loaded.0.len(), 1);
+        assert_eq!(loaded.0[0].value, "saved");
+    }
+
+    #[tokio::test]
+    async fn test_cookie_store_rejects_unsigned_flash_cookie() {
+        let store = CookieStore::new().key(Key::generate());
+        let mut req = Request::new();
+        let mut depot = Depot::new();
+        let mut flash = Flash::default();
+        flash.success("forged");
+        req.cookies_mut().add(Cookie::new(
+            store.name.clone(),
+            serde_json::to_string(&flash).unwrap(),
+        ));
+
+        assert!(store.load_flash(&mut req, &mut depot).await.is_none());
     }
 }

--- a/crates/jwt-auth/src/finder.rs
+++ b/crates/jwt-auth/src/finder.rs
@@ -95,13 +95,44 @@ impl JwtTokenFinder for HeaderFinder {
         if self.cared_methods.contains(req.method()) {
             for header_name in &self.header_names {
                 if let Some(Ok(auth)) = req.headers().get(header_name).map(|auth| auth.to_str())
-                    && auth.starts_with("Bearer")
+                    && let Some((scheme, token)) = auth.split_once(' ')
+                    && scheme.eq_ignore_ascii_case("Bearer")
                 {
-                    return auth.split_once(' ').map(|(_, token)| token.to_owned());
+                    let token = token.trim_start();
+                    if !token.is_empty() {
+                        return Some(token.to_owned());
+                    }
                 }
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo_core::http::header::AUTHORIZATION;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn header_finder_rejects_prefixed_bearer_scheme() {
+        let finder = HeaderFinder::new();
+        let mut req = Request::new();
+        req.headers_mut()
+            .insert(AUTHORIZATION, "BearerX token".parse().unwrap());
+
+        assert_eq!(finder.find_token(&mut req).await, None);
+    }
+
+    #[tokio::test]
+    async fn header_finder_accepts_case_insensitive_bearer_scheme() {
+        let finder = HeaderFinder::new();
+        let mut req = Request::new();
+        req.headers_mut()
+            .insert(AUTHORIZATION, "bearer token".parse().unwrap());
+
+        assert_eq!(finder.find_token(&mut req).await.as_deref(), Some("token"));
     }
 }
 

--- a/crates/rate-limiter/src/fixed_guard.rs
+++ b/crates/rate-limiter/src/fixed_guard.rs
@@ -51,7 +51,7 @@ impl RateGuard for FixedGuard {
     }
 
     async fn remaining(&self, quota: &Self::Quota) -> usize {
-        quota.limit - self.count
+        quota.limit.saturating_sub(self.count)
     }
 
     async fn reset(&self, _: &Self::Quota) -> i64 {
@@ -156,6 +156,15 @@ mod tests {
 
         guard.verify(&quota).await;
         assert_eq!(guard.remaining(&quota).await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_fixed_guard_remaining_zero_quota_saturates() {
+        let mut guard = FixedGuard::new();
+        let quota = BasicQuota::per_second(0);
+
+        assert!(guard.verify(&quota).await);
+        assert_eq!(guard.remaining(&quota).await, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- Fix HMAC CSRF verification so custom token sizes validate the random token length instead of the fixed SHA-256 proof length.
- Make fixed-window rate-limit remaining counts saturating to avoid zero-quota underflow in headers.
- Stop ForceHttps from trusting Host/:authority by default, with an explicit trust_host_header(true) escape hatch for validated proxy deployments.
- Sign flash cookies by default and add a stable key setter for multi-process deployments.
- Return 404 for unknown ACME HTTP-01 challenge tokens.
- Tighten Basic and Bearer Authorization scheme parsing to exact, case-insensitive matches.

## Why

These changes address the security review findings around CSRF availability, rate-limit header underflow, Host-header redirect poisoning, client-forged flash cookies, ACME token reflection, and loose authentication scheme parsing.

## Validation

- cargo test -p salvo-csrf -p salvo-rate-limiter -p salvo_extra -p salvo-flash -p salvo-jwt-auth -p salvo-acme --all-features --target-dir target-codex-security --color never
- cargo check --workspace --all-targets --all-features --target-dir target-codex-security --color never
- cargo test -p salvo-flash --all-features --target-dir target-codex-security --color never
- cargo fmt -p salvo-csrf -p salvo-rate-limiter -p salvo_extra -p salvo-flash -p salvo-jwt-auth -p salvo-acme --check
- git diff --check

## Notes

cargo audit still reports upstream/transitive advisories through certon/hickory-proto/rsa that are not fully fixable in this repository without an upstream dependency release or ACME dependency replacement.