### PR TITLE
perf(serve-static): drop duplicate URL encoding in directory listing

### DIFF
--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -620,34 +620,31 @@ fn human_size(bytes: u64) -> String {
     format!("{} {}", bytes, units[index])
 }
 fn list_html(current: &CurrentInfo) -> String {
-    fn header_link(path: &str) -> String {
-        let segments = path
+    fn header_link(out: &mut String, path: &str) {
+        let _ = write!(out, r#"<a href="/">{HOME_ICON}</a>"#);
+        let mut link = String::new();
+        for seg in path
             .trim_start_matches('/')
             .trim_end_matches('/')
-            .split('/');
-        let mut link = "".to_owned();
-        format!(
-            r#"<a href="/">{}</a>{}"#,
-            HOME_ICON,
-            segments
-                .map(|seg| {
-                    link = format!("{link}/{}", encode_url_path(seg));
-                    format!("/<a href=\"{link}\">{}</a>", encode_url_path(seg))
-                })
-                .collect::<Vec<_>>()
-                .join("")
-        )
+            .split('/')
+        {
+            let encoded = encode_url_path(seg);
+            link.push('/');
+            link.push_str(&encoded);
+            let _ = write!(out, r#"/<a href="{link}">{encoded}</a>"#);
+        }
     }
     let mut ftxt = format!(
         r#"<!DOCTYPE html><html><head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width">
         <title>{}</title>
-        <style>{}</style></head><body><header><h3>Index of: {}</h3></header><hr/>"#,
+        <style>{}</style></head><body><header><h3>Index of: "#,
         encode_url_path(&current.path),
         HTML_STYLE,
-        header_link(&current.path)
     );
+    header_link(&mut ftxt, &current.path);
+    let _ = write!(ftxt, "</h3></header><hr/>");
     if current.dirs.is_empty() && current.files.is_empty() {
         let _ = write!(ftxt, "<p>No files</p>");
     } else {
@@ -661,22 +658,24 @@ fn list_html(current: &CurrentInfo) -> String {
         );
         let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
         for dir in &current.dirs {
+            let encoded = encode_url_path(&dir.name);
             let _ = write!(
                 ftxt,
                 r#"<tr><td>{}</td><td><a href="./{}/">{}</a></td><td>{}</td><td></td></tr>"#,
                 DIR_ICON,
-                encode_url_path(&dir.name),
-                encode_url_path(&dir.name),
+                encoded,
+                encoded,
                 dir.modified.format(&format).expect("format time failed"),
             );
         }
         for file in &current.files {
+            let encoded = encode_url_path(&file.name);
             let _ = write!(
                 ftxt,
                 r#"<tr><td>{}</td><td><a href="./{}">{}</a></td><td>{}</td><td>{}</td></tr>"#,
                 FILE_ICON,
-                encode_url_path(&file.name),
-                encode_url_path(&file.name),
+                encoded,
+                encoded,
                 file.modified.format(&format).expect("format time failed"),
                 human_size(file.size)
             );


### PR DESCRIPTION
## Summary

Two small allocations per row in the auto-generated directory listing:

- Each entry called `encode_url_path(&entry.name)` twice — once for the
  `href`, once for the visible label — encoding (and allocating) the
  same string twice. Compute it once and reuse it.
- `header_link` built each breadcrumb via `format!()` inside a `.map()`,
  collected into a `Vec`, and joined with `\"\"`. Replaced with a single
  buffer that we write into directly; each segment is encoded once and
  appended in place.

The rendered HTML is byte-identical (verified manually for `/`,
`/foo`, `/foo/bar`).

## Test plan

- [x] `cargo test -p salvo-serve-static`
- [x] Manual trace through `header_link` for `\"/\"`, `\"/foo\"`,
      `\"/foo/bar\"`, and trailing-slash inputs