### PR TITLE
fix(session): avoid UTF-8 boundary panic verifying session cookie

### DIFF
--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -438,14 +438,16 @@ where
     /// verifies the signed value and returns it. If there's a problem, returns
     /// an `Err` with a string describing the issue.
     fn verify_signature(&self, cookie_value: &str) -> Result<String, Error> {
-        if cookie_value.len() < BASE64_DIGEST_LEN {
+        // Split [MAC | original-value] into its two parts.
+        //
+        // The digest prefix is always ASCII base64; if the cookie value's
+        // 44th byte falls inside a multi-byte UTF-8 codepoint, the value is
+        // malformed and we reject it instead of panicking via `split_at`.
+        let Some((digest_str, value)) = cookie_value.split_at_checked(BASE64_DIGEST_LEN) else {
             return Err(Error::Other(
                 "length of value is <= BASE64_DIGEST_LEN".into(),
             ));
-        }
-
-        // Split [MAC | original-value] into its two parts.
-        let (digest_str, value) = cookie_value.split_at(BASE64_DIGEST_LEN);
+        };
         let digest = general_purpose::STANDARD
             .decode(digest_str)
             .map_err(|_| Error::Other("bad base64 digest".into()))?;
@@ -601,6 +603,36 @@ mod tests {
             .send(&service)
             .await;
         assert_eq!(response.take_string().await.unwrap(), "home");
+    }
+
+    #[test]
+    fn test_verify_signature_rejects_non_ascii_at_digest_boundary() {
+        // 43 ASCII bytes + a 2-byte UTF-8 codepoint puts byte 44 (the digest
+        // length) inside the multi-byte char. `split_at` would panic; the
+        // checked variant must reject the cookie cleanly.
+        let handler = SessionHandler::builder(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .build()
+        .unwrap();
+
+        let malformed = "A".repeat(43) + "Ä" + "rest";
+        assert_eq!(malformed.len(), 43 + 2 + 4);
+        assert!(handler.verify_signature(&malformed).is_err());
+    }
+
+    #[test]
+    fn test_verify_signature_rejects_short_value() {
+        let handler = SessionHandler::builder(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .build()
+        .unwrap();
+
+        assert!(handler.verify_signature("too-short").is_err());
+        assert!(handler.verify_signature("").is_err());
     }
 
     // Tests for HandlerBuilder


### PR DESCRIPTION
## Summary

`SessionHandler::verify_signature` split the cookie value at byte 44
(`BASE64_DIGEST_LEN`) with `str::split_at`. If that byte falls inside a
multi-byte UTF-8 codepoint, `split_at` panics. The cookie crate exposes
`Cookie::value()` as `&str` over arbitrary UTF-8, so a client can send a
malformed session cookie (43 ASCII bytes + a 2-byte char + filler) and
crash the request task on every request that carries it — a cheap DoS
on any handler stack that uses sessions.

The existing length pre-check only guarded `len() < BASE64_DIGEST_LEN`,
not the codepoint boundary at the split point.

Switched to `str::split_at_checked` (stable since 1.80, well within the
1.92 MSRV), which returns `None` for both \"too short\" and
\"non-boundary\" cases. Reject those cookies with the same error path
the rest of the function uses for malformed signatures. The legitimate
base64 prefix is always ASCII, so well-formed cookies are unaffected.

Repro on `main` panics inside `core::str::slice_error_fail` with
`end byte index 44 is not a char boundary`.

## Test plan

- [x] New unit test reproduces the panic and asserts a clean `Err`
- [x] New unit test covers the short-value rejection path
- [x] `cargo test -p salvo-session` (29 passed)