### PR TITLE
ci(fuzz): drop --locked from cargo-fuzz install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz
 
       - name: Run target
         working-directory: ./fuzz


### PR DESCRIPTION
## Summary
- The scheduled `fuzz` workflow has been failing on the `Install cargo-fuzz` step.
- Root cause: `cargo install cargo-fuzz --locked` uses cargo-fuzz's bundled `Cargo.lock`, which pins `rustix 0.36.5`. That version relies on unstable `rustc_attrs` that no longer compile on current nightly toolchains, so the install fails before any fuzz target runs.
- Removing `--locked` lets cargo resolve a newer `rustix` (and other transitive deps) that compiles on today's nightly.

Failing run: https://github.com/salvo-rs/salvo/actions/runs/25621628709

## Test plan
- [ ] Re-run the `fuzz` workflow (manually via `workflow_dispatch` or wait for the next scheduled run) and confirm `Install cargo-fuzz` succeeds for all matrix targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)