### PR TITLE
fix(craft): forward doc/deprecated attrs to #[endpoint] impl block

### DIFF
--- a/crates/craft-macros/src/craft.rs
+++ b/crates/craft-macros/src/craft.rs
@@ -146,11 +146,20 @@ fn rewrite_method(
             // `#[endpoint]` on an `impl` block reads doc/deprecated attributes from the
             // impl block itself (see oapi-macros `endpoint.rs`). Forward those attributes
             // from the original method onto the generated impl block so the OpenAPI
-            // description and `deprecated` flag are picked up.
+            // description and `deprecated` flag are picked up. Restrict to the
+            // `#[doc = "..."]` NameValue form so list-form attributes like
+            // `#[doc(alias = "...")]`, which are valid on methods but not on impl
+            // blocks, do not break compilation.
             let forwarded_attrs: Vec<Attribute> = method
                 .attrs
                 .iter()
-                .filter(|a| a.path().is_ident("doc") || a.path().is_ident("deprecated"))
+                .filter(|a| {
+                    if a.path().is_ident("doc") {
+                        matches!(a.meta, syn::Meta::NameValue(_))
+                    } else {
+                        a.path().is_ident("deprecated")
+                    }
+                })
                 .cloned()
                 .collect();
             method.sig.inputs[0] = FnArg::Receiver(parse_quote!(&self));

--- a/crates/craft-macros/src/craft.rs
+++ b/crates/craft-macros/src/craft.rs
@@ -143,6 +143,16 @@ fn rewrite_method(
                 FnReceiver::Arc => (quote!(self: &::std::sync::Arc<Self>), quote!(self.clone())),
                 _ => unreachable!(),
             };
+            // `#[endpoint]` on an `impl` block reads doc/deprecated attributes from the
+            // impl block itself (see oapi-macros `endpoint.rs`). Forward those attributes
+            // from the original method onto the generated impl block so the OpenAPI
+            // description and `deprecated` flag are picked up.
+            let forwarded_attrs: Vec<Attribute> = method
+                .attrs
+                .iter()
+                .filter(|a| a.path().is_ident("doc") || a.path().is_ident("deprecated"))
+                .cloned()
+                .collect();
             method.sig.inputs[0] = FnArg::Receiver(parse_quote!(&self));
             method.sig.ident = Ident::new("handle", Span::call_site());
             let where_clause = impl_generics.make_where_clause().clone();
@@ -167,6 +177,7 @@ fn rewrite_method(
                     }
                     #[allow(unused_imports)]
                     use ::std::ops::Deref as _;
+                    #(#forwarded_attrs)*
                     #macro_attr
                     impl #impl_generics handle #angle_bracketed #where_clause{
                         #method

--- a/crates/craft/tests/craft_oapi_doc_comments.rs
+++ b/crates/craft/tests/craft_oapi_doc_comments.rs
@@ -1,0 +1,95 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use salvo::oapi::extract::QueryParam;
+use salvo::oapi::{OpenApi, PathItemType};
+use salvo::prelude::*;
+use salvo_craft::craft;
+
+#[derive(Clone, Debug)]
+pub struct DocService {
+    base: i64,
+}
+
+#[craft]
+impl DocService {
+    /// Add with self
+    ///
+    /// Adds the base to the two query parameters.
+    #[craft(endpoint)]
+    fn add_ref(&self, left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (self.base + *left + *right).to_string()
+    }
+
+    /// Add with arc
+    ///
+    /// Same as `add_ref` but takes `Arc<Self>`.
+    #[craft(endpoint)]
+    fn add_arc(self: Arc<Self>, left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (self.base + *left + *right).to_string()
+    }
+
+    /// Add plain
+    ///
+    /// Adds two query parameters without a receiver.
+    #[craft(endpoint)]
+    fn add_plain(left: QueryParam<i64>, right: QueryParam<i64>) -> String {
+        (*left + *right).to_string()
+    }
+}
+
+fn description_for(doc: &OpenApi, path: &str) -> Option<String> {
+    doc.paths
+        .get(path)
+        .and_then(|item| item.operations.get(&PathItemType::Get))
+        .and_then(|op| op.description.clone())
+}
+
+fn summary_for(doc: &OpenApi, path: &str) -> Option<String> {
+    doc.paths
+        .get(path)
+        .and_then(|item| item.operations.get(&PathItemType::Get))
+        .and_then(|op| op.summary.clone())
+}
+
+#[test]
+fn craft_endpoint_propagates_doc_comments() {
+    let service = Arc::new(DocService { base: 1 });
+    let router = Router::new()
+        .push(Router::with_path("add-ref").get(service.add_ref()))
+        .push(Router::with_path("add-arc").get(service.add_arc()))
+        .push(Router::with_path("add-plain").get(DocService::add_plain()));
+
+    let doc = OpenApi::new("Craft Doc Test", "0.0.1").merge_router(&router);
+
+    // `&self` receiver: doc comments must reach the OpenAPI operation.
+    assert_eq!(
+        summary_for(&doc, "/add-ref").as_deref(),
+        Some("Add with self")
+    );
+    assert_eq!(
+        description_for(&doc, "/add-ref").as_deref(),
+        Some("Adds the base to the two query parameters.")
+    );
+
+    // `Arc<Self>` receiver: same expectation.
+    assert_eq!(
+        summary_for(&doc, "/add-arc").as_deref(),
+        Some("Add with arc")
+    );
+    assert_eq!(
+        description_for(&doc, "/add-arc").as_deref(),
+        Some("Same as `add_ref` but takes `Arc<Self>`.")
+    );
+
+    // No-receiver: already worked, but assert it stays correct.
+    assert_eq!(
+        summary_for(&doc, "/add-plain").as_deref(),
+        Some("Add plain")
+    );
+    assert_eq!(
+        description_for(&doc, "/add-plain").as_deref(),
+        Some("Adds two query parameters without a receiver.")
+    );
+}

--- a/crates/craft/tests/craft_oapi_doc_comments.rs
+++ b/crates/craft/tests/craft_oapi_doc_comments.rs
@@ -25,6 +25,9 @@ impl DocService {
     /// Add with arc
     ///
     /// Same as `add_ref` but takes `Arc<Self>`.
+    // `#[doc(alias = ...)]` is valid on methods but not on impl blocks. The macro
+    // must not forward list-form `doc` attributes to the generated impl block.
+    #[doc(alias = "add-arc")]
     #[craft(endpoint)]
     fn add_arc(self: Arc<Self>, left: QueryParam<i64>, right: QueryParam<i64>) -> String {
         (self.base + *left + *right).to_string()


### PR DESCRIPTION
## Summary
- Fixes #1477: `#[craft(endpoint)]` on methods with `&self` / `Arc<Self>` receivers now propagates `///` doc comments to the OpenAPI operation's `summary`/`description`.
- Root cause: the macro expansion placed `#[endpoint]` on a generated inner `impl` block, but left the original method's `#[doc]` attributes attached to the method. `oapi-macros` reads doc comments from `item_impl.attrs` ([endpoint.rs](crates/oapi-macros/src/endpoint.rs#L135)), so it never saw them. Methods without a receiver went through `Item::Fn` and were already fine.
- Fix: in `rewrite_method` (craft-macros), forward `#[doc]` and `#[deprecated]` from the original method onto the generated impl block before `#[endpoint]` is expanded.

## Test plan
- [x] New integration test `crates/craft/tests/craft_oapi_doc_comments.rs` asserts that for `&self`, `Arc<Self>`, and no-receiver methods, both the OpenAPI `summary` (first doc line) and `description` (remaining lines) are populated.
- [x] `cargo test -p salvo-craft -p salvo-craft-macros` (all tests + doctests pass).
- [x] `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)