### PR TITLE
[codex] Fix security review P0 issues

### DIFF
--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -72,31 +72,32 @@ impl FormData {
             }
             Some(ctype) if ctype.type_() == mime::MULTIPART => {
                 let mut form_data = Self::new();
-                if let Some(boundary) = headers
+                let Some(boundary) = headers
                     .get(CONTENT_TYPE)
                     .and_then(|ct| ct.to_str().ok())
                     .and_then(|ct| multra::parse_boundary(ct).ok())
-                {
-                    let mut multipart = Multipart::new(body, boundary);
-                    while let Some(mut field) = multipart.next_field().await.map_err(|e| {
-                        // Check if the multra error contains a LengthLimitError
-                        let mut source = std::error::Error::source(&e);
-                        while let Some(err) = source {
-                            if err.is::<http_body_util::LengthLimitError>() {
-                                return ParseError::PayloadTooLarge;
-                            }
-                            source = std::error::Error::source(err);
+                else {
+                    return Err(ParseError::InvalidContentType);
+                };
+                let mut multipart = Multipart::new(body, boundary);
+                while let Some(mut field) = multipart.next_field().await.map_err(|e| {
+                    // Check if the multra error contains a LengthLimitError
+                    let mut source = std::error::Error::source(&e);
+                    while let Some(err) = source {
+                        if err.is::<http_body_util::LengthLimitError>() {
+                            return ParseError::PayloadTooLarge;
                         }
-                        ParseError::Multer(e)
-                    })? {
-                        if let Some(name) = field.name().map(|s| s.to_owned()) {
-                            if field.headers().get(CONTENT_TYPE).is_some() {
-                                form_data
-                                    .files
-                                    .insert(name, FilePart::create(&mut field).await?);
-                            } else {
-                                form_data.fields.insert(name, field.text().await?);
-                            }
+                        source = std::error::Error::source(err);
+                    }
+                    ParseError::Multer(e)
+                })? {
+                    if let Some(name) = field.name().map(|s| s.to_owned()) {
+                        if field.file_name().is_some() {
+                            form_data
+                                .files
+                                .insert(name, FilePart::create(&mut field).await?);
+                        } else {
+                            form_data.fields.insert(name, field.text().await?);
                         }
                     }
                 }

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -1586,6 +1586,33 @@ file content\r\n\
         assert_eq!(file.headers().get("content-type").unwrap(), "text/plain");
         let files = req.files("file1").await.unwrap();
         assert_eq!(files[0].name().unwrap(), "err.txt");
+
+        let mut req: Request = TestClient::post("http://127.0.0.1:8698/hello")
+            .add_header(
+                "content-type",
+                "multipart/form-data; boundary=----WebKitFormBoundaryNoPartContentType",
+                true,
+            )
+            .body(
+                "------WebKitFormBoundaryNoPartContentType\r\n\
+Content-Disposition: form-data; name=\"file1\"; filename=\"err.txt\"\r\n\r\n\
+file content\r\n\
+------WebKitFormBoundaryNoPartContentType--\r\n",
+            )
+            .build();
+        let file = req.file("file1").await.unwrap();
+        assert_eq!(file.name().unwrap(), "err.txt");
+    }
+
+    #[tokio::test]
+    async fn test_form_data_multipart_requires_boundary() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/upload")
+            .add_header("content-type", "multipart/form-data", true)
+            .body("ignored")
+            .build();
+
+        let err = req.form_data().await.unwrap_err();
+        assert!(matches!(err, ParseError::InvalidContentType));
     }
 
     /// Test that `form_data()` works correctly after `payload()` has been accessed.

--- a/crates/core/src/routing.rs
+++ b/crates/core/src/routing.rs
@@ -415,7 +415,7 @@ use std::sync::Arc;
 pub use flow_ctrl::FlowCtrl;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
-use crate::http::uri::{Parts as UriParts, Uri};
+use crate::http::uri::Uri;
 use crate::{Handler, Response};
 
 const HTML_ENCODE_SET: &AsciiSet = &CONTROLS
@@ -505,35 +505,22 @@ pub fn normalize_url_path(path: &str) -> String {
 
 #[doc(hidden)]
 pub fn redirect_to_dir_url(req_uri: &Uri, res: &mut Response) {
-    let UriParts {
-        scheme,
-        authority,
-        path_and_query,
-        ..
-    } = req_uri.clone().into_parts();
-    let mut builder = Uri::builder();
-    if let Some(scheme) = scheme {
-        builder = builder.scheme(scheme);
+    let Some(path_and_query) = req_uri.path_and_query() else {
+        tracing::error!(uri = %req_uri, "failed to build redirect URI from path");
+        res.status_code(crate::http::StatusCode::INTERNAL_SERVER_ERROR);
+        return;
+    };
+    let path = path_and_query.path();
+    let mut redirect_uri = if path.ends_with('/') {
+        path.to_owned()
+    } else {
+        format!("{path}/")
+    };
+    if let Some(query) = path_and_query.query() {
+        redirect_uri.push('?');
+        redirect_uri.push_str(query);
     }
-    if let Some(authority) = authority {
-        builder = builder.authority(authority);
-    }
-    if let Some(path_and_query) = path_and_query {
-        if let Some(query) = path_and_query.query() {
-            builder = builder.path_and_query(format!("{}/?{}", path_and_query.path(), query));
-        } else {
-            builder = builder.path_and_query(format!("{}/", path_and_query.path()));
-        }
-    }
-    match builder.build() {
-        Ok(redirect_uri) => {
-            res.render(crate::writing::Redirect::found(redirect_uri.to_string()));
-        }
-        Err(e) => {
-            tracing::error!(error = ?e, "failed to build redirect URI");
-            res.status_code(crate::http::StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    }
+    res.render(crate::writing::Redirect::found(redirect_uri));
 }
 
 /// Check if a path component is a Windows reserved device name.
@@ -562,6 +549,8 @@ fn is_windows_reserved_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::http::header::LOCATION;
+    use crate::http::uri::Uri;
     use crate::prelude::*;
     use crate::routing::{is_windows_reserved_name, normalize_url_path};
     use crate::test::{ResponseExt, TestClient};
@@ -686,6 +675,16 @@ mod tests {
         // Empty parts
         assert_eq!(normalize_url_path("a//b"), "a/b");
         assert_eq!(normalize_url_path(""), "");
+    }
+
+    #[test]
+    fn test_redirect_to_dir_url_uses_origin_form_location() {
+        let uri: Uri = "http://attacker.example/assets?x=1".parse().unwrap();
+        let mut res = Response::new();
+
+        super::redirect_to_dir_url(&uri, &mut res);
+
+        assert_eq!(res.headers()[LOCATION], "/assets/?x=1");
     }
 
     #[test]

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -105,7 +105,7 @@ impl ConstDecoder {
     /// If you have (n, e) RSA public key components as strings, use this.
     pub fn from_rsa_components(modulus: &str, exponent: &str) -> Result<Self, JwtError> {
         DecodingKey::from_rsa_components(modulus, exponent)
-            .map(|key| Self::with_validation(key, Validation::new(Algorithm::PS512)))
+            .map(|key| Self::with_validation(key, Validation::new(Algorithm::RS256)))
     }
 
     /// If you have (n, e) RSA public key components already decoded, use this.
@@ -113,7 +113,7 @@ impl ConstDecoder {
     pub fn from_rsa_raw_components(modulus: &[u8], exponent: &[u8]) -> Self {
         Self::with_validation(
             DecodingKey::from_rsa_raw_components(modulus, exponent),
-            Validation::new(Algorithm::PS512),
+            Validation::new(Algorithm::RS256),
         )
     }
 
@@ -168,6 +168,18 @@ impl ConstDecoder {
     pub fn from_ed_components(x: &str) -> Result<Self, JwtError> {
         DecodingKey::from_ed_components(x)
             .map(|key| Self::with_validation(key, Validation::new(Algorithm::EdDSA)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rsa_raw_components_default_to_rs256() {
+        let decoder = ConstDecoder::from_rsa_raw_components(&[1, 2, 3], &[1, 0, 1]);
+
+        assert_eq!(decoder.validation.algorithms, [Algorithm::RS256]);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements the low-risk P0 fixes from the local security review reports (`_improve.md` / `_codex_improve.md`):

- make directory-slash redirects use origin-form `Location` values so absolute-form request targets cannot inject scheme/authority into redirects
- classify multipart file parts by `filename` instead of per-part `Content-Type`
- return `InvalidContentType` when `multipart/*` lacks a parseable boundary instead of silently returning an empty form
- align RSA component decoder defaults with PEM RSA defaults by using `RS256`

## Impact

These changes narrow redirect and upload parsing footguns without changing public API shape. The RSA component change fixes an inconsistent default that made common JWKS-style RSA components default to `PS512` while PEM RSA defaulted to `RS256`.

## Validation

- `cargo test -p salvo_core`
- `cargo test -p salvo-jwt-auth`