### PR TITLE
fix(jwt-auth): RSA components decoders should default to RS256

### DIFF
--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -105,7 +105,7 @@ impl ConstDecoder {
     /// If you have (n, e) RSA public key components as strings, use this.
     pub fn from_rsa_components(modulus: &str, exponent: &str) -> Result<Self, JwtError> {
         DecodingKey::from_rsa_components(modulus, exponent)
-            .map(|key| Self::with_validation(key, Validation::new(Algorithm::PS512)))
+            .map(|key| Self::with_validation(key, Validation::new(Algorithm::RS256)))
     }
 
     /// If you have (n, e) RSA public key components already decoded, use this.
@@ -113,7 +113,7 @@ impl ConstDecoder {
     pub fn from_rsa_raw_components(modulus: &[u8], exponent: &[u8]) -> Self {
         Self::with_validation(
             DecodingKey::from_rsa_raw_components(modulus, exponent),
-            Validation::new(Algorithm::PS512),
+            Validation::new(Algorithm::RS256),
         )
     }
 
@@ -168,6 +168,18 @@ impl ConstDecoder {
     pub fn from_ed_components(x: &str) -> Result<Self, JwtError> {
         DecodingKey::from_ed_components(x)
             .map(|key| Self::with_validation(key, Validation::new(Algorithm::EdDSA)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rsa_raw_components_default_to_rs256() {
+        let decoder = ConstDecoder::from_rsa_raw_components(&[1, 2, 3], &[1, 0, 1]);
+
+        assert_eq!(decoder.validation.algorithms, [Algorithm::RS256]);
     }
 }
 


### PR DESCRIPTION
## Summary

`ConstDecoder::from_rsa_pem` defaults to `Algorithm::RS256`, but `from_rsa_components` and `from_rsa_raw_components` defaulted to `Algorithm::PS512`. Almost every JWKS endpoint publishes RSA keys signed with `RS256` (the OIDC default), so wiring a decoder via the component constructors silently rejected valid tokens.

This change aligns both component-based constructors with the PEM constructor. Callers who genuinely need `PS512` can still set it via the validation builder.

## Test plan

- [x] `cargo test -p salvo-jwt-auth --lib` — 58 passed
- [x] New unit test `rsa_raw_components_default_to_rs256` asserts the default algorithm on `ConstDecoder::from_rsa_raw_components`

## References

- See `_improve.md` (Q1) for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)