### PR TITLE
fix(core): multipart form_data must error when boundary is missing

### DIFF
--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -72,31 +72,32 @@ impl FormData {
             }
             Some(ctype) if ctype.type_() == mime::MULTIPART => {
                 let mut form_data = Self::new();
-                if let Some(boundary) = headers
+                let Some(boundary) = headers
                     .get(CONTENT_TYPE)
                     .and_then(|ct| ct.to_str().ok())
                     .and_then(|ct| multra::parse_boundary(ct).ok())
-                {
-                    let mut multipart = Multipart::new(body, boundary);
-                    while let Some(mut field) = multipart.next_field().await.map_err(|e| {
-                        // Check if the multra error contains a LengthLimitError
-                        let mut source = std::error::Error::source(&e);
-                        while let Some(err) = source {
-                            if err.is::<http_body_util::LengthLimitError>() {
-                                return ParseError::PayloadTooLarge;
-                            }
-                            source = std::error::Error::source(err);
+                else {
+                    return Err(ParseError::InvalidContentType);
+                };
+                let mut multipart = Multipart::new(body, boundary);
+                while let Some(mut field) = multipart.next_field().await.map_err(|e| {
+                    // Check if the multra error contains a LengthLimitError
+                    let mut source = std::error::Error::source(&e);
+                    while let Some(err) = source {
+                        if err.is::<http_body_util::LengthLimitError>() {
+                            return ParseError::PayloadTooLarge;
                         }
-                        ParseError::Multer(e)
-                    })? {
-                        if let Some(name) = field.name().map(|s| s.to_owned()) {
-                            if field.headers().get(CONTENT_TYPE).is_some() {
-                                form_data
-                                    .files
-                                    .insert(name, FilePart::create(&mut field).await?);
-                            } else {
-                                form_data.fields.insert(name, field.text().await?);
-                            }
+                        source = std::error::Error::source(err);
+                    }
+                    ParseError::Multer(e)
+                })? {
+                    if let Some(name) = field.name().map(|s| s.to_owned()) {
+                        if field.headers().get(CONTENT_TYPE).is_some() {
+                            form_data
+                                .files
+                                .insert(name, FilePart::create(&mut field).await?);
+                        } else {
+                            form_data.fields.insert(name, field.text().await?);
                         }
                     }
                 }

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -1588,6 +1588,17 @@ file content\r\n\
         assert_eq!(files[0].name().unwrap(), "err.txt");
     }
 
+    #[tokio::test]
+    async fn test_form_data_multipart_requires_boundary() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/upload")
+            .add_header("content-type", "multipart/form-data", true)
+            .body("ignored")
+            .build();
+
+        let err = req.form_data().await.unwrap_err();
+        assert!(matches!(err, ParseError::InvalidContentType));
+    }
+
     /// Test that `form_data()` works correctly after `payload()` has been accessed.
     ///
     /// This simulates a common scenario where middleware reads the request body


### PR DESCRIPTION
## Summary

When a request advertised `Content-Type: multipart/form-data` but the boundary could not be parsed (missing or malformed), `FormData::read` silently fell through and returned `Ok(empty_form)`. Downstream code that relies on \"if it parsed, it was a real multipart payload\" could therefore process attacker-shaped requests as empty submissions, missing the obvious validation error.

This change converts the boundary-missing branch into an explicit `ParseError::InvalidContentType`, matching the behaviour for entirely unsupported content types.

## Test plan

- [x] `cargo test -p salvo_core --lib test_form` — 6 passed
- [x] New `test_form_data_multipart_requires_boundary` asserts the new error path

## References

- See `_improve.md` (A6) and `_codex_improve.md` for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)