### PR TITLE
fix(core): detect multipart file parts by filename, not Content-Type

### DIFF
--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -90,7 +90,7 @@ impl FormData {
                         ParseError::Multer(e)
                     })? {
                         if let Some(name) = field.name().map(|s| s.to_owned()) {
-                            if field.headers().get(CONTENT_TYPE).is_some() {
+                            if field.file_name().is_some() {
                                 form_data
                                     .files
                                     .insert(name, FilePart::create(&mut field).await?);

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -1586,6 +1586,22 @@ file content\r\n\
         assert_eq!(file.headers().get("content-type").unwrap(), "text/plain");
         let files = req.files("file1").await.unwrap();
         assert_eq!(files[0].name().unwrap(), "err.txt");
+
+        let mut req: Request = TestClient::post("http://127.0.0.1:8698/hello")
+            .add_header(
+                "content-type",
+                "multipart/form-data; boundary=----WebKitFormBoundaryNoPartContentType",
+                true,
+            )
+            .body(
+                "------WebKitFormBoundaryNoPartContentType\r\n\
+Content-Disposition: form-data; name=\"file1\"; filename=\"err.txt\"\r\n\r\n\
+file content\r\n\
+------WebKitFormBoundaryNoPartContentType--\r\n",
+            )
+            .build();
+        let file = req.file("file1").await.unwrap();
+        assert_eq!(file.name().unwrap(), "err.txt");
     }
 
     /// Test that `form_data()` works correctly after `payload()` has been accessed.


### PR DESCRIPTION
## Summary

The multipart parser classified a part as a file when the part carried a per-part `Content-Type` header, and otherwise read the body into memory via `field.text().await`. RFC 7578 §4.2 makes the `filename` directive in `Content-Disposition` the indicator of a file part; per-part `Content-Type` is optional metadata.

As a result a binary upload with `Content-Disposition: form-data; name=...; filename=...` but no per-part `Content-Type` was streamed into a `String` instead of written to a temp file. For any deployment that raised \`form_data_max_size\` to accept uploads, this amplified memory pressure and could turn a benign upload into a request-level memory-spike DoS surface.

This change keys the file-vs-text decision on `field.file_name().is_some()`. The `FilePart` continues to capture the per-part `Content-Type` as metadata via `field.headers()`.

## Test plan

- [x] `cargo test -p salvo_core --lib test_form` — 5 passed
- [x] `test_form` extended with a multipart payload that has `filename` but no per-part `Content-Type`; the new assertion verifies it ends up in `files`, not `fields`

## References

- See `_improve.md` (A2) and `_codex_improve.md` for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)