### PR TITLE
fix(core): avoid panicking on invalid Content-Type in catcher

### DIFF
--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -502,10 +502,11 @@ pub fn write_error_default(req: &Request, res: &mut Response, footer: Option<&st
             footer,
         )
     };
-    res.headers_mut().insert(
-        header::CONTENT_TYPE,
-        format.to_string().parse().expect("invalid `Content-Type`"),
-    );
+    let content_type = format
+        .to_string()
+        .parse()
+        .unwrap_or_else(|_| header::HeaderValue::from_static("text/plain; charset=utf-8"));
+    res.headers_mut().insert(header::CONTENT_TYPE, content_type);
     let _ = res.write_body(data);
 }
 


### PR DESCRIPTION
## Summary

`write_error_default` parsed `Mime::to_string()` into a `HeaderValue` via `.expect(\"invalid \\`Content-Type\\`\")`. In practice the value returned by `guess_accept_mime` always serialises to a valid header token, so the panic was unreachable today — but the invariant is fragile and easy to break in future refactors of `guess_accept_mime`. A library helper that ultimately renders an error response should not have any panic edges of its own.

Fall back to `text/plain; charset=utf-8` instead of panicking, so the error-rendering path stays safe regardless of how `Mime` parsing evolves upstream.

## Test plan

- [x] `cargo test -p salvo_core --lib catcher` — 2 passed

## References

- See `_improve.md` (Q2) for the audit context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)