### PR TITLE
feat(jwt-auth): reject symmetric JWKs from OIDC discovery by default

### DIFF
--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -104,6 +104,9 @@ where
     pub validation: Option<Validation>,
     /// The expected OIDC token audiences.
     pub audiences: Option<Vec<String>>,
+    /// Whether to accept symmetric (`kty: "oct"` / HS*) keys served by
+    /// the JWKS endpoint. Disabled by default.
+    pub allow_symmetric_jwks: bool,
 }
 impl<T: AsRef<str>> Debug for DecoderBuilder<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -111,6 +114,7 @@ impl<T: AsRef<str>> Debug for DecoderBuilder<T> {
             .field("http_client", &self.http_client)
             .field("validation", &self.validation)
             .field("audiences", &self.audiences)
+            .field("allow_symmetric_jwks", &self.allow_symmetric_jwks)
             .finish()
     }
 }
@@ -126,6 +130,7 @@ where
             http_client: None,
             validation: None,
             audiences: None,
+            allow_symmetric_jwks: false,
         }
     }
     /// Set the http client for the decoder.
@@ -159,6 +164,21 @@ where
         self
     }
 
+    /// Allow symmetric (`kty: "oct"` / HS*) keys to be loaded from the
+    /// JWKS endpoint.
+    ///
+    /// **Disabled by default.** OIDC JWKS endpoints normally publish only
+    /// asymmetric public keys (RSA / EC / OKP). Accepting symmetric keys
+    /// widens the trust surface — a leaked or substituted shared secret
+    /// would let an attacker mint tokens the decoder accepts. Enable this
+    /// only when the issuer is known to publish HS* keys and is trusted
+    /// to keep them secret.
+    #[must_use]
+    pub fn allow_symmetric_jwks(mut self, allow: bool) -> Self {
+        self.allow_symmetric_jwks = allow;
+        self
+    }
+
     /// Build a `OidcDecoder`.
     pub async fn build(self) -> Result<OidcDecoder, JwtAuthError> {
         let Self {
@@ -166,6 +186,7 @@ where
             http_client,
             validation,
             audiences,
+            allow_symmetric_jwks,
         } = self;
         let raw_issuer = issuer.as_ref();
 
@@ -175,11 +196,10 @@ where
         let validation =
             configure_oidc_validation(validation.unwrap_or_default(), raw_issuer, audiences)?;
         let issuer = raw_issuer.trim_end_matches('/').to_owned();
-        let cache = Arc::new(RwLock::new(JwkSetStore::new(
-            jwks,
-            CachePolicy::default(),
-            validation,
-        )));
+        let cache = Arc::new(RwLock::new(
+            JwkSetStore::new(jwks, CachePolicy::default(), validation)
+                .with_allow_symmetric_jwks(allow_symmetric_jwks),
+        ));
         let cache_state = Arc::new(CacheState::new());
         let http_client = resolve_or_else(http_client, default_http_client)?;
         let decoder = OidcDecoder {
@@ -485,6 +505,7 @@ async fn collect_limited_body(
 pub(crate) fn decode_jwk(
     jwk: &Jwk,
     validation: &Validation,
+    allow_symmetric_jwks: bool,
 ) -> Result<(String, DecodingInfo), JwtAuthError> {
     let kid = jwk.common.key_id.clone();
     let alg = jwk.common.key_algorithm;
@@ -503,6 +524,14 @@ pub(crate) fn decode_jwk(
             DecodingKey::from_rsa_components(&params.n, &params.e).ok()
         }
         jsonwebtoken::jwk::AlgorithmParameters::OctetKey(ref params) => {
+            if !allow_symmetric_jwks {
+                tracing::warn!(
+                    kid = ?kid,
+                    "rejecting symmetric (oct) JWK; OIDC JWKS should publish public keys. \
+                     Enable allow_symmetric_jwks(true) on the decoder builder to opt in."
+                );
+                return Err(JwtAuthError::InvalidJwk);
+            }
             DecodingKey::from_base64_secret(&params.value).ok()
         }
         jsonwebtoken::jwk::AlgorithmParameters::OctetKeyPair(ref params) => {
@@ -559,8 +588,37 @@ mod tests {
         });
         let jwk: Jwk = serde_json::from_value(jwk_json).unwrap();
         let validation = Validation::new(Algorithm::RS256);
-        let result = decode_jwk(&jwk, &validation);
+        let result = decode_jwk(&jwk, &validation, false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_jwk_rejects_symmetric_by_default() {
+        // valid base64url of "secret"
+        let jwk_json = json!({
+            "kty": "oct",
+            "kid": "test-oct",
+            "alg": "HS256",
+            "k": "c2VjcmV0"
+        });
+        let jwk: Jwk = serde_json::from_value(jwk_json).unwrap();
+        let validation = Validation::new(Algorithm::HS256);
+        let result = decode_jwk(&jwk, &validation, false);
+        assert!(matches!(result, Err(JwtAuthError::InvalidJwk)));
+    }
+
+    #[test]
+    fn test_decode_jwk_accepts_symmetric_when_opted_in() {
+        let jwk_json = json!({
+            "kty": "oct",
+            "kid": "test-oct",
+            "alg": "HS256",
+            "k": "c2VjcmV0"
+        });
+        let jwk: Jwk = serde_json::from_value(jwk_json).unwrap();
+        let validation = Validation::new(Algorithm::HS256);
+        let result = decode_jwk(&jwk, &validation, true);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/jwt-auth/src/oidc/cache.rs
+++ b/crates/jwt-auth/src/oidc/cache.rs
@@ -158,6 +158,7 @@ pub struct JwkSetStore {
     /// The cache policy for this store
     pub cache_policy: CachePolicy,
     validation: Validation,
+    allow_symmetric_jwks: bool,
 }
 
 impl JwkSetStore {
@@ -168,16 +169,32 @@ impl JwkSetStore {
             decoding_map: HashMap::new(),
             cache_policy,
             validation,
+            allow_symmetric_jwks: false,
         }
+    }
+
+    /// Allow symmetric (`kty: "oct"` / HS*) JWKs from this JWKS endpoint.
+    ///
+    /// **Disabled by default.** OIDC JWKS endpoints normally publish only
+    /// asymmetric public keys (RSA / EC / OKP); accepting symmetric keys
+    /// widens the trust surface because a leaked or substituted secret
+    /// would let an attacker mint tokens the decoder accepts. Enable this
+    /// only when the issuer is known to publish HS* keys and is trusted to
+    /// keep them secret.
+    #[must_use]
+    pub fn with_allow_symmetric_jwks(mut self, allow: bool) -> Self {
+        self.allow_symmetric_jwks = allow;
+        self
     }
 
     fn update_jwks(&mut self, new_jwks: JwkSet) {
         self.jwks = new_jwks;
+        let allow_symmetric = self.allow_symmetric_jwks;
         let keys = self
             .jwks
             .keys
             .iter()
-            .filter_map(|i| decode_jwk(i, &self.validation).ok());
+            .filter_map(|i| decode_jwk(i, &self.validation, allow_symmetric).ok());
         // Clear our cache of decoding keys
         self.decoding_map.clear();
         // Load the keys back into our hashmap cache.


### PR DESCRIPTION
## Summary

`decode_jwk` previously loaded `kty: \"oct\"` keys from the JWKS endpoint via `DecodingKey::from_base64_secret`. OIDC JWKS endpoints are public-key distribution endpoints; an `oct` entry there means the decoder is willing to verify HS* tokens signed with whatever secret the JWKS ships. A misconfigured `issuer` / discovery URL or a substituted JWKS file would let an attacker mint tokens the decoder accepts, because they hold the same secret the JWKS itself reveals.

This change defaults `allow_symmetric_jwks` to `false` and adds an opt-in builder method for users who knowingly deploy HS* on a private JWKS:

- `DecoderBuilder::allow_symmetric_jwks(true)`
- `JwkSetStore::with_allow_symmetric_jwks(true)` (lower-level entry point)

When the option is off, `oct` entries are skipped with `tracing::warn!`, matching how malformed keys already behave. RSA / EC / OKP paths are unchanged.

## Test plan

- [x] `cargo test -p salvo-jwt-auth --features oidc --lib` — 60 passed
- [x] New `test_decode_jwk_rejects_symmetric_by_default` (returns `InvalidJwk`)
- [x] New `test_decode_jwk_accepts_symmetric_when_opted_in` (round-trips successfully)
- [x] Existing `test_decode_jwk_missing_alg` updated to the new signature

## References

- See `_improve.md` / `_codex_improve.md` (A4) for the audit context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)