### PR TITLE
feat(tus): warn when absolute Location is enabled without a canonical origin

### DIFF
--- a/crates/tus/Cargo.toml
+++ b/crates/tus/Cargo.toml
@@ -36,3 +36,4 @@ tracing       = { workspace = true }
 salvo_core    = { workspace = true, features = ["test"] }
 tempfile      = { workspace = true }
 tokio         = { workspace = true, features = ["rt", "macros", "time"] }
+tracing-test  = { workspace = true }

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -302,6 +302,14 @@ impl Tus {
 
     pub fn into_router(self) -> Router {
         let base_path = normalize_path(&self.options.path);
+        if !self.options.relative_location && self.options.canonical_origin.is_none() {
+            tracing::warn!(
+                "Tus is configured with relative_location(false) but no canonical_origin; \
+                 absolute Location headers will be derived from the inbound Host / Forwarded \
+                 headers, which a misbehaving client or unauthenticated proxy can spoof. \
+                 Set Tus::canonical_origin(\"https://your.host\") to pin the origin."
+            );
+        }
         let state = Arc::new(self);
 
         Router::with_path(base_path)
@@ -405,6 +413,32 @@ mod tests {
         assert_eq!(CancellationReason::Abort, CancellationReason::Abort);
         assert_eq!(CancellationReason::Cancel, CancellationReason::Cancel);
         assert_ne!(CancellationReason::Abort, CancellationReason::Cancel);
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_into_router_warns_on_absolute_location_without_canonical_origin() {
+        let _ = Tus::new().relative_location(false).into_router();
+        assert!(logs_contain(
+            "no canonical_origin; absolute Location headers will be derived from"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_into_router_does_not_warn_when_relative_location_is_true() {
+        let _ = Tus::new().relative_location(true).into_router();
+        assert!(!logs_contain("canonical_origin"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_into_router_does_not_warn_when_canonical_origin_is_set() {
+        let _ = Tus::new()
+            .relative_location(false)
+            .canonical_origin("https://uploads.example.com")
+            .into_router();
+        assert!(!logs_contain("no canonical_origin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TusOptions::relative_location = false` together with `canonical_origin = None` falls back to building the `Location` header from the inbound `Host` header (and, when `respect_forwarded_headers` is on, `Forwarded` / `X-Forwarded-Host` / `X-Forwarded-Proto`). For deployments without a trusted reverse proxy in front, a misbehaving client can spoof those headers and steer the `Location` response toward arbitrary hostnames.

This change emits a single `tracing::warn!` at router-construction time (`Tus::into_router`) when the combination is detected, pointing operators at `Tus::canonical_origin(...)`. Existing behaviour is unchanged — no `Location` strings move.

The default `Tus::new()` keeps `relative_location = true`, so out-of-the-box users see no new warning.

## Test plan

- [x] `cargo test -p salvo-tus --lib` — 230 passed
- [x] New `test_into_router_warns_on_absolute_location_without_canonical_origin` asserts the warn fires
- [x] New negative tests verify the warn does **not** fire when `relative_location = true` (default), or when `canonical_origin` is set

## References

- See `_improve.md` (A8) and `_codex_improve.md` for the audit context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)