### PR TITLE
[codex] expand README and rustdoc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ## Quick Start
 
 Create a new project:
+
 ```bash
 cargo new hello-salvo
 cd hello-salvo
@@ -72,6 +73,7 @@ async fn main() {
 ```
 
 Run it:
+
 ```bash
 cargo run
 ```
@@ -101,6 +103,42 @@ Router::new()
     .push(Router::with_path("articles").get(list_articles))
     // Protected routes
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
+```
+
+### JSON APIs
+
+Salvo handlers can deserialize request bodies and return typed JSON responses:
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+For this pattern, add Serde's derive feature:
+
+```bash
+cargo add serde --features derive
 ```
 
 ### OpenAPI in One Line
@@ -138,6 +176,7 @@ salvo new my_project
 - [Official Website](https://salvo.rs)
 - [API Documentation](https://docs.rs/salvo)
 - [Examples](./examples/)
+- [Feature-specific crates](./crates/)
 
 ## Recommended Projects
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -106,6 +106,42 @@ Router::new()
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
 ```
 
+### JSON API
+
+Handler 可以反序列化請求體，並返回型別化的 JSON 回應：
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+這種寫法需要啟用 Serde 的 derive 功能：
+
+```bash
+cargo add serde --features derive
+```
+
 ### 一行程式碼支援 OpenAPI
 
 只需將 `#[handler]` 改為 `#[endpoint]`：
@@ -141,6 +177,7 @@ salvo new my_project
 - [官方網站](https://salvo.rs)
 - [API 文件](https://docs.rs/salvo)
 - [範例程式碼](./examples/)
+- [按功能拆分的 crate](./crates/)
 
 ## 推薦專案
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,6 +108,42 @@ Router::new()
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
 ```
 
+### JSON API
+
+Handler 可以反序列化请求体，并返回类型化的 JSON 响应：
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+这种写法需要启用 Serde 的 derive 功能：
+
+```bash
+cargo add serde --features derive
+```
+
 ### 一行代码支持 OpenAPI
 
 只需将 `#[handler]` 改为 `#[endpoint]`：
@@ -143,6 +179,7 @@ salvo new my_project
 - [官方网站](https://salvo.rs)
 - [API 文档](https://docs.rs/salvo)
 - [示例代码](./examples/)
+- [按功能拆分的 crate](./crates/)
 
 ## 推荐项目
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -115,11 +115,11 @@ cfg_feature! {
     pub use moka_store::{MokaStore};
 }
 
-/// Issuer
+/// Issues a cache key for a request, deciding whether the request should be cached.
 pub trait CacheIssuer: Send + Sync + 'static {
-    /// The key is used to identify the rate limit.
+    /// The key type used to identify a cached entry.
     type Key: Hash + Eq + Send + Sync + 'static;
-    /// Issue a new key for the request. If it returns `None`, the request will not be cached.
+    /// Issue a key for the request. If it returns `None`, the request will not be cached.
     fn issue(
         &self,
         req: &mut Request,

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -190,9 +190,10 @@ pub struct Compression {
     pub algos: IndexMap<CompressionAlgo, CompressionLevel>,
     /// Content types to compress.
     pub content_types: Vec<Mime>,
-    /// Sets minimum compression size, if body is less than this value, no compression.
+    /// Minimum body size to compress; bodies smaller than this value are not compressed.
     pub min_length: usize,
-    /// Ignore request algorithms order in `Accept-Encoding` header and always server's config.
+    /// Ignore the client's algorithm order in `Accept-Encoding` and always use the server's
+    /// configured priority.
     pub force_priority: bool,
 }
 

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -204,9 +204,8 @@ impl Catcher {
         self
     }
 
-    /// Add a handler as middleware, it will run the handler when error caught.
-    ///
-    /// This middleware is only effective when the filter returns true..
+    /// Add a handler as middleware. It runs the handler when an error is caught,
+    /// but only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn hoop_when<H, F>(mut self, hoop: H, filter: F) -> Self

--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -2,10 +2,10 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 
-/// Store temp data for current request.
+/// Store temporary data for the current request.
 ///
-/// A `Depot` created when server process a request from client. It will dropped when all process
-/// for this request done.
+/// A `Depot` is created when the server processes a request from a client, and dropped
+/// when all processing for the request is finished.
 ///
 /// # Example
 /// We set `current_user` value in function `set_user` , and then use this value in the following
@@ -89,17 +89,17 @@ impl Depot {
         self
     }
 
-    /// Obtain a reference to a value previous inject to the depot.
+    /// Obtain a reference to a value previously injected into the depot.
     ///
-    /// Returns `Err(None)` if value is not present in depot.
-    /// Returns `Err(Some(Box<dyn Any + Send + Sync>))` if value is present in depot but downcasting
+    /// Returns `Err(None)` if the value is not present in the depot.
+    /// Returns `Err(Some(Box<dyn Any + Send + Sync>))` if the value is present but downcasting
     /// failed.
     #[inline]
     pub fn obtain<T: Any + Send + Sync>(&self) -> Result<&T, Option<&Box<dyn Any + Send + Sync>>> {
         self.get(&type_key::<T>())
     }
 
-    /// Obtain a mutable reference to a value previous inject to the depot.
+    /// Obtain a mutable reference to a value previously injected into the depot.
     ///
     /// Returns `Err(None)` if value is not present in depot.
     /// Returns `Err(Some(Box<dyn Any + Send + Sync>))` if value is present in depot but downcasting
@@ -122,15 +122,15 @@ impl Depot {
         self
     }
 
-    /// Check is there a value stored in depot with this key.
+    /// Check whether a value is stored in the depot under the given key.
     #[inline]
     #[must_use]
     pub fn contains_key(&self, key: &str) -> bool {
         self.map.contains_key(key)
     }
-    /// Check is there a value is injected to the depot.
+    /// Check whether a value of this type has been injected into the depot.
     ///
-    /// **Note**: This is only check injected value.
+    /// **Note**: Only checks values inserted via [`Depot::inject`].
     #[inline]
     #[must_use]
     pub fn contains<T: Any + Send + Sync>(&self) -> bool {
@@ -176,8 +176,7 @@ impl Depot {
         }
     }
 
-    /// Remove value from depot and returning the value at the key if the key was previously in the
-    /// depot.
+    /// Remove the value at the given key from the depot and return it, if present.
     #[inline]
     pub fn remove<V: Any + Send + Sync>(
         &mut self,
@@ -196,7 +195,7 @@ impl Depot {
         self.map.remove(key).is_some()
     }
 
-    /// Remove value from depot and returning the value if the type was previously in the depot.
+    /// Remove the injected value of the given type from the depot and return it, if present.
     #[inline]
     pub fn scrape<T: Any + Send + Sync>(
         &mut self,

--- a/crates/core/src/extract.rs
+++ b/crates/core/src/extract.rs
@@ -1,7 +1,8 @@
-//! Extract is a feature to let you deserialize request to custom type.
+//! Request extraction for deserializing request data into application types.
 //!
-//! You can easily get data from multiple different data sources and assemble it into the type you
-//! want. You can define a custom type first, then in `Handler` you can get the data like this:
+//! Extraction can collect values from multiple request sources, such as path
+//! parameters, query strings, headers, cookies, form bodies, and JSON bodies.
+//! Define an [`Extractible`] type, then ask the request to build it in a handler:
 //!
 //! ```
 //! # use salvo_core::prelude::*;
@@ -22,11 +23,12 @@
 //! #[handler]
 //! async fn edit(req: &mut Request, depot: &mut Depot) {
 //!     let good_man: GoodMan<'_> = req.extract(depot).await.unwrap();
+//!     let _ = good_man;
 //! }
 //! ```
 //!
-//! There is considerable flexibility in the definition of data types, and can even be resolved into
-//! nested structures as needed:
+//! Extracted types can be nested. Use `#[salvo(extract(flatten))]` or
+//! `#[serde(flatten)]` when a nested type should be parsed from the same request:
 //!
 //! ```
 //! # use salvo_core::prelude::*;
@@ -41,7 +43,7 @@
 //!     first_name: String,
 //!     last_name: String,
 //!     lovers: Vec<String>,
-//!     /// The nested field is completely reparsed from Request.
+//!     /// The nested field is parsed from the same request.
 //!     #[serde(flatten)]
 //!     nested: Nested<'a>,
 //! }
@@ -61,7 +63,9 @@
 //! }
 //! ```
 //!
-//! View [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs)
+//! View the [full nested extraction example] in the repository.
+//!
+//! [full nested extraction example]: https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs
 
 /// Metadata types.
 pub mod metadata;
@@ -74,15 +78,19 @@ pub use case::RenameRule;
 use crate::http::{ParseError, Request};
 use crate::{Depot, Writer};
 
-/// If a type implements this trait, it will give a metadata, this will help request to extracts
-/// data to this type.
+/// Describes how to extract a type from a request.
+///
+/// Implementations provide metadata used by Salvo's extraction machinery and
+/// OpenAPI integration, then perform the actual extraction from [`Request`] and
+/// [`Depot`].
 pub trait Extractible<'ex> {
-    /// Metadata for Extractible type.
+    /// Metadata for this extractible type.
     fn metadata() -> &'static Metadata;
 
-    /// Extract data from request.
+    /// Extracts data from a request.
     ///
-    /// **NOTE:** Set status code to 400 if extract failed and status code is not error.
+    /// **Note:** if extraction fails and the response does not already contain
+    /// an error status, Salvo renders the failure as `400 Bad Request`.
     fn extract(
         req: &'ex mut Request,
         depot: &'ex mut Depot,

--- a/crates/core/src/extract.rs
+++ b/crates/core/src/extract.rs
@@ -90,7 +90,7 @@ pub trait Extractible<'ex> {
     where
         Self: Sized;
 
-    /// Extract data from request with a argument. This function used in macros internal.
+    /// Extract data from a request with an argument. This function is used internally by macros.
     fn extract_with_arg(
         req: &'ex mut Request,
         depot: &'ex mut Depot,

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -199,7 +199,7 @@ pub trait Handler: Send + Sync + 'static {
 
     /// Hoop this handler with middleware.
     ///
-    /// This middleware is only effective when the filter returns true..
+    /// This middleware is only effective when the filter returns `true`.
     #[inline]
     fn hoop_when<H, F>(self, hoop: H, filter: F) -> HoopedHandler
     where
@@ -352,19 +352,19 @@ impl HoopedHandler {
         }
     }
 
-    /// Get current catcher's middlewares reference.
+    /// Get a reference to the middlewares attached to this handler.
     #[inline]
     #[must_use]
     pub fn hoops(&self) -> &Vec<Arc<dyn Handler>> {
         &self.hoops
     }
-    /// Get current catcher's middlewares mutable reference.
+    /// Get a mutable reference to the middlewares attached to this handler.
     #[inline]
     pub fn hoops_mut(&mut self) -> &mut Vec<Arc<dyn Handler>> {
         &mut self.hoops
     }
 
-    /// Add a handler as middleware, it will run the handler when error caught.
+    /// Add a handler as middleware. It will run before this handler.
     #[inline]
     #[must_use]
     pub fn hoop<H: Handler>(mut self, hoop: H) -> Self {
@@ -372,9 +372,8 @@ impl HoopedHandler {
         self
     }
 
-    /// Add a handler as middleware, it will run the handler when error caught.
-    ///
-    /// This middleware is only effective when the filter returns true..
+    /// Add a handler as middleware. It runs the handler when an error is caught,
+    /// but only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn hoop_when<H, F>(mut self, hoop: H, filter: F) -> Self

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -1,18 +1,18 @@
-//! Handler module for handle [`Request`].
+//! Handler abstractions for processing [`Request`] values.
 //!
-//! Middleware is actually also a `Handler`. They can do some processing before or after the request
-//! reaches the `Handler` that officially handles the request, such as: login verification, data
-//! compression, etc.
+//! A middleware is also a [`Handler`]. Middleware can inspect or modify the request,
+//! share state through [`Depot`], write to [`Response`], or stop the remaining handler
+//! chain with [`FlowCtrl::skip_rest`].
 //!
-//! Middleware is added through the `hoop` function of `Router`. The added middleware will affect
-//! the current `Router` and all its internal descendants `Router`.
+//! Middleware is added with [`Router::hoop`](crate::routing::Router::hoop).
+//! Middleware attached to a router applies to that router and all of its descendants.
 //!
 //! ## Macro `#[handler]`
 //!
-//! `#[handler]` can greatly simplify the writing of the code, and improve the flexibility of the
-//! code.
+//! `#[handler]` keeps handlers concise while still allowing Salvo to inject any
+//! request context the function asks for.
 //!
-//! It can be added to a function to make it implement `Handler`:
+//! Add it to a function to make that function implement [`Handler`]:
 //!
 //! ```
 //! use salvo_core::prelude::*;
@@ -21,7 +21,7 @@
 //! async fn hello() -> &'static str {
 //!     "hello world!"
 //! }
-//! ````
+//! ```
 //!
 //! This is equivalent to:
 //!
@@ -43,19 +43,17 @@
 //!         res.render(Text::Plain("hello world!"));
 //!     }
 //! }
-//! ````
+//! ```
 //!
-//! As you can see, in the case of using `#[handler]`, the code becomes much simpler:
+//! With `#[handler]`, the code becomes much simpler:
+//!
 //! - No need to manually add `#[async_trait]`.
-//! - The parameters that are not needed in the function have been omitted, and the required
-//!   parameters can be arranged in any order.
-//! - For objects that implement `Writer` or `Scribe` abstraction, it can be directly used as the
-//!   return value of the function. Here `&'static str` implements `Scribe`, so it can be returned
-//!   directly as the return value of the function.
+//! - Unused context parameters can be omitted.
+//! - Required parameters can be listed in any supported order.
+//! - Return values that implement [`Writer`] or [`Scribe`] can be returned directly.
 //!
-//! `#[handler]` can not only be added to the function, but also can be added to the `impl` of
-//! `struct` to let `struct` implement `Handler`. At this time, the `handle` function in the `impl`
-//! code block will be Identified as the specific implementation of `handle` in `Handler`:
+//! `#[handler]` can also be added to an `impl` block. In that form, the `handle`
+//! method becomes the [`Handler::handle`] implementation for the struct:
 //!
 //! ```
 //! use salvo_core::prelude::*;
@@ -68,18 +66,17 @@
 //!         res.render(Text::Plain("hello world!"));
 //!     }
 //! }
-//! ````
+//! ```
 //!
 //! ## Handle errors
 //!
-//! `Handler` in Salvo can return `Result`, only the types of `Ok` and `Err` in `Result` are
-//! implemented `Writer` trait.
+//! A Salvo handler can return `Result<T, E>` when both `T` and `E` can be written
+//! to the response.
 //!
-//! Taking into account the widespread use of `anyhow`, the `Writer` implementation of
-//! `anyhow::Error` is provided by default if `anyhow` feature is enabled, and `anyhow::Error` is
-//! Mapped to `InternalServerError`.
+//! When the `anyhow` feature is enabled, `anyhow::Error` can be returned from a
+//! handler and is rendered as `500 Internal Server Error`.
 //!
-//! For custom error types, you can output different error pages according to your needs.
+//! Custom error types can implement [`Writer`] to control the generated response:
 //!
 //! ```ignore
 //! use anyhow::anyhow;
@@ -115,14 +112,15 @@
 //!
 //! ## Implement Handler trait directly
 //!
-//! Under certain circumstances, We need to implement `Handler` directly.
+//! Implement [`Handler`] directly when a type needs to own configuration or when
+//! the handler logic cannot be expressed cleanly as a function.
 //!
 //! ```
+//! use salvo_core::hyper::body::Body;
 //! use salvo_core::prelude::*;
 //!
-//! use crate::salvo_core::http::Body;
-//!
 //! pub struct MaxSizeHandler(u64);
+//!
 //! #[async_trait]
 //! impl Handler for MaxSizeHandler {
 //!     async fn handle(
@@ -147,7 +145,7 @@ use std::sync::Arc;
 use crate::http::StatusCode;
 use crate::{Depot, FlowCtrl, Request, Response, async_trait};
 
-/// `Handler` is used for handle [`Request`].
+/// Processes a request and writes to a response.
 ///
 /// View [module level documentation](index.html) for more details.
 #[async_trait]
@@ -160,7 +158,7 @@ pub trait Handler: Send + Sync + 'static {
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }
-    /// Handle http request.
+    /// Handles one HTTP request.
     #[must_use = "handle future must be used"]
     async fn handle(
         &self,

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -22,7 +22,7 @@ use crate::{BoxedError, Error, Scribe};
 /// Represents an HTTP response.
 #[non_exhaustive]
 pub struct Response {
-    /// The HTTP status code.WebTransportSession
+    /// The HTTP status code.
     pub status_code: Option<StatusCode>,
     /// The HTTP headers.
     pub headers: HeaderMap,

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -40,7 +40,7 @@ impl Debug for MethodFilter {
 pub struct SchemeFilter {
     /// Scheme to filter.
     pub scheme: Scheme,
-    /// When scheme is lack in request uri, use this value.
+    /// Fallback value returned by the filter when the request URI has no scheme.
     pub lack: bool,
 }
 impl SchemeFilter {
@@ -52,7 +52,7 @@ impl SchemeFilter {
             lack: false,
         }
     }
-    /// Set lack value and return `Self`.
+    /// Set the fallback value used when the request URI lacks this component, and return `Self`.
     #[must_use]
     pub fn lack(mut self, lack: bool) -> Self {
         self.lack = lack;
@@ -86,7 +86,7 @@ impl Debug for SchemeFilter {
 pub struct HostFilter {
     /// Host to filter.
     pub host: String,
-    /// When host is lack in request uri, use this value.
+    /// Fallback value returned by the filter when the request URI has no host.
     pub lack: bool,
 }
 impl HostFilter {
@@ -97,7 +97,7 @@ impl HostFilter {
             lack: false,
         }
     }
-    /// Set lack value and return `Self`.
+    /// Set the fallback value used when the request URI lacks this component, and return `Self`.
     #[must_use]
     pub fn lack(mut self, lack: bool) -> Self {
         self.lack = lack;
@@ -109,8 +109,8 @@ impl HostFilter {
 impl Filter for HostFilter {
     #[inline]
     async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
-        // Http1, if `fix-http1-request-uri` feature is disabled, host is lack. so use header host
-        // instead. https://github.com/hyperium/hyper/issues/1310
+        // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
+        // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
         let host = req.uri().authority().map(|a| a.as_str());
         #[cfg(not(feature = "fix-http1-request-uri"))]
@@ -122,7 +122,7 @@ impl Filter for HostFilter {
         host.map(|h| {
             if h.contains(':') {
                 h.rsplit_once(':')
-                    .expect("rsplit_once by ':' should not returns `None`")
+                    .expect("rsplit_once by ':' should not return `None`")
                     .0
             } else {
                 h
@@ -143,13 +143,13 @@ impl Debug for HostFilter {
     }
 }
 
-/// Filter by request uri host.
+/// Filter by request URI port.
 #[derive(Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct PortFilter {
     /// Port to filter.
     pub port: u16,
-    /// When port is lack in request uri, use this value.
+    /// Fallback value returned by the filter when the request URI has no port.
     pub lack: bool,
 }
 
@@ -159,7 +159,7 @@ impl PortFilter {
     pub fn new(port: u16) -> Self {
         Self { port, lack: false }
     }
-    /// Set lack value and return `Self`.
+    /// Set the fallback value used when the request URI lacks this component, and return `Self`.
     #[must_use]
     pub fn lack(mut self, lack: bool) -> Self {
         self.lack = lack;
@@ -171,8 +171,8 @@ impl PortFilter {
 impl Filter for PortFilter {
     #[inline]
     async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
-        // Http1, if `fix-http1-request-uri` feature is disabled, port is lack. so use header host
-        // instead. https://github.com/hyperium/hyper/issues/1310
+        // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
+        // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
         let host = req.uri().authority().map(|a| a.as_str());
         #[cfg(not(feature = "fix-http1-request-uri"))]
@@ -184,7 +184,7 @@ impl Filter for PortFilter {
         host.map(|h| {
             if h.contains(':') {
                 h.rsplit_once(':')
-                    .expect("rsplit_once by ':' should not returns `None`")
+                    .expect("rsplit_once by ':' should not return `None`")
                     .1
             } else {
                 h

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -57,8 +57,8 @@ impl FlowCtrl {
     /// Call next handler. If get next handler and executed, returns `true``, otherwise returns
     /// `false`.
     ///
-    /// **NOTE**: If response status code is error or is redirection, all reset handlers will be
-    /// skipped.
+    /// **NOTE**: If the response status code is an error or a redirection, all remaining
+    /// handlers will be skipped.
     #[inline]
     pub async fn call_next(
         &mut self,
@@ -91,16 +91,17 @@ impl FlowCtrl {
         }
     }
 
-    /// Skip all reset handlers.
+    /// Skip all remaining handlers.
     #[inline]
     pub fn skip_rest(&mut self) {
         self.cursor = self.handlers.len()
     }
 
-    /// Check is `FlowCtrl` ceased.
+    /// Check whether the `FlowCtrl` has been ceased.
     ///
-    /// **NOTE**: If handler is used as middleware, it should use `is_ceased` to check is flow
-    /// ceased. If `is_ceased` returns `true`, the handler should skip the following logic.
+    /// **NOTE**: When a handler is used as middleware, it should call `is_ceased` to check
+    /// whether the flow has been ceased. If `is_ceased` returns `true`, the handler should
+    /// skip the following logic.
     #[inline]
     #[must_use]
     pub fn is_ceased(&self) -> bool {

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -4,17 +4,40 @@ use std::sync::Arc;
 use crate::http::{Request, Response};
 use crate::{Depot, Handler};
 
-/// Control the flow of execute handlers.
+/// Controls execution of a matched handler chain.
 ///
-/// When a request is coming, [`Router`] will detect it and get the matched router.
-/// And then salvo will collect all handlers (including added as middlewares) from the matched
-/// router tree. All handlers in this list will executed one by one.
+/// When a request arrives, [`Router`] matches it against the routing tree. Salvo
+/// then collects the matched goal handler and all middleware handlers from the
+/// matched route branch. Handlers in that list are executed in order.
 ///
-/// Each handler can use `FlowCtrl` to control execute flow, let the flow call next handler or skip
-/// all rest handlers.
+/// Most middleware only needs to read or write request state and then return.
+/// Use [`FlowCtrl::call_next`] for around-style middleware that needs to run
+/// logic after later handlers have finished, or [`FlowCtrl::skip_rest`] to stop
+/// the remaining handlers.
 ///
-/// **NOTE**: When `Response`'s status code is set, and the status code [`Response::is_stamped()`]
-/// is returns false, all remaining handlers will be skipped.
+/// **Note:** when the response becomes stamped, remaining handlers are skipped.
+/// See [`Response::is_stamped`] for the exact status-code behavior.
+///
+/// # Example
+///
+/// ```
+/// use salvo_core::http::header::{HeaderValue, SERVER};
+/// use salvo_core::prelude::*;
+///
+/// #[handler]
+/// async fn add_server_header(
+///     req: &mut Request,
+///     depot: &mut Depot,
+///     res: &mut Response,
+///     ctrl: &mut FlowCtrl,
+/// ) {
+///     ctrl.call_next(req, depot, res).await;
+///     if !ctrl.is_ceased() {
+///         res.headers_mut()
+///             .insert(SERVER, HeaderValue::from_static("salvo"));
+///     }
+/// }
+/// ```
 ///
 /// [`Router`]: crate::routing::Router
 #[derive(Default)]
@@ -47,15 +70,16 @@ impl FlowCtrl {
             handlers,
         }
     }
-    /// Has next handler.
+    /// Returns whether there is another handler in the chain.
     #[inline]
     #[must_use]
     pub fn has_next(&self) -> bool {
         self.cursor < self.handlers.len() // && !self.handlers.is_empty()
     }
 
-    /// Call next handler. If get next handler and executed, returns `true``, otherwise returns
-    /// `false`.
+    /// Calls the next handler.
+    ///
+    /// Returns `true` if a handler was found and executed, otherwise returns `false`.
     ///
     /// **NOTE**: If the response status code is an error or a redirection, all remaining
     /// handlers will be skipped.
@@ -97,21 +121,20 @@ impl FlowCtrl {
         self.cursor = self.handlers.len()
     }
 
-    /// Check whether the `FlowCtrl` has been ceased.
+    /// Checks whether the handler chain has been ceased.
     ///
-    /// **NOTE**: When a handler is used as middleware, it should call `is_ceased` to check
-    /// whether the flow has been ceased. If `is_ceased` returns `true`, the handler should
-    /// skip the following logic.
+    /// **Note:** around-style middleware should check this after
+    /// [`FlowCtrl::call_next`] and skip post-processing when it returns `true`.
     #[inline]
     #[must_use]
     pub fn is_ceased(&self) -> bool {
         self.is_ceased
     }
-    /// Cease all following logic.
+    /// Ceases the remaining handler chain.
     ///
-    /// **NOTE**: This function will mark is_ceased as `true`, but whether the subsequent logic can
-    /// be skipped depends on whether the middleware correctly checks is_ceased and skips the
-    /// subsequent logic.
+    /// This marks the flow as ceased and skips all remaining handlers. Middleware
+    /// that has already called [`FlowCtrl::call_next`] should still check
+    /// [`FlowCtrl::is_ceased`] before running any post-processing.
     #[inline]
     pub fn cease(&mut self) {
         self.skip_rest();

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -167,16 +167,16 @@ impl Router {
         self
     }
 
-    /// Add a handler as middleware, it will run the handler in current router or its descendants.
-    /// handle the request.
+    /// Add a handler as middleware. It runs the handler in the current router or its
+    /// descendants when handling the request.
     #[inline]
     #[must_use]
     pub fn with_hoop<H: Handler>(hoop: H) -> Self {
         Self::new().hoop(hoop)
     }
 
-    /// Add a handler as middleware, it will run the handler in current router or its descendants.
-    /// handle the request. This middleware is only effective when the filter returns true..
+    /// Add a handler as middleware. It runs the handler in the current router or its
+    /// descendants when handling the request, but only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn with_hoop_when<H, F>(hoop: H, filter: F) -> Self
@@ -187,8 +187,8 @@ impl Router {
         Self::new().hoop_when(hoop, filter)
     }
 
-    /// Add a handler as middleware, it will run the handler in current router or its descendants.
-    /// handle the request.
+    /// Add a handler as middleware. It runs the handler in the current router or its
+    /// descendants when handling the request.
     #[inline]
     #[must_use]
     pub fn hoop<H: Handler>(mut self, hoop: H) -> Self {
@@ -196,8 +196,8 @@ impl Router {
         self
     }
 
-    /// Add a handler as middleware, it will run the handler in current router or its descendants.
-    /// handle the request. This middleware is only effective when the filter returns true..
+    /// Add a handler as middleware. It runs the handler in the current router or its
+    /// descendants when handling the request, but only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn hoop_when<H, F>(mut self, hoop: H, filter: F) -> Self

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -106,9 +106,8 @@ impl Service {
         self
     }
 
-    /// Add a handler as middleware, it will run the handler when request received.
-    ///
-    /// This middleware is only effective when the filter returns true..
+    /// Add a handler as middleware. It runs the handler when a request is received,
+    /// but only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn hoop_when<H, F>(mut self, hoop: H, filter: F) -> Self

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -7,11 +7,12 @@ use super::{Scribe, try_set_header};
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
 use crate::http::{Response, StatusError};
 
-/// Write serializable content to response as json content.
+/// Writes serializable content to the response as JSON.
 ///
-/// It will set `content-type` to `application/json; charset=utf-8`.
+/// `Json<T>` sets `content-type` to `application/json; charset=utf-8` and
+/// serializes the wrapped value with `serde_json`.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use salvo_core::prelude::*;
@@ -26,6 +27,30 @@ use crate::http::{Response, StatusError};
 ///     Json(User {
 ///         name: "jobs".into(),
 ///     })
+/// }
+/// ```
+///
+/// It is commonly returned together with request parsing:
+///
+/// ```
+/// use salvo_core::http::ParseError;
+/// use salvo_core::prelude::*;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Deserialize)]
+/// struct CreateUser {
+///     name: String,
+/// }
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     name: String,
+/// }
+///
+/// #[handler]
+/// async fn create_user(req: &mut Request) -> Result<Json<User>, ParseError> {
+///     let input = req.parse_json::<CreateUser>().await?;
+///     Ok(Json(User { name: input.name }))
 /// }
 /// ```
 pub struct Json<T>(pub T);

--- a/crates/core/src/writing/text.rs
+++ b/crates/core/src/writing/text.rs
@@ -4,7 +4,7 @@ use super::{Scribe, try_set_header};
 use crate::http::Response;
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
 
-/// Write text content to response as text content.
+/// Render text content as the response body.
 ///
 /// # Example
 ///

--- a/crates/cors/README.md
+++ b/crates/cors/README.md
@@ -45,6 +45,42 @@ This is an official crate, so you can enable it in `Cargo.toml` like this:
 salvo = { version = "*", features = ["cors"] }
 ```
 
+## Quick Start
+
+Add the CORS handler to `Service`, not to `Router`. Browsers send preflight
+`OPTIONS` requests before the real request, and those preflight requests may not
+match any router branch.
+
+```rust
+use salvo::cors::Cors;
+use salvo::http::Method;
+use salvo::prelude::*;
+
+#[handler]
+async fn hello() -> &'static str {
+    "Hello World"
+}
+
+#[tokio::main]
+async fn main() {
+    let cors = Cors::new()
+        .allow_origin("https://example.com")
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers("content-type")
+        .into_handler();
+
+    let router = Router::new().get(hello);
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+
+    Server::new(acceptor)
+        .serve(Service::new(router).hoop(cors))
+        .await;
+}
+```
+
+For development-only APIs you can use `Cors::permissive()`. For authenticated
+production APIs, prefer explicit origins and avoid `Cors::very_permissive()`.
+
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-cors)

--- a/crates/craft-macros/src/craft.rs
+++ b/crates/craft-macros/src/craft.rs
@@ -26,7 +26,7 @@ pub(crate) fn generate(input: Item) -> syn::Result<TokenStream> {
         Item::Fn(_) => Ok(input.into_token_stream()),
         _ => Err(syn::Error::new_spanned(
             input,
-            "#[craft] must added to `impl`",
+            "#[craft] must be applied to an `impl` block",
         )),
     }
 }

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -187,18 +187,18 @@ fn default_skipper(req: &mut Request, _depot: &Depot) -> bool {
     )
 }
 
-/// Store proof.
+/// Storage backend for CSRF `(token, proof)` pairs.
 pub trait CsrfStore: Send + Sync + 'static {
-    /// Error type for CsrfStore.
+    /// Error type produced by store operations.
     type Error: StdError + Send + Sync + 'static;
-    /// Get the proof from the store.
+    /// Load the previously saved `(token, proof)` pair from the store, if any.
     fn load<C: CsrfCipher>(
         &self,
         req: &mut Request,
         depot: &mut Depot,
         cipher: &C,
     ) -> impl Future<Output = Option<(String, String)>> + Send;
-    /// Save the proof from the store.
+    /// Save the `(token, proof)` pair to the store.
     fn save(
         &self,
         req: &mut Request,
@@ -209,14 +209,14 @@ pub trait CsrfStore: Send + Sync + 'static {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-/// Generate token and proof and valid token.
+/// Generates and verifies CSRF token / proof pairs.
 pub trait CsrfCipher: Send + Sync + 'static {
-    /// Verify token is valid.
+    /// Verify whether the given token matches the proof.
     fn verify(&self, token: &str, proof: &str) -> bool;
-    /// Generate new token and proof.
+    /// Generate a new `(token, proof)` pair.
     fn generate(&self) -> (String, String);
 
-    /// Generate a random bytes.
+    /// Generate `len` random bytes.
     fn random_bytes(&self, len: usize) -> Vec<u8> {
         rand::rng().sample_iter(StandardUniform).take(len).collect()
     }

--- a/crates/extra/src/caching_headers.rs
+++ b/crates/extra/src/caching_headers.rs
@@ -38,7 +38,7 @@ pub struct ETag {
 }
 
 impl ETag {
-    /// constructs a new Etag handler
+    /// Constructs a new `ETag` handler.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/crates/extra/src/catch_panic.rs
+++ b/crates/extra/src/catch_panic.rs
@@ -1,7 +1,7 @@
-//! Middleware for catch panic in handlers.
+//! Middleware that catches panics in handlers.
 //!
-//! This middleware catches panics and write `500 Internal Server Error` into response.
-//! This middleware should be used as the first middleware.
+//! This middleware catches panics and writes a `500 Internal Server Error` response.
+//! It should be installed as the outermost middleware.
 //!
 //! # Example
 //!

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -53,7 +53,7 @@ use salvo_core::http::{Request, ResBody, Response};
 use salvo_core::writing::Redirect;
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 
-/// Middleware for force redirect to http uri.
+/// Middleware that redirects HTTP requests to their HTTPS equivalent.
 #[derive(Default)]
 pub struct ForceHttps {
     https_port: Option<u16>,

--- a/crates/extra/src/request_id.rs
+++ b/crates/extra/src/request_id.rs
@@ -32,13 +32,6 @@ pub const REQUEST_ID_KEY: &str = "::salvo::request_id";
 pub trait RequestIdDepotExt {
     /// Get a reference to the request id from the depot, if one has been set.
     fn request_id(&self) -> Option<&str>;
-
-    /// Deprecated alias for [`RequestIdDepotExt::request_id`]; the original name was
-    /// erroneously copied from the CSRF module.
-    #[deprecated(since = "0.93.0", note = "use `request_id` instead")]
-    fn csrf_token(&self) -> Option<&str> {
-        self.request_id()
-    }
 }
 
 impl RequestIdDepotExt for Depot {

--- a/crates/extra/src/request_id.rs
+++ b/crates/extra/src/request_id.rs
@@ -25,30 +25,37 @@ use ulid::Ulid;
 use salvo_core::http::{HeaderValue, Request, Response, header::HeaderName};
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 
-/// Key for incoming flash messages in depot.
+/// Key used to store the request id in the depot.
 pub const REQUEST_ID_KEY: &str = "::salvo::request_id";
 
-/// Extension for Depot.
+/// Extension trait that exposes the current request id stored on the [`Depot`].
 pub trait RequestIdDepotExt {
-    /// Get request id reference from depot.
-    fn csrf_token(&self) -> Option<&str>;
+    /// Get a reference to the request id from the depot, if one has been set.
+    fn request_id(&self) -> Option<&str>;
+
+    /// Deprecated alias for [`RequestIdDepotExt::request_id`]; the original name was
+    /// erroneously copied from the CSRF module.
+    #[deprecated(since = "0.93.0", note = "use `request_id` instead")]
+    fn csrf_token(&self) -> Option<&str> {
+        self.request_id()
+    }
 }
 
 impl RequestIdDepotExt for Depot {
     #[inline]
-    fn csrf_token(&self) -> Option<&str> {
+    fn request_id(&self) -> Option<&str> {
         self.get::<String>(REQUEST_ID_KEY).map(|v| &**v).ok()
     }
 }
 
-/// A middleware for generate request id.
+/// Middleware that assigns a request id to every incoming request.
 #[non_exhaustive]
 pub struct RequestId {
-    /// The header name for request id.
+    /// The header name used to carry the request id.
     pub header_name: HeaderName,
-    /// Whether overwrite exists request id. Default is `true`
+    /// Whether to overwrite an existing request id. Default is `true`.
     pub overwrite: bool,
-    /// The generator for request id.
+    /// The generator used to produce request ids.
     pub generator: Box<dyn IdGenerator + Send + Sync>,
 }
 
@@ -62,7 +69,7 @@ impl Debug for RequestId {
 }
 
 impl RequestId {
-    /// Create new `CatchPanic` middleware.
+    /// Create a new `RequestId` middleware.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -72,21 +79,21 @@ impl RequestId {
         }
     }
 
-    /// Set the header name for request id.
+    /// Set the header name used to carry the request id.
     #[must_use]
     pub fn header_name(mut self, name: HeaderName) -> Self {
         self.header_name = name;
         self
     }
 
-    /// Set whether overwrite exists request id. Default is `true`.
+    /// Set whether to overwrite an existing request id. Default is `true`.
     #[must_use]
     pub fn overwrite(mut self, overwrite: bool) -> Self {
         self.overwrite = overwrite;
         self
     }
 
-    /// Set the generator for request id.
+    /// Set the generator used to produce request ids.
     #[must_use]
     pub fn generator(mut self, generator: impl IdGenerator + Send + Sync + 'static) -> Self {
         self.generator = Box::new(generator);
@@ -116,7 +123,7 @@ impl Default for RequestId {
     }
 }
 
-/// A trait for generate request id.
+/// Trait for types that can generate a new request id.
 pub trait IdGenerator {
     /// Generate a new request id.
     fn generate(&self, req: &mut Request, depot: &mut Depot) -> String;
@@ -131,11 +138,11 @@ where
     }
 }
 
-/// A generator for generate request id with ulid.
+/// An [`IdGenerator`] that produces request ids using ULIDs.
 #[derive(Default, Debug)]
 pub struct UlidGenerator {}
 impl UlidGenerator {
-    /// Create new `UlidGenerator`.
+    /// Create a new `UlidGenerator`.
     #[must_use]
     pub fn new() -> Self {
         Self {}

--- a/crates/extra/src/trailing_slash.rs
+++ b/crates/extra/src/trailing_slash.rs
@@ -79,14 +79,14 @@ pub fn default_add_skipper(req: &mut Request, _depot: &Depot) -> bool {
     }
 }
 
-/// TrailingSlash
+/// Middleware that adds, removes, or redirects trailing slashes on request paths.
 #[non_exhaustive]
 pub struct TrailingSlash {
-    /// Action of this `TrailingSlash`.
+    /// Action to perform on the trailing slash.
     pub action: TrailingSlashAction,
-    /// Skip to Remove or add slash when skipper is returns `true`.
+    /// Skip adding or removing the trailing slash when this skipper returns `true`.
     pub skipper: Box<dyn Skipper>,
-    /// Redirect code is used when redirect url.
+    /// HTTP status code used when redirecting to the canonical URL.
     pub redirect_code: StatusCode,
 }
 

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -197,7 +197,7 @@ impl FlashMessage {
             value: message.into(),
         }
     }
-    /// create a new `FlashMessage` with `FlashLevel::Error`.
+    /// Create a new `FlashMessage` with `FlashLevel::Error`.
     #[inline]
     pub fn error(message: impl Into<String>) -> Self {
         Self {

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -57,6 +57,53 @@ This is an official crate, so you can enable it in `Cargo.toml`:
 salvo = { version = "*", features = ["jwt-auth"] }
 ```
 
+## Quick Start
+
+Use `HeaderFinder` for the standard `Authorization: Bearer <token>` header.
+`force_passed(true)` lets the request reach your handler so the handler can
+decide how to respond to authorized, unauthorized, and forbidden states.
+
+```rust
+use salvo::jwt_auth::{ConstDecoder, HeaderFinder, JwtAuthState};
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+const SECRET: &[u8] = b"replace-with-a-secret-from-your-config";
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Claims {
+    sub: String,
+    exp: i64,
+}
+
+#[handler]
+async fn me(depot: &mut Depot, res: &mut Response) {
+    match depot.jwt_auth_state() {
+        JwtAuthState::Authorized => {
+            let data = depot.jwt_auth_data::<Claims>().unwrap();
+            res.render(Json(&data.claims));
+        }
+        JwtAuthState::Unauthorized => res.render(StatusError::unauthorized()),
+        JwtAuthState::Forbidden => res.render(StatusError::forbidden()),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let auth = JwtAuth::<Claims, _>::new(ConstDecoder::from_secret(SECRET))
+        .finders(vec![Box::new(HeaderFinder::new())])
+        .force_passed(true);
+
+    let router = Router::new().hoop(auth).get(me);
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+    Server::new(acceptor).serve(router).await;
+}
+```
+
+Avoid query-string tokens in production because URLs are commonly saved in
+browser history, logs, and referrer headers. Prefer Authorization headers or
+secure, `HttpOnly` cookies.
+
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-jwt-auth)

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Security Considerations
 //!
-//! **⚠️ WARNING: Avoid passing JWT tokens in URL query parameters in production!**
+//! **Warning: avoid passing JWT tokens in URL query parameters in production.**
 //!
 //! While this crate supports extracting tokens from query parameters (via [`QueryFinder`]),
 //! this method has significant security risks:
@@ -28,15 +28,14 @@
 //! - Use [`HeaderFinder`] with the `Authorization: Bearer <token>` header (recommended)
 //! - Use [`CookieFinder`] with `HttpOnly` and `Secure` cookie flags
 //!
-//! The example below uses query parameters for simplicity, but **production applications
-//! should use the Authorization header or secure cookies instead**.
+//! The example below uses the Authorization header via [`HeaderFinder`].
 //!
 //! # Example:
 //!
 //! ```no_run
 //! use jsonwebtoken::{self, EncodingKey};
 //! use salvo::http::{Method, StatusError};
-//! use salvo::jwt_auth::{ConstDecoder, QueryFinder};
+//! use salvo::jwt_auth::{ConstDecoder, HeaderFinder};
 //! use salvo::prelude::*;
 //! use serde::{Deserialize, Serialize};
 //! use time::{Duration, OffsetDateTime};
@@ -52,11 +51,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let auth_handler: JwtAuth<JwtClaims, _> = JwtAuth::new(ConstDecoder::from_secret(SECRET_KEY.as_bytes()))
-//!         .finders(vec![
-//!             // Box::new(HeaderFinder::new()),
-//!             Box::new(QueryFinder::new("jwt_token")),
-//!             // Box::new(CookieFinder::new("jwt_token")),
-//!         ])
+//!         .finders(vec![Box::new(HeaderFinder::new())])
 //!         .force_passed(true);
 //!
 //!     let acceptor = TcpListener::new("0.0.0.0:8698").bind().await;
@@ -85,7 +80,9 @@
 //!             &claim,
 //!             &EncodingKey::from_secret(SECRET_KEY.as_bytes()),
 //!         )?;
-//!         res.render(Redirect::other(format!("/?jwt_token={token}")));
+//!         res.render(Text::Plain(format!(
+//!             "Use this token as `Authorization: Bearer {token}`"
+//!         )));
 //!     } else {
 //!         match depot.jwt_auth_state() {
 //!             JwtAuthState::Authorized => {

--- a/crates/macros/src/handler.rs
+++ b/crates/macros/src/handler.rs
@@ -75,7 +75,7 @@ pub(crate) fn generate(input: Item) -> syn::Result<TokenStream> {
         }
         _ => Err(syn::Error::new_spanned(
             input,
-            "#[handler] must added to `impl` or `fn`",
+            "#[handler] must be applied to an `impl` block or `fn`",
         )),
     }
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,4 +1,4 @@
-//! The macros lib of Salvo web framework.
+//! Procedural macros for the Salvo web framework.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]

--- a/crates/oapi/README.md
+++ b/crates/oapi/README.md
@@ -39,7 +39,7 @@ Salvo is an extremely simple and powerful Rust web backend framework. Only basic
 
 # salvo-oapi
 
-## Provide a OpenAPI supports for Salvo.
+OpenAPI support for Salvo.
 
 This is an official crate, so you can enable it in `Cargo.toml` like this:
 
@@ -47,6 +47,35 @@ This is an official crate, so you can enable it in `Cargo.toml` like this:
 salvo = { version = "*", features = ["oapi"] }
 ```
 
+## Quick Start
+
+Change `#[handler]` to `#[endpoint]`, build an `OpenApi` document from the
+router, then mount the JSON document and a UI router.
+
+```rust
+use salvo::oapi::extract::QueryParam;
+use salvo::prelude::*;
+
+#[endpoint]
+async fn hello(name: QueryParam<String, false>) -> String {
+    format!("Hello, {}!", name.as_deref().unwrap_or("World"))
+}
+
+#[tokio::main]
+async fn main() {
+    let router = Router::new().push(Router::with_path("hello").get(hello));
+    let doc = OpenApi::new("hello api", "0.1.0").merge_router(&router);
+
+    let router = router
+        .unshift(doc.into_router("/api-doc/openapi.json"))
+        .unshift(SwaggerUi::new("/api-doc/openapi.json").into_router("/swagger-ui"));
+
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+    Server::new(acceptor).serve(router).await;
+}
+```
+
+Open `http://127.0.0.1:7878/swagger-ui` to inspect the generated API document.
 
 ## Documentation & Resources
 

--- a/crates/oapi/src/openapi/components.rs
+++ b/crates/oapi/src/openapi/components.rs
@@ -98,9 +98,8 @@ impl Components {
 
     /// Add [`SecurityScheme`] to [`Components`] and returns `Self`.
     ///
-    /// Accepts two arguments where first is the name of the [`SecurityScheme`]. This is later when
-    /// referenced by [`SecurityRequirement`][requirement]s. Second parameter is the
-    /// [`SecurityScheme`].
+    /// Accepts two arguments: the name of the [`SecurityScheme`] (used later when referenced
+    /// by [`SecurityRequirement`][requirement]s) and the [`SecurityScheme`] itself.
     ///
     /// [requirement]: crate::SecurityRequirement
     #[must_use]
@@ -117,9 +116,8 @@ impl Components {
 
     /// Add iterator of [`SecurityScheme`]s to [`Components`].
     ///
-    /// Accepts two arguments where first is the name of the [`SecurityScheme`]. This is later when
-    /// referenced by [`SecurityRequirement`][requirement]s. Second parameter is the
-    /// [`SecurityScheme`].
+    /// Accepts two arguments: the name of the [`SecurityScheme`] (used later when referenced
+    /// by [`SecurityRequirement`][requirement]s) and the [`SecurityScheme`] itself.
     ///
     /// [requirement]: crate::SecurityRequirement
     #[must_use]

--- a/crates/oapi/src/openapi/external_docs.rs
+++ b/crates/oapi/src/openapi/external_docs.rs
@@ -1,6 +1,6 @@
 //! Implements [OpenAPI External Docs Object][external_docs] types.
 //!
-//! [external_docs]: https://spec.openapis.org/oas/latest.html#xml-object
+//! [external_docs]: https://spec.openapis.org/oas/latest.html#external-documentation-object
 use serde::{Deserialize, Serialize};
 
 use crate::PropMap;
@@ -10,7 +10,7 @@ use crate::PropMap;
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ExternalDocs {
-    /// Target url for external documentation location.
+    /// Target URL for the external documentation location.
     pub url: String,
     /// Additional description supporting markdown syntax of the external documentation.
     pub description: Option<String>,

--- a/crates/oapi/src/openapi/info.rs
+++ b/crates/oapi/src/openapi/info.rs
@@ -64,8 +64,8 @@ pub struct Info {
 impl Info {
     /// Construct a new [`Info`] object.
     ///
-    /// This function accepts two arguments. One which is the title of the API and two the
-    /// version of the api document typically the API version.
+    /// Accepts two arguments: the API title, and the document version (typically the
+    /// API version).
     ///
     /// # Examples
     ///
@@ -81,42 +81,42 @@ impl Info {
             ..Default::default()
         }
     }
-    /// Add title of the API.
+    /// Set the title of the API.
     #[must_use]
     pub fn title<I: Into<String>>(mut self, title: I) -> Self {
         self.title = title.into();
         self
     }
 
-    /// Add version of the api document typically the API version.
+    /// Set the version of the API document (typically the API version).
     #[must_use]
     pub fn version<I: Into<String>>(mut self, version: I) -> Self {
         self.version = version.into();
         self
     }
 
-    /// Add description of the API.
+    /// Set the description of the API.
     #[must_use]
     pub fn description<S: Into<String>>(mut self, description: S) -> Self {
         self.description = Some(description.into());
         self
     }
 
-    /// Add url for terms of the API.
+    /// Set the URL pointing to the terms of service for the API.
     #[must_use]
     pub fn terms_of_service<S: Into<String>>(mut self, terms_of_service: S) -> Self {
         self.terms_of_service = Some(terms_of_service.into());
         self
     }
 
-    /// Add contact information of the API.
+    /// Set the contact information of the API.
     #[must_use]
     pub fn contact(mut self, contact: Contact) -> Self {
         self.contact = Some(contact);
         self
     }
 
-    /// Add license of the API.
+    /// Set the license of the API.
     #[must_use]
     pub fn license(mut self, license: License) -> Self {
         self.license = Some(license);

--- a/crates/oapi/src/openapi/parameter.rs
+++ b/crates/oapi/src/openapi/parameter.rs
@@ -161,8 +161,8 @@ pub struct Parameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_reserved: Option<bool>,
 
-    /// Example of [`Parameter`]'s potential value. This examples will override example
-    /// within [`Parameter::schema`] if defined.
+    /// Example of the [`Parameter`]'s potential value. This example will override any
+    /// example defined within [`Parameter::schema`].
     #[serde(skip_serializing_if = "Option::is_none")]
     example: Option<Value>,
 
@@ -200,7 +200,7 @@ impl Parameter {
         self
     }
 
-    /// Add in of the [`Parameter`].
+    /// Set the location (`in`) of the [`Parameter`].
     #[must_use]
     pub fn parameter_in(mut self, parameter_in: ParameterIn) -> Self {
         self.parameter_in = parameter_in;
@@ -386,7 +386,8 @@ impl Parameter {
     }
 }
 
-/// In definition of [`Parameter`].
+/// Possible values for the OpenAPI parameter `in` field, indicating where the parameter
+/// is located in the request.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Default, Copy, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum ParameterIn {

--- a/crates/oapi/src/openapi/schema/array.rs
+++ b/crates/oapi/src/openapi/schema/array.rs
@@ -153,11 +153,11 @@ pub struct Array {
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     pub default_value: Option<Value>,
 
-    /// Max length of the array.
+    /// Maximum number of items allowed in the array.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_items: Option<usize>,
 
-    /// Min length of the array.
+    /// Minimum number of items allowed in the array.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_items: Option<usize>,
 

--- a/crates/oapi/src/openapi/server.rs
+++ b/crates/oapi/src/openapi/server.rs
@@ -6,8 +6,8 @@
 //! [`Server`] can be used to alter connection url for _**path operations**_. It can be a
 //! relative path e.g `/api/v1` or valid http url e.g. `http://alternative.api.com/api/v1`.
 //!
-//! Relative path will append to the **sever address** so the connection url for _**path
-//! operations**_ will become `server address + relative path`.
+//! A relative path is appended to the **server address**, so the connection URL for
+//! _**path operations**_ becomes `server address + relative path`.
 //!
 //! Optionally it also supports parameter substitution with `{variable}` syntax.
 //!
@@ -136,7 +136,7 @@ impl Servers {
 /// Represents target server object. It can be used to alter server connection for
 /// _**path operations**_.
 ///
-/// By default OpenAPI will implicitly implement [`Server`] with `url = "/"` if no servers is
+/// By default OpenAPI will implicitly add a [`Server`] with `url = "/"` if no servers are
 /// provided to the [`OpenApi`][openapi].
 ///
 /// [openapi]: ../struct.OpenApi.html

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -132,11 +132,11 @@ cfg_feature! {
     pub use sliding_guard::SlidingGuard;
 }
 
-/// Issuer is used to identify every request.
+/// Issues a rate-limit key for a request, identifying the subject being limited.
 pub trait RateIssuer: Send + Sync + 'static {
-    /// The key is used to identify the rate limit.
+    /// The key type that uniquely identifies a rate-limited subject (e.g. client IP, user id).
     type Key: Hash + Eq + Send + Sync + 'static;
-    /// Issue a new key for the request.
+    /// Issue a key for the request. If it returns `None`, the request will not be rate-limited.
     fn issue(
         &self,
         req: &mut Request,

--- a/crates/serde-util/src/lib.rs
+++ b/crates/serde-util/src/lib.rs
@@ -1,4 +1,4 @@
-//! Provides serde related features parsing serde attributes from types.
+//! Utilities for parsing `serde` attributes from type definitions.
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
@@ -27,22 +27,22 @@ fn parse_next_lit_str(next: Cursor) -> Option<(String, Span)> {
     }
 }
 
-/// Value type of a `#[serde(...)]` attribute.
+/// Parsed values from a `#[serde(...)]` attribute.
 #[derive(Default, Debug)]
 pub struct SerdeValue {
-    /// Skip field.
+    /// Whether the field has `#[serde(skip)]` (or its serialize/deserialize variants).
     pub skip: bool,
-    /// Rename field.
+    /// Value of `#[serde(rename = "...")]`, if any.
     pub rename: Option<String>,
-    /// Aliases of field.
+    /// Values from `#[serde(alias = "...")]` declarations.
     pub aliases: Vec<String>,
-    /// Is default value.
+    /// Whether the field has `#[serde(default)]` or `#[serde(default = "...")]`.
     pub is_default: bool,
-    /// Flatten field.
+    /// Whether the field has `#[serde(flatten)]`.
     pub flatten: bool,
-    /// Skip serializing if.
+    /// Whether the field has `#[serde(skip_serializing_if = "...")]`.
     pub skip_serializing_if: bool,
-    /// Double option.
+    /// Whether the field has `#[serde(with = "double_option")]`.
     pub double_option: bool,
 }
 

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -220,9 +220,9 @@ where
 
     /// Sets the name of the cookie that the session is stored with or in.
     ///
-    /// If you are running multiple tide applications on the same
+    /// If you are running multiple Salvo applications on the same
     /// domain, you will need different values for each
-    /// application. The default value is "salvo.session_id".
+    /// application. The default value is `"salvo.session_id"`.
     #[inline]
     #[must_use]
     pub fn cookie_name(mut self, cookie_name: impl Into<String>) -> Self {


### PR DESCRIPTION
## What changed

- Added JSON API examples to the English, Simplified Chinese, and Traditional Chinese READMEs.
- Added practical quick-start examples to the CORS, JWT auth, and OpenAPI crate READMEs.
- Cleaned up core rustdoc wording for handlers, extraction, flow control, and JSON responses.
- Updated the JWT auth rustdoc example to use `Authorization: Bearer` via `HeaderFinder` instead of query-string tokens.

## Why

These docs now give new users clearer next steps after the hello-world example and make security-sensitive middleware examples point at safer defaults.

## Validation

- `cargo fmt`
- `cargo test -p salvo_core --doc`
- `cargo test -p salvo-cors --doc`
- `cargo test -p salvo-jwt-auth --doc`
- `cargo check -p salvo --features oapi,cors,jwt-auth`