### PR TITLE
[codex] expand README and rustdoc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ## Quick Start
 
 Create a new project:
+
 ```bash
 cargo new hello-salvo
 cd hello-salvo
@@ -72,6 +73,7 @@ async fn main() {
 ```
 
 Run it:
+
 ```bash
 cargo run
 ```
@@ -101,6 +103,42 @@ Router::new()
     .push(Router::with_path("articles").get(list_articles))
     // Protected routes
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
+```
+
+### JSON APIs
+
+Salvo handlers can deserialize request bodies and return typed JSON responses:
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+For this pattern, add Serde's derive feature:
+
+```bash
+cargo add serde --features derive
 ```
 
 ### OpenAPI in One Line
@@ -138,6 +176,7 @@ salvo new my_project
 - [Official Website](https://salvo.rs)
 - [API Documentation](https://docs.rs/salvo)
 - [Examples](./examples/)
+- [Feature-specific crates](./crates/)
 
 ## Recommended Projects
 

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -106,6 +106,42 @@ Router::new()
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
 ```
 
+### JSON API
+
+Handler 可以反序列化請求體，並返回型別化的 JSON 回應：
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+這種寫法需要啟用 Serde 的 derive 功能：
+
+```bash
+cargo add serde --features derive
+```
+
 ### 一行程式碼支援 OpenAPI
 
 只需將 `#[handler]` 改為 `#[endpoint]`：
@@ -141,6 +177,7 @@ salvo new my_project
 - [官方網站](https://salvo.rs)
 - [API 文件](https://docs.rs/salvo)
 - [範例程式碼](./examples/)
+- [按功能拆分的 crate](./crates/)
 
 ## 推薦專案
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,6 +108,42 @@ Router::new()
     .push(Router::with_path("articles").hoop(auth_check).post(create_article).delete(delete_article))
 ```
 
+### JSON API
+
+Handler 可以反序列化请求体，并返回类型化的 JSON 响应：
+
+```rust
+use salvo::http::ParseError;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct CreateTodo {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    id: u64,
+    text: String,
+}
+
+#[handler]
+async fn create_todo(req: &mut Request) -> Result<Json<Todo>, ParseError> {
+    let payload = req.parse_json::<CreateTodo>().await?;
+    Ok(Json(Todo {
+        id: 1,
+        text: payload.text,
+    }))
+}
+```
+
+这种写法需要启用 Serde 的 derive 功能：
+
+```bash
+cargo add serde --features derive
+```
+
 ### 一行代码支持 OpenAPI
 
 只需将 `#[handler]` 改为 `#[endpoint]`：
@@ -143,6 +179,7 @@ salvo new my_project
 - [官方网站](https://salvo.rs)
 - [API 文档](https://docs.rs/salvo)
 - [示例代码](./examples/)
+- [按功能拆分的 crate](./crates/)
 
 ## 推荐项目
 

--- a/crates/core/src/extract.rs
+++ b/crates/core/src/extract.rs
@@ -1,7 +1,8 @@
-//! Extract is a feature to let you deserialize request to custom type.
+//! Request extraction for deserializing request data into application types.
 //!
-//! You can easily get data from multiple different data sources and assemble it into the type you
-//! want. You can define a custom type first, then in `Handler` you can get the data like this:
+//! Extraction can collect values from multiple request sources, such as path
+//! parameters, query strings, headers, cookies, form bodies, and JSON bodies.
+//! Define an [`Extractible`] type, then ask the request to build it in a handler:
 //!
 //! ```
 //! # use salvo_core::prelude::*;
@@ -22,11 +23,12 @@
 //! #[handler]
 //! async fn edit(req: &mut Request, depot: &mut Depot) {
 //!     let good_man: GoodMan<'_> = req.extract(depot).await.unwrap();
+//!     let _ = good_man;
 //! }
 //! ```
 //!
-//! There is considerable flexibility in the definition of data types, and can even be resolved into
-//! nested structures as needed:
+//! Extracted types can be nested. Use `#[salvo(extract(flatten))]` or
+//! `#[serde(flatten)]` when a nested type should be parsed from the same request:
 //!
 //! ```
 //! # use salvo_core::prelude::*;
@@ -41,7 +43,7 @@
 //!     first_name: String,
 //!     last_name: String,
 //!     lovers: Vec<String>,
-//!     /// The nested field is completely reparsed from Request.
+//!     /// The nested field is parsed from the same request.
 //!     #[serde(flatten)]
 //!     nested: Nested<'a>,
 //! }
@@ -61,7 +63,9 @@
 //! }
 //! ```
 //!
-//! View [full source code](https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs)
+//! View the [full nested extraction example] in the repository.
+//!
+//! [full nested extraction example]: https://github.com/salvo-rs/salvo/blob/main/examples/extract-nested/src/main.rs
 
 /// Metadata types.
 pub mod metadata;
@@ -74,15 +78,19 @@ pub use case::RenameRule;
 use crate::http::{ParseError, Request};
 use crate::{Depot, Writer};
 
-/// If a type implements this trait, it will give a metadata, this will help request to extracts
-/// data to this type.
+/// Describes how to extract a type from a request.
+///
+/// Implementations provide metadata used by Salvo's extraction machinery and
+/// OpenAPI integration, then perform the actual extraction from [`Request`] and
+/// [`Depot`].
 pub trait Extractible<'ex> {
-    /// Metadata for Extractible type.
+    /// Metadata for this extractible type.
     fn metadata() -> &'static Metadata;
 
-    /// Extract data from request.
+    /// Extracts data from a request.
     ///
-    /// **NOTE:** Set status code to 400 if extract failed and status code is not error.
+    /// **Note:** if extraction fails and the response does not already contain
+    /// an error status, Salvo renders the failure as `400 Bad Request`.
     fn extract(
         req: &'ex mut Request,
         depot: &'ex mut Depot,

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -1,18 +1,18 @@
-//! Handler module for handle [`Request`].
+//! Handler abstractions for processing [`Request`] values.
 //!
-//! Middleware is actually also a `Handler`. They can do some processing before or after the request
-//! reaches the `Handler` that officially handles the request, such as: login verification, data
-//! compression, etc.
+//! A middleware is also a [`Handler`]. Middleware can inspect or modify the request,
+//! share state through [`Depot`], write to [`Response`], or stop the remaining handler
+//! chain with [`FlowCtrl::skip_rest`].
 //!
-//! Middleware is added through the `hoop` function of `Router`. The added middleware will affect
-//! the current `Router` and all its internal descendants `Router`.
+//! Middleware is added with [`Router::hoop`](crate::routing::Router::hoop).
+//! Middleware attached to a router applies to that router and all of its descendants.
 //!
 //! ## Macro `#[handler]`
 //!
-//! `#[handler]` can greatly simplify the writing of the code, and improve the flexibility of the
-//! code.
+//! `#[handler]` keeps handlers concise while still allowing Salvo to inject any
+//! request context the function asks for.
 //!
-//! It can be added to a function to make it implement `Handler`:
+//! Add it to a function to make that function implement [`Handler`]:
 //!
 //! ```
 //! use salvo_core::prelude::*;
@@ -21,7 +21,7 @@
 //! async fn hello() -> &'static str {
 //!     "hello world!"
 //! }
-//! ````
+//! ```
 //!
 //! This is equivalent to:
 //!
@@ -43,19 +43,17 @@
 //!         res.render(Text::Plain("hello world!"));
 //!     }
 //! }
-//! ````
+//! ```
 //!
-//! As you can see, in the case of using `#[handler]`, the code becomes much simpler:
+//! With `#[handler]`, the code becomes much simpler:
+//!
 //! - No need to manually add `#[async_trait]`.
-//! - The parameters that are not needed in the function have been omitted, and the required
-//!   parameters can be arranged in any order.
-//! - For objects that implement `Writer` or `Scribe` abstraction, it can be directly used as the
-//!   return value of the function. Here `&'static str` implements `Scribe`, so it can be returned
-//!   directly as the return value of the function.
+//! - Unused context parameters can be omitted.
+//! - Required parameters can be listed in any supported order.
+//! - Return values that implement [`Writer`] or [`Scribe`] can be returned directly.
 //!
-//! `#[handler]` can not only be added to the function, but also can be added to the `impl` of
-//! `struct` to let `struct` implement `Handler`. At this time, the `handle` function in the `impl`
-//! code block will be Identified as the specific implementation of `handle` in `Handler`:
+//! `#[handler]` can also be added to an `impl` block. In that form, the `handle`
+//! method becomes the [`Handler::handle`] implementation for the struct:
 //!
 //! ```
 //! use salvo_core::prelude::*;
@@ -68,18 +66,17 @@
 //!         res.render(Text::Plain("hello world!"));
 //!     }
 //! }
-//! ````
+//! ```
 //!
 //! ## Handle errors
 //!
-//! `Handler` in Salvo can return `Result`, only the types of `Ok` and `Err` in `Result` are
-//! implemented `Writer` trait.
+//! A Salvo handler can return `Result<T, E>` when both `T` and `E` can be written
+//! to the response.
 //!
-//! Taking into account the widespread use of `anyhow`, the `Writer` implementation of
-//! `anyhow::Error` is provided by default if `anyhow` feature is enabled, and `anyhow::Error` is
-//! Mapped to `InternalServerError`.
+//! When the `anyhow` feature is enabled, `anyhow::Error` can be returned from a
+//! handler and is rendered as `500 Internal Server Error`.
 //!
-//! For custom error types, you can output different error pages according to your needs.
+//! Custom error types can implement [`Writer`] to control the generated response:
 //!
 //! ```ignore
 //! use anyhow::anyhow;
@@ -115,14 +112,15 @@
 //!
 //! ## Implement Handler trait directly
 //!
-//! Under certain circumstances, We need to implement `Handler` directly.
+//! Implement [`Handler`] directly when a type needs to own configuration or when
+//! the handler logic cannot be expressed cleanly as a function.
 //!
 //! ```
+//! use salvo_core::hyper::body::Body;
 //! use salvo_core::prelude::*;
 //!
-//! use crate::salvo_core::http::Body;
-//!
 //! pub struct MaxSizeHandler(u64);
+//!
 //! #[async_trait]
 //! impl Handler for MaxSizeHandler {
 //!     async fn handle(
@@ -147,7 +145,7 @@ use std::sync::Arc;
 use crate::http::StatusCode;
 use crate::{Depot, FlowCtrl, Request, Response, async_trait};
 
-/// `Handler` is used for handle [`Request`].
+/// Processes a request and writes to a response.
 ///
 /// View [module level documentation](index.html) for more details.
 #[async_trait]
@@ -160,7 +158,7 @@ pub trait Handler: Send + Sync + 'static {
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }
-    /// Handle http request.
+    /// Handles one HTTP request.
     #[must_use = "handle future must be used"]
     async fn handle(
         &self,

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -4,17 +4,40 @@ use std::sync::Arc;
 use crate::http::{Request, Response};
 use crate::{Depot, Handler};
 
-/// Control the flow of execute handlers.
+/// Controls execution of a matched handler chain.
 ///
-/// When a request is coming, [`Router`] will detect it and get the matched router.
-/// And then salvo will collect all handlers (including added as middlewares) from the matched
-/// router tree. All handlers in this list will executed one by one.
+/// When a request arrives, [`Router`] matches it against the routing tree. Salvo
+/// then collects the matched goal handler and all middleware handlers from the
+/// matched route branch. Handlers in that list are executed in order.
 ///
-/// Each handler can use `FlowCtrl` to control execute flow, let the flow call next handler or skip
-/// all rest handlers.
+/// Most middleware only needs to read or write request state and then return.
+/// Use [`FlowCtrl::call_next`] for around-style middleware that needs to run
+/// logic after later handlers have finished, or [`FlowCtrl::skip_rest`] to stop
+/// the remaining handlers.
 ///
-/// **NOTE**: When `Response`'s status code is set, and the status code [`Response::is_stamped()`]
-/// is returns false, all remaining handlers will be skipped.
+/// **Note:** when the response becomes stamped, remaining handlers are skipped.
+/// See [`Response::is_stamped`] for the exact status-code behavior.
+///
+/// # Example
+///
+/// ```
+/// use salvo_core::http::header::{HeaderValue, SERVER};
+/// use salvo_core::prelude::*;
+///
+/// #[handler]
+/// async fn add_server_header(
+///     req: &mut Request,
+///     depot: &mut Depot,
+///     res: &mut Response,
+///     ctrl: &mut FlowCtrl,
+/// ) {
+///     ctrl.call_next(req, depot, res).await;
+///     if !ctrl.is_ceased() {
+///         res.headers_mut()
+///             .insert(SERVER, HeaderValue::from_static("salvo"));
+///     }
+/// }
+/// ```
 ///
 /// [`Router`]: crate::routing::Router
 #[derive(Default)]
@@ -47,15 +70,16 @@ impl FlowCtrl {
             handlers,
         }
     }
-    /// Has next handler.
+    /// Returns whether there is another handler in the chain.
     #[inline]
     #[must_use]
     pub fn has_next(&self) -> bool {
         self.cursor < self.handlers.len() // && !self.handlers.is_empty()
     }
 
-    /// Call next handler. If get next handler and executed, returns `true``, otherwise returns
-    /// `false`.
+    /// Calls the next handler.
+    ///
+    /// Returns `true` if a handler was found and executed, otherwise returns `false`.
     ///
     /// **NOTE**: If the response status code is an error or a redirection, all remaining
     /// handlers will be skipped.
@@ -97,21 +121,20 @@ impl FlowCtrl {
         self.cursor = self.handlers.len()
     }
 
-    /// Check whether the `FlowCtrl` has been ceased.
+    /// Checks whether the handler chain has been ceased.
     ///
-    /// **NOTE**: When a handler is used as middleware, it should call `is_ceased` to check
-    /// whether the flow has been ceased. If `is_ceased` returns `true`, the handler should
-    /// skip the following logic.
+    /// **Note:** around-style middleware should check this after
+    /// [`FlowCtrl::call_next`] and skip post-processing when it returns `true`.
     #[inline]
     #[must_use]
     pub fn is_ceased(&self) -> bool {
         self.is_ceased
     }
-    /// Cease all following logic.
+    /// Ceases the remaining handler chain.
     ///
-    /// **NOTE**: This function will mark is_ceased as `true`, but whether the subsequent logic can
-    /// be skipped depends on whether the middleware correctly checks is_ceased and skips the
-    /// subsequent logic.
+    /// This marks the flow as ceased and skips all remaining handlers. Middleware
+    /// that has already called [`FlowCtrl::call_next`] should still check
+    /// [`FlowCtrl::is_ceased`] before running any post-processing.
     #[inline]
     pub fn cease(&mut self) {
         self.skip_rest();

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -7,11 +7,12 @@ use super::{Scribe, try_set_header};
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
 use crate::http::{Response, StatusError};
 
-/// Write serializable content to response as json content.
+/// Writes serializable content to the response as JSON.
 ///
-/// It will set `content-type` to `application/json; charset=utf-8`.
+/// `Json<T>` sets `content-type` to `application/json; charset=utf-8` and
+/// serializes the wrapped value with `serde_json`.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use salvo_core::prelude::*;
@@ -26,6 +27,30 @@ use crate::http::{Response, StatusError};
 ///     Json(User {
 ///         name: "jobs".into(),
 ///     })
+/// }
+/// ```
+///
+/// It is commonly returned together with request parsing:
+///
+/// ```
+/// use salvo_core::http::ParseError;
+/// use salvo_core::prelude::*;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Deserialize)]
+/// struct CreateUser {
+///     name: String,
+/// }
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     name: String,
+/// }
+///
+/// #[handler]
+/// async fn create_user(req: &mut Request) -> Result<Json<User>, ParseError> {
+///     let input = req.parse_json::<CreateUser>().await?;
+///     Ok(Json(User { name: input.name }))
 /// }
 /// ```
 pub struct Json<T>(pub T);

--- a/crates/cors/README.md
+++ b/crates/cors/README.md
@@ -45,6 +45,42 @@ This is an official crate, so you can enable it in `Cargo.toml` like this:
 salvo = { version = "*", features = ["cors"] }
 ```
 
+## Quick Start
+
+Add the CORS handler to `Service`, not to `Router`. Browsers send preflight
+`OPTIONS` requests before the real request, and those preflight requests may not
+match any router branch.
+
+```rust
+use salvo::cors::Cors;
+use salvo::http::Method;
+use salvo::prelude::*;
+
+#[handler]
+async fn hello() -> &'static str {
+    "Hello World"
+}
+
+#[tokio::main]
+async fn main() {
+    let cors = Cors::new()
+        .allow_origin("https://example.com")
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers("content-type")
+        .into_handler();
+
+    let router = Router::new().get(hello);
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+
+    Server::new(acceptor)
+        .serve(Service::new(router).hoop(cors))
+        .await;
+}
+```
+
+For development-only APIs you can use `Cors::permissive()`. For authenticated
+production APIs, prefer explicit origins and avoid `Cors::very_permissive()`.
+
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-cors)

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -57,6 +57,53 @@ This is an official crate, so you can enable it in `Cargo.toml`:
 salvo = { version = "*", features = ["jwt-auth"] }
 ```
 
+## Quick Start
+
+Use `HeaderFinder` for the standard `Authorization: Bearer <token>` header.
+`force_passed(true)` lets the request reach your handler so the handler can
+decide how to respond to authorized, unauthorized, and forbidden states.
+
+```rust
+use salvo::jwt_auth::{ConstDecoder, HeaderFinder, JwtAuthState};
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+const SECRET: &[u8] = b"replace-with-a-secret-from-your-config";
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Claims {
+    sub: String,
+    exp: i64,
+}
+
+#[handler]
+async fn me(depot: &mut Depot, res: &mut Response) {
+    match depot.jwt_auth_state() {
+        JwtAuthState::Authorized => {
+            let data = depot.jwt_auth_data::<Claims>().unwrap();
+            res.render(Json(&data.claims));
+        }
+        JwtAuthState::Unauthorized => res.render(StatusError::unauthorized()),
+        JwtAuthState::Forbidden => res.render(StatusError::forbidden()),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let auth = JwtAuth::<Claims, _>::new(ConstDecoder::from_secret(SECRET))
+        .finders(vec![Box::new(HeaderFinder::new())])
+        .force_passed(true);
+
+    let router = Router::new().hoop(auth).get(me);
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+    Server::new(acceptor).serve(router).await;
+}
+```
+
+Avoid query-string tokens in production because URLs are commonly saved in
+browser history, logs, and referrer headers. Prefer Authorization headers or
+secure, `HttpOnly` cookies.
+
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/salvo-jwt-auth)

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Security Considerations
 //!
-//! **⚠️ WARNING: Avoid passing JWT tokens in URL query parameters in production!**
+//! **Warning: avoid passing JWT tokens in URL query parameters in production.**
 //!
 //! While this crate supports extracting tokens from query parameters (via [`QueryFinder`]),
 //! this method has significant security risks:
@@ -28,15 +28,14 @@
 //! - Use [`HeaderFinder`] with the `Authorization: Bearer <token>` header (recommended)
 //! - Use [`CookieFinder`] with `HttpOnly` and `Secure` cookie flags
 //!
-//! The example below uses query parameters for simplicity, but **production applications
-//! should use the Authorization header or secure cookies instead**.
+//! The example below uses the Authorization header via [`HeaderFinder`].
 //!
 //! # Example:
 //!
 //! ```no_run
 //! use jsonwebtoken::{self, EncodingKey};
 //! use salvo::http::{Method, StatusError};
-//! use salvo::jwt_auth::{ConstDecoder, QueryFinder};
+//! use salvo::jwt_auth::{ConstDecoder, HeaderFinder};
 //! use salvo::prelude::*;
 //! use serde::{Deserialize, Serialize};
 //! use time::{Duration, OffsetDateTime};
@@ -52,11 +51,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let auth_handler: JwtAuth<JwtClaims, _> = JwtAuth::new(ConstDecoder::from_secret(SECRET_KEY.as_bytes()))
-//!         .finders(vec![
-//!             // Box::new(HeaderFinder::new()),
-//!             Box::new(QueryFinder::new("jwt_token")),
-//!             // Box::new(CookieFinder::new("jwt_token")),
-//!         ])
+//!         .finders(vec![Box::new(HeaderFinder::new())])
 //!         .force_passed(true);
 //!
 //!     let acceptor = TcpListener::new("0.0.0.0:8698").bind().await;
@@ -85,7 +80,9 @@
 //!             &claim,
 //!             &EncodingKey::from_secret(SECRET_KEY.as_bytes()),
 //!         )?;
-//!         res.render(Redirect::other(format!("/?jwt_token={token}")));
+//!         res.render(Text::Plain(format!(
+//!             "Use this token as `Authorization: Bearer {token}`"
+//!         )));
 //!     } else {
 //!         match depot.jwt_auth_state() {
 //!             JwtAuthState::Authorized => {

--- a/crates/oapi-macros/src/operation/request_body.rs
+++ b/crates/oapi-macros/src/operation/request_body.rs
@@ -38,14 +38,14 @@ use crate::{AnyValue, Array, DiagResult, Required, TryToTokens, parse_utils};
 ///    request_body = Foo,
 /// )]
 /// ```
-///
+/// 
 /// Or the request body content can also be an array as well by surrounding it with brackets `[..]`.
 /// ```text
 /// #[salvo_oapi::endpoint(
 ///    request_body = [Foo],
 /// )]
 /// ```
-///
+/// 
 /// To define optional request body just wrap the type in `Option<type>`.
 /// ```text
 /// #[salvo_oapi::endpoint(

--- a/crates/oapi/README.md
+++ b/crates/oapi/README.md
@@ -39,7 +39,7 @@ Salvo is an extremely simple and powerful Rust web backend framework. Only basic
 
 # salvo-oapi
 
-## Provide a OpenAPI supports for Salvo.
+OpenAPI support for Salvo.
 
 This is an official crate, so you can enable it in `Cargo.toml` like this:
 
@@ -47,6 +47,35 @@ This is an official crate, so you can enable it in `Cargo.toml` like this:
 salvo = { version = "*", features = ["oapi"] }
 ```
 
+## Quick Start
+
+Change `#[handler]` to `#[endpoint]`, build an `OpenApi` document from the
+router, then mount the JSON document and a UI router.
+
+```rust
+use salvo::oapi::extract::QueryParam;
+use salvo::prelude::*;
+
+#[endpoint]
+async fn hello(name: QueryParam<String, false>) -> String {
+    format!("Hello, {}!", name.as_deref().unwrap_or("World"))
+}
+
+#[tokio::main]
+async fn main() {
+    let router = Router::new().push(Router::with_path("hello").get(hello));
+    let doc = OpenApi::new("hello api", "0.1.0").merge_router(&router);
+
+    let router = router
+        .unshift(doc.into_router("/api-doc/openapi.json"))
+        .unshift(SwaggerUi::new("/api-doc/openapi.json").into_router("/swagger-ui"));
+
+    let acceptor = TcpListener::new("127.0.0.1:7878").bind().await;
+    Server::new(acceptor).serve(router).await;
+}
+```
+
+Open `http://127.0.0.1:7878/swagger-ui` to inspect the generated API document.
 
 ## Documentation & Resources
 


### PR DESCRIPTION
## What changed

- Added JSON API examples to the English, Simplified Chinese, and Traditional Chinese READMEs.
- Added practical quick-start examples to the CORS, JWT auth, and OpenAPI crate READMEs.
- Cleaned up core rustdoc wording for handlers, extraction, flow control, and JSON responses.
- Updated the JWT auth rustdoc example to use `Authorization: Bearer` via `HeaderFinder` instead of query-string tokens.

## Why

These docs now give new users clearer next steps after the hello-world example and make security-sensitive middleware examples point at safer defaults.

## Validation

- `cargo fmt --check`
- `cargo test -p salvo_core --doc`
- `cargo test -p salvo-cors --doc`
- `cargo test -p salvo-jwt-auth --doc`
- `cargo check -p salvo --features oapi,cors,jwt-auth`

Note: `cargo fmt --check` succeeds, but stable rustfmt prints warnings for existing nightly-only rustfmt options in this repository.