### PR TITLE
docs: fix typos and grammar across rustdoc

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -137,7 +137,7 @@ where
     }
 }
 
-/// Identify user by Request Uri.
+/// Identify cacheable requests by their URI.
 #[derive(Clone, Debug)]
 pub struct RequestIssuer {
     use_scheme: bool,

--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -8,7 +8,7 @@ use std::fmt::{self, Debug, Formatter};
 /// when all processing for the request is finished.
 ///
 /// # Example
-/// We set `current_user` value in function `set_user` , and then use this value in the following
+/// We set the `current_user` value in function `set_user`, and then use this value in the following
 /// middlewares and handlers.
 ///
 /// ```no_run

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -249,10 +249,10 @@ impl Handler for EmptyHandler {
     }
 }
 
-/// This is a empty implement for `Handler`.
+/// An empty implementation of `Handler`.
 ///
-/// `EmptyHandler` does nothing except set [`Response`]'s status as [`StatusCode::OK`], it just
-/// marker a router exits.
+/// `EmptyHandler` does nothing except setting the [`Response`] status to [`StatusCode::OK`]; it
+/// just marks the end of a handler chain when no handler is set.
 #[must_use]
 pub fn empty() -> EmptyHandler {
     EmptyHandler

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -51,7 +51,7 @@ pub fn set_global_secure_max_size(size: usize) {
     GLOBAL_SECURE_MAX_SIZE.store(size, Ordering::Relaxed);
 }
 
-/// Middleware for set the secure maximum size of request body.
+/// Middleware to set the secure maximum size of the request body.
 ///
 /// **Note**: The security maximum value applies to request body reads and form parsing,
 /// including multipart file uploads. Increase the limit if you need to accept large uploads.

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -63,7 +63,7 @@ impl Service {
         self.router.clone()
     }
 
-    /// When the response code is 400-600 and the body is empty, capture and set the error page
+    /// When the response code is 400-599 and the body is empty, capture and set the error page
     /// content. If catchers is not set, the default error page will be used.
     ///
     /// # Example

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -246,7 +246,7 @@ impl Display for FlashLevel {
     }
 }
 
-/// `FlashStore` is for stores flash messages.
+/// `FlashStore` stores flash messages.
 pub trait FlashStore: Debug + Send + Sync + 'static {
     /// Get the flash messages from the store.
     fn load_flash(

--- a/crates/oapi/src/naming.rs
+++ b/crates/oapi/src/naming.rs
@@ -20,10 +20,9 @@ static GLOBAL_NAMER: LazyLock<RwLock<Box<dyn Namer>>> =
 static NAME_TYPES: LazyLock<RwLock<BTreeMap<String, (TypeId, &'static str)>>> =
     LazyLock::new(Default::default);
 
-/// Set global namer.
+/// Sets the global namer.
 ///
-/// Set global namer, all the types will be named by this namer. You should call this method before
-/// at before you generate OpenAPI schema.
+/// All types will be named by this namer. Call this method before generating the OpenAPI schema.
 ///
 /// # Example
 ///

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -222,7 +222,7 @@ where
     ///
     /// If you are running multiple Salvo applications on the same
     /// domain, you will need different values for each
-    /// application. The default value is `"salvo.session_id"`.
+    /// application. The default value is `"salvo.session.id"`.
     #[inline]
     #[must_use]
     pub fn cookie_name(mut self, cookie_name: impl Into<String>) -> Self {
@@ -232,7 +232,7 @@ where
 
     /// Sets the `save_unchanged` value.
     ///
-    /// When `save_unchanged` is enabled, a session will cookie will always be set.
+    /// When `save_unchanged` is enabled, a session cookie will always be set.
     ///
     /// With `save_unchanged` disabled, the session data must be modified
     /// from the `Default` value in order for it to save. If a session


### PR DESCRIPTION
## Summary

A small audit pass over rustdoc surfaced a batch of grammatical errors plus one inconsistency between a documented default and the actual value, and an HTTP status range that runs one bucket too high. **Documentation-only — no code changes.**

- **session**: documented default cookie name now matches the implementation (`salvo.session.id`, not `salvo.session_id`); removed a duplicated `will` in the `save_unchanged` doc.
- **core/service**: HTTP status range corrected from `400-600` to `400-599`.
- **oapi/naming**: `set_namer` rustdoc had a duplicated sentence and the phrase "before at before" — cleaned up.
- **flash**: "is for stores flash messages" → "stores flash messages".
- **cache**: `RequestIssuer` docs no longer claim to identify *users* — it identifies *requests*.
- **core/depot**, **core/http/request**, **core/handler**: small grammar/article fixes; `EmptyHandler`'s doc comment now parses as English.

Replaces #1501 (which was opened against a now-merged branch). Rebased on top of the current `main` (`b53672c1`).

## Test plan

- [ ] `cargo doc --no-deps --workspace` builds without new warnings
- [ ] `cargo test --workspace` (doc-tests still pass — no code blocks were modified)
- [ ] Spot-check the regenerated rustdoc for `Depot`, `EmptyHandler`, `RequestIssuer`, `FlashStore`, `set_namer`, and `Service::catcher` to confirm the prose reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)