### PR TITLE
docs: expand feature table, fix stale info; add Parameter::location

### DIFF
--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -388,7 +388,12 @@ impl Response {
         self
     }
 
-    /// Render content.
+    /// Render content into this response.
+    ///
+    /// Delegates to the [`Scribe`] implementation, which writes the body, headers,
+    /// and (if not already set) the `Content-Type`. If serialization fails, the
+    /// `Scribe` impl is responsible for converting the error into a `5xx` response
+    /// instead of panicking or returning an error here.
     ///
     /// # Example
     ///

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -77,12 +77,19 @@ impl FlowCtrl {
         self.cursor < self.handlers.len() // && !self.handlers.is_empty()
     }
 
-    /// Calls the next handler.
+    /// Runs the next handler in the chain.
     ///
-    /// Returns `true` if a handler was found and executed, otherwise returns `false`.
+    /// Returns `true` if at least one handler ran, and `false` if there was no
+    /// remaining handler to dispatch to.
     ///
-    /// **NOTE**: If the response status code is an error or a redirection, all remaining
-    /// handlers will be skipped.
+    /// **NOTE**: If the response is already in a terminal state (an error or
+    /// redirection status code, as reported by [`Response::is_stamped`]) when this
+    /// method is called — or becomes terminal after a handler runs — the remaining
+    /// handlers are skipped. The first call to `call_next` latches whether catcher
+    /// mode is active, so subsequent calls behave consistently within the same
+    /// request.
+    ///
+    /// [`Response::is_stamped`]: crate::http::Response::is_stamped
     #[inline]
     pub async fn call_next(
         &mut self,

--- a/crates/cors/src/lib.rs
+++ b/crates/cors/src/lib.rs
@@ -437,14 +437,20 @@ impl Cors {
     }
 }
 
-/// Enum to control when to call next handler.
+/// Controls when [`CorsHandler`] runs the rest of the middleware/handler chain
+/// relative to writing the CORS headers.
 #[non_exhaustive]
 #[derive(Default, Clone, Copy, Eq, PartialEq, Debug)]
 pub enum CallNext {
-    /// Call next handlers before [`CorsHandler`] write data to response.
+    /// Run the remaining handlers **before** [`CorsHandler`] writes the CORS
+    /// headers onto the response. This is the default and the right choice for
+    /// most setups: downstream handlers see the request unmodified, and CORS
+    /// headers are appended last.
     #[default]
     Before,
-    /// Call next handlers after [`CorsHandler`] write data to response.
+    /// Run the remaining handlers **after** [`CorsHandler`] has written the CORS
+    /// headers. Use this when downstream handlers need to inspect or augment the
+    /// CORS headers — note that they may also overwrite them.
     After,
 }
 

--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -11,14 +11,14 @@
 //!
 //! ```toml
 //! [dependencies]
-//! salvo_extra = { version = "0.88", features = ["basic-auth", "websocket"] }
+//! salvo_extra = { version = "0.93", features = ["basic-auth", "websocket"] }
 //! ```
 //!
 //! Or use the `salvo` umbrella crate which re-exports these features:
 //!
 //! ```toml
 //! [dependencies]
-//! salvo = { version = "0.88", features = ["basic-auth", "websocket"] }
+//! salvo = { version = "0.93", features = ["basic-auth", "websocket"] }
 //! ```
 //!
 //! # Feature Categories
@@ -149,7 +149,7 @@ cfg_feature! {
     pub mod request_id;
 }
 cfg_feature! {
-    #![feature ="tower-compat"]
+    #![feature = "tower-compat"]
     pub mod tower_compat;
     pub use tower_compat::{TowerServiceCompat, TowerLayerCompat};
 }

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -111,9 +111,12 @@ pub const INCOMING_FLASH_KEY: &str = "::salvo::flash::incoming_flash";
 /// Key for outgoing flash messages in depot.
 pub const OUTGOING_FLASH_KEY: &str = "::salvo::flash::outgoing_flash";
 
-/// A flash is a list of messages.
+/// A flash is a list of messages carried between requests.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-pub struct Flash(pub Vec<FlashMessage>);
+pub struct Flash(
+    /// The ordered list of flash messages buffered for the current request/response cycle.
+    pub Vec<FlashMessage>,
+);
 impl Flash {
     /// Add a new message with level `Debug`.
     #[inline]

--- a/crates/oapi-macros/src/feature.rs
+++ b/crates/oapi-macros/src/feature.rs
@@ -245,8 +245,8 @@ impl TryToTokens for Feature {
             Self::Rename(rename) => rename.to_token_stream(),
             Self::Style(style) => quote! { .style(#style) },
             Self::DefaultStyle(style) => quote! { .style(#style) },
-            Self::ParameterIn(parameter_in) => quote! { .parameter_in(#parameter_in) },
-            Self::DefaultParameterIn(parameter_in) => quote! { .parameter_in(#parameter_in) },
+            Self::ParameterIn(parameter_in) => quote! { .location(#parameter_in) },
+            Self::DefaultParameterIn(parameter_in) => quote! { .location(#parameter_in) },
             Self::MultipleOf(multiple_of) => quote! { .multiple_of(#multiple_of) },
             Self::AllowReserved(allow_reserved) => {
                 quote! { .allow_reserved(Some(#allow_reserved)) }

--- a/crates/oapi-macros/src/parameter.rs
+++ b/crates/oapi-macros/src/parameter.rs
@@ -289,7 +289,7 @@ impl TryToTokens for ValueParameter<'_> {
             #oapi::oapi::parameter::Parameter::from(#oapi::oapi::parameter::Parameter::new(#name))
         });
         if let Some(parameter_in) = &self.parameter_in {
-            tokens.extend(quote! { .parameter_in(#parameter_in) });
+            tokens.extend(quote! { .location(#parameter_in) });
         }
 
         let (schema_features, param_features) = &self.features;

--- a/crates/oapi-macros/src/parameter/derive.rs
+++ b/crates/oapi-macros/src/parameter/derive.rs
@@ -565,7 +565,7 @@ impl TryToTokens for Parameter<'_> {
         tokens.extend(quote! { #oapi::oapi::parameter::Parameter::new(#name)});
 
         if let Some(parameter_in) = param_features.pop_parameter_in_feature() {
-            tokens.extend(quote! { .parameter_in(#parameter_in) });
+            tokens.extend(quote! { .location(#parameter_in) });
         } else if let Some(parameter_in) = &self.container_attributes.default_parameter_in {
             tokens.extend(parameter_in.try_to_token_stream()?);
         }

--- a/crates/oapi/src/extract/parameter/cookie.rs
+++ b/crates/oapi/src/extract/parameter/cookie.rs
@@ -146,7 +146,7 @@ where
 {
     fn register(components: &mut Components, operation: &mut Operation, arg: &str) {
         let parameter = Parameter::new(arg)
-            .parameter_in(ParameterIn::Cookie)
+            .location(ParameterIn::Cookie)
             .description(format!("Get parameter `{arg}` from request cookie."))
             .schema(T::to_schema(components))
             .required(R);

--- a/crates/oapi/src/extract/parameter/header.rs
+++ b/crates/oapi/src/extract/parameter/header.rs
@@ -150,7 +150,7 @@ where
 {
     fn register(components: &mut Components, operation: &mut Operation, arg: &str) {
         let parameter = Parameter::new(arg)
-            .parameter_in(ParameterIn::Header)
+            .location(ParameterIn::Header)
             .description(format!("Get parameter `{arg}` from request headers."))
             .schema(T::to_schema(components))
             .required(R);

--- a/crates/oapi/src/extract/parameter/path.rs
+++ b/crates/oapi/src/extract/parameter/path.rs
@@ -95,7 +95,7 @@ where
 {
     fn register(components: &mut Components, operation: &mut Operation, arg: &str) {
         let parameter = Parameter::new(arg)
-            .parameter_in(ParameterIn::Path)
+            .location(ParameterIn::Path)
             .description(format!("Get parameter `{arg}` from request url path."))
             .schema(T::to_schema(components))
             .required(true);

--- a/crates/oapi/src/extract/parameter/query.rs
+++ b/crates/oapi/src/extract/parameter/query.rs
@@ -135,7 +135,7 @@ where
 {
     fn register(components: &mut Components, operation: &mut Operation, arg: &str) {
         let parameter = Parameter::new(arg)
-            .parameter_in(ParameterIn::Query)
+            .location(ParameterIn::Query)
             .description(format!("Get parameter `{arg}` from request url query."))
             .schema(T::to_schema(components))
             .required(R);

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -904,7 +904,7 @@ impl ComposeSchema for serde_json::value::RawValue {
 ///             .parameter(
 ///                 salvo_oapi::Parameter::new("id")
 ///                     .required(salvo_oapi::Required::True)
-///                     .parameter_in(salvo_oapi::ParameterIn::Path)
+///                     .location(salvo_oapi::ParameterIn::Path)
 ///                     .description("Id of pet")
 ///                     .schema(
 ///                         salvo_oapi::Object::new()
@@ -917,7 +917,7 @@ impl ComposeSchema for serde_json::value::RawValue {
 ///             .parameter(
 ///                 salvo_oapi::Parameter::new("name")
 ///                     .required(salvo_oapi::Required::True)
-///                     .parameter_in(salvo_oapi::ParameterIn::Query)
+///                     .location(salvo_oapi::ParameterIn::Query)
 ///                     .description("Name of pet")
 ///                     .schema(
 ///                         salvo_oapi::Object::new()

--- a/crates/oapi/src/naming.rs
+++ b/crates/oapi/src/naming.rs
@@ -201,9 +201,11 @@ pub fn set_name_type_info(
     NAME_TYPES.write().insert(name, (type_id, type_name))
 }
 
-/// Assign name to type and returns the name.
+/// Assigns a name to a type and returns it.
 ///
-/// If the type is already named, return the existing name.
+/// If the type already has a registered name, the existing name is returned and
+/// `rule` is ignored. This function never panics: it consults the global namer
+/// and registers a fresh name on miss.
 pub fn assign_name<T: 'static>(rule: NameRule) -> String {
     let type_id = TypeId::of::<T>();
     let type_name = std::any::type_name::<T>();

--- a/crates/oapi/src/openapi/components.rs
+++ b/crates/oapi/src/openapi/components.rs
@@ -386,7 +386,7 @@ mod tests {
         let components = Components::new()
             .add_parameter(
                 "PageParam",
-                Parameter::new("page").parameter_in(ParameterIn::Query),
+                Parameter::new("page").location(ParameterIn::Query),
             )
             .add_example(
                 "PetExample",

--- a/crates/oapi/src/openapi/parameter.rs
+++ b/crates/oapi/src/openapi/parameter.rs
@@ -200,14 +200,23 @@ impl Parameter {
         self
     }
 
-    /// Set the location (`in`) of the [`Parameter`].
+    /// Sets the location (`in`) of the [`Parameter`].
+    ///
+    /// If the location is [`ParameterIn::Path`], the parameter is also marked required.
     #[must_use]
-    pub fn parameter_in(mut self, parameter_in: ParameterIn) -> Self {
-        self.parameter_in = parameter_in;
+    pub fn location(mut self, location: ParameterIn) -> Self {
+        self.parameter_in = location;
         if self.parameter_in == ParameterIn::Path {
             self.required = Required::True;
         }
         self
+    }
+
+    /// Sets the location (`in`) of the [`Parameter`].
+    #[deprecated(since = "0.94.0", note = "use `Parameter::location` instead")]
+    #[must_use]
+    pub fn parameter_in(self, parameter_in: ParameterIn) -> Self {
+        self.location(parameter_in)
     }
 
     /// Fill [`Parameter`] with values from another [`Parameter`]. Fields will replaced if it is not
@@ -447,7 +456,7 @@ mod tests {
 
         let parameter = parameter
             .name("new name")
-            .parameter_in(ParameterIn::Query)
+            .location(ParameterIn::Query)
             .required(Required::True)
             .description("description")
             .deprecated(Deprecated::False)
@@ -621,7 +630,7 @@ mod tests {
 
     #[test]
     fn parameter_required_unset_is_omitted() {
-        let parameter = Parameter::new("filter").parameter_in(ParameterIn::Query);
+        let parameter = Parameter::new("filter").location(ParameterIn::Query);
         let value = serde_json::to_value(&parameter).expect("serialize");
         assert!(
             value.get("required").is_none(),
@@ -631,7 +640,7 @@ mod tests {
 
     #[test]
     fn parameter_required_true_is_emitted_for_path_in() {
-        let parameter = Parameter::new("id").parameter_in(ParameterIn::Path);
+        let parameter = Parameter::new("id").location(ParameterIn::Path);
         // parameter_in(Path) should force required=true (per spec) and serialize it.
         let value = serde_json::to_value(&parameter).expect("serialize");
         assert_eq!(value["required"], serde_json::Value::Bool(true));
@@ -642,7 +651,7 @@ mod tests {
         use crate::Example;
 
         let parameter = Parameter::new("filter")
-            .parameter_in(ParameterIn::Query)
+            .location(ParameterIn::Query)
             .add_example("first", Example::new().value(json!("foo")))
             .add_example("second", Example::new().value(json!("bar")));
 
@@ -659,7 +668,7 @@ mod tests {
     #[test]
     fn parameter_with_content_serializes_as_media_type_map() {
         let parameter = Parameter::new("filter")
-            .parameter_in(ParameterIn::Query)
+            .location(ParameterIn::Query)
             .content(
                 "application/json",
                 Content::new(RefOr::Ref(crate::Ref::from_schema_name("Filter"))),
@@ -679,7 +688,7 @@ mod tests {
     #[test]
     fn parameter_allow_empty_value_round_trips_under_camel_case() {
         let parameter = Parameter::new("flag")
-            .parameter_in(ParameterIn::Query)
+            .location(ParameterIn::Query)
             .allow_empty_value(true);
 
         let value = serde_json::to_value(&parameter).expect("serialize");

--- a/crates/oapi/src/openapi/path.rs
+++ b/crates/oapi/src/openapi/path.rs
@@ -339,7 +339,7 @@ mod tests {
         use crate::Parameter;
 
         let path_item = PathItem::new(PathItemType::Get, Operation::new())
-            .parameters([Parameter::new("id").parameter_in(crate::ParameterIn::Path)]);
+            .parameters([Parameter::new("id").location(crate::ParameterIn::Path)]);
 
         assert_json_eq!(
             path_item,

--- a/crates/salvo/src/lib.rs
+++ b/crates/salvo/src/lib.rs
@@ -9,6 +9,7 @@
 //! | --- | --- | :---: |
 //! | `cookie` | Support for Cookie | ✔️ |
 //! | `server` | Built-in Server implementation | ✔️ |
+//! | `server-handle` | Expose a [`ServerHandle`](salvo_core::server::ServerHandle) for graceful/forced shutdown | ✔️ |
 //! | `http1` | Support for HTTP 1.1 protocol | ✔️ |
 //! | `http2` | Support for HTTP 2 protocol | ✔️ |
 //! | `http2-cleartext` | Support for HTTP 2 over cleartext TCP | ❌ |
@@ -18,7 +19,13 @@
 //! | `rustls` | TLS built on [`rustls`](https://crates.io/crates/rustls) | ❌ |
 //! | `openssl` | TLS built on [`openssl-tls`](https://crates.io/crates/openssl) | ❌ |
 //! | `native-tls` | TLS built on [`native-tls`](https://crates.io/crates/native-tls) | ❌ |
+//! | `tls12` | Allow TLS 1.2 (in addition to 1.3) for the rustls backend | ❌ |
+//! | `aws-lc-rs` | Use [`aws-lc-rs`](https://crates.io/crates/aws-lc-rs) as the rustls crypto provider | ✔️ |
+//! | `ring` | Use [`ring`](https://crates.io/crates/ring) as the rustls crypto provider | ❌ |
 //! | `unix` | Listener based on Unix socket | ❌ |
+//! | `socket2` | Tune listener socket options via [`socket2`](https://crates.io/crates/socket2) | ❌ |
+//! | `fix-http1-request-uri` | Rewrite HTTP/1.1 absolute-form request URIs to origin-form | ✔️ |
+//! | `matched-path` | Expose the matched route template on the request | ✔️ |
 //! | `tower-compat` | Adapters for `tower::Layer` and `tower::Service` | ❌ |
 //! | `anyhow` | Integrate with the [`anyhow`](https://crates.io/crates/anyhow) crate | ❌ |
 //! | `eyre` | Integrate with the [`eyre`](https://crates.io/crates/eyre) crate | ❌ |
@@ -36,6 +43,19 @@
 //! | `timeout` | Middleware for setting a timeout | ❌ |
 //! | `trailing-slash` | Middleware for handling trailing slashes | ❌ |
 //! | `websocket` | WebSocket implementation | ❌ |
+//! | `cache` | Response caching middleware | ❌ |
+//! | `compression` | Response compression middleware | ❌ |
+//! | `cors` | CORS middleware | ❌ |
+//! | `csrf` | CSRF protection middleware | ❌ |
+//! | `flash` | Flash messages middleware | ❌ |
+//! | `jwt-auth` | JWT authentication middleware | ❌ |
+//! | `oapi` | OpenAPI 3 generation and Swagger/RapiDoc/ReDoc/Scalar UIs | ❌ |
+//! | `otel` | OpenTelemetry integration | ❌ |
+//! | `proxy` | Reverse-proxy middleware | ❌ |
+//! | `rate-limiter` | Rate-limiting middleware | ❌ |
+//! | `serve-static` | Static file / directory serving | ❌ |
+//! | `session` | Cookie-based session middleware | ❌ |
+//! | `tus` | [tus.io](https://tus.io) resumable upload protocol | ❌ |
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -49,137 +69,137 @@ pub use salvo_core::*;
 extern crate self as salvo;
 
 cfg_feature! {
-    #![feature ="affix-state"]
+    #![feature = "affix-state"]
     // #[doc(no_inline)]
     pub use salvo_extra::affix_state;
 }
 cfg_feature! {
-    #![feature ="basic-auth"]
+    #![feature = "basic-auth"]
     // #[doc(no_inline)]
     pub use salvo_extra::basic_auth;
 }
 cfg_feature! {
-    #![feature ="caching-headers"]
+    #![feature = "caching-headers"]
     // #[doc(no_inline)]
     pub use salvo_extra::caching_headers;
 }
 cfg_feature! {
-    #![feature ="catch-panic"]
+    #![feature = "catch-panic"]
     // #[doc(no_inline)]
     pub use salvo_extra::catch_panic;
 }
 cfg_feature! {
-    #![feature ="force-https"]
+    #![feature = "force-https"]
     // #[doc(no_inline)]
     pub use salvo_extra::force_https;
 }
 cfg_feature! {
-    #![feature ="logging"]
+    #![feature = "logging"]
     // #[doc(no_inline)]
     pub use salvo_extra::logging;
 }
 cfg_feature! {
-    #![feature ="concurrency-limiter"]
+    #![feature = "concurrency-limiter"]
     // #[doc(no_inline)]
     pub use salvo_extra::concurrency_limiter;
 }
 cfg_feature! {
-    #![feature ="size-limiter"]
+    #![feature = "size-limiter"]
     // #[doc(no_inline)]
     pub use salvo_extra::size_limiter;
 }
 cfg_feature! {
-    #![feature ="sse"]
+    #![feature = "sse"]
     // #[doc(no_inline)]
     pub use salvo_extra::sse;
 }
 cfg_feature! {
-    #![feature ="trailing-slash"]
+    #![feature = "trailing-slash"]
     // #[doc(no_inline)]
     pub use salvo_extra::trailing_slash;
 }
 cfg_feature! {
-    #![feature ="timeout"]
+    #![feature = "timeout"]
     // #[doc(no_inline)]
     pub use salvo_extra::timeout;
 }
 cfg_feature! {
-    #![feature ="websocket"]
+    #![feature = "websocket"]
     // #[doc(no_inline)]
     pub use salvo_extra::websocket;
 }
 cfg_feature! {
-    #![feature ="request-id"]
+    #![feature = "request-id"]
     // #[doc(no_inline)]
     pub use salvo_extra::request_id;
 }
 cfg_feature! {
-    #![feature ="cache"]
+    #![feature = "cache"]
     #[doc(no_inline)]
     pub use salvo_cache as cache;
 }
 cfg_feature! {
-    #![feature ="compression"]
+    #![feature = "compression"]
     #[doc(no_inline)]
     pub use salvo_compression as compression;
 }
 cfg_feature! {
-    #![feature ="cors"]
+    #![feature = "cors"]
     #[doc(no_inline)]
     pub use salvo_cors as cors;
 }
 cfg_feature! {
-    #![feature ="craft"]
+    #![feature = "craft"]
     // #[doc(no_inline)]
     pub use salvo_craft as craft;
 }
 cfg_feature! {
-    #![feature ="csrf"]
+    #![feature = "csrf"]
     #[doc(no_inline)]
     pub use salvo_csrf as csrf;
 }
 cfg_feature! {
-    #![feature ="flash"]
+    #![feature = "flash"]
     #[doc(no_inline)]
     pub use salvo_flash as flash;
 }
 cfg_feature! {
-    #![feature ="jwt-auth"]
+    #![feature = "jwt-auth"]
     #[doc(no_inline)]
     pub use salvo_jwt_auth as jwt_auth;
 }
 cfg_feature! {
-    #![feature ="proxy"]
+    #![feature = "proxy"]
     #[doc(no_inline)]
     pub use salvo_proxy as proxy;
 }
 cfg_feature! {
-    #![feature ="rate-limiter"]
+    #![feature = "rate-limiter"]
     #[doc(no_inline)]
     pub use salvo_rate_limiter as rate_limiter;
 }
 cfg_feature! {
-    #![feature ="session"]
+    #![feature = "session"]
     #[doc(no_inline)]
     pub use salvo_session as session;
 }
 cfg_feature! {
-    #![feature ="serve-static"]
+    #![feature = "serve-static"]
     #[doc(no_inline)]
     pub use salvo_serve_static as serve_static;
 }
 cfg_feature! {
-    #![feature ="otel"]
+    #![feature = "otel"]
     #[doc(no_inline)]
     pub use salvo_otel as otel;
 }
 cfg_feature! {
-    #![feature ="acme"]
+    #![feature = "acme"]
     #[doc(no_inline)]
     pub use salvo_acme as acme;
 }
 cfg_feature! {
-    #![feature ="oapi"]
+    #![feature = "oapi"]
     #[doc(no_inline)]
     pub use salvo_oapi as oapi;
 }
@@ -193,96 +213,96 @@ cfg_feature! {
 pub mod prelude {
     pub use salvo_core::prelude::*;
     cfg_feature! {
-        #![feature ="affix-state"]
+        #![feature = "affix-state"]
         pub use salvo_extra::affix_state;
     }
     cfg_feature! {
-        #![feature ="basic-auth"]
+        #![feature = "basic-auth"]
         pub use salvo_extra::basic_auth::{BasicAuth, BasicAuthDepotExt, BasicAuthValidator};
     }
     cfg_feature! {
-        #![feature ="caching-headers"]
+        #![feature = "caching-headers"]
         pub use salvo_extra::caching_headers::CachingHeaders;
     }
     cfg_feature! {
-        #![feature ="catch-panic"]
+        #![feature = "catch-panic"]
         pub use salvo_extra::catch_panic::CatchPanic;
     }
     cfg_feature! {
-        #![feature ="compression"]
+        #![feature = "compression"]
         pub use salvo_compression::{Compression, CompressionAlgo, CompressionLevel};
     }
     cfg_feature! {
-        #![feature ="craft"]
+        #![feature = "craft"]
         // #[doc(no_inline)]
         pub use salvo_craft::craft;
     }
     cfg_feature! {
-        #![feature ="csrf"]
+        #![feature = "csrf"]
         pub use salvo_csrf::CsrfDepotExt;
     }
     cfg_feature! {
-        #![feature ="force-https"]
+        #![feature = "force-https"]
         pub use salvo_extra::force_https::ForceHttps;
     }
     cfg_feature! {
-        #![feature ="jwt-auth"]
+        #![feature = "jwt-auth"]
         pub use salvo_jwt_auth::{JwtAuthDepotExt, JwtAuth, JwtAuthState};
     }
     cfg_feature! {
-        #![feature ="logging"]
+        #![feature = "logging"]
         pub use salvo_extra::logging::Logger;
     }
     cfg_feature! {
-        #![feature ="proxy"]
+        #![feature = "proxy"]
         pub use salvo_proxy::Proxy;
     }
     cfg_feature! {
-        #![feature ="session"]
+        #![feature = "session"]
         pub use salvo_session::{SessionDepotExt, SessionHandler, SessionStore};
     }
     cfg_feature! {
-        #![feature ="concurrency-limiter"]
+        #![feature = "concurrency-limiter"]
         pub use salvo_extra::concurrency_limiter::max_concurrency;
     }
     cfg_feature! {
-        #![feature ="size-limiter"]
+        #![feature = "size-limiter"]
         pub use salvo_extra::size_limiter::max_size;
     }
     cfg_feature! {
-        #![feature ="sse"]
+        #![feature = "sse"]
         pub use salvo_extra::sse::{SseEvent, SseKeepAlive};
     }
     cfg_feature! {
-        #![feature ="trailing-slash"]
+        #![feature = "trailing-slash"]
         pub use salvo_extra::trailing_slash::{self, TrailingSlash, TrailingSlashAction};
     }
     cfg_feature! {
-        #![feature ="timeout"]
+        #![feature = "timeout"]
         pub use salvo_extra::timeout::Timeout;
     }
     cfg_feature! {
-        #![feature ="tower-compat"]
+        #![feature = "tower-compat"]
         pub use salvo_extra::tower_compat::{TowerServiceCompat, TowerLayerCompat};
     }
     cfg_feature! {
-        #![feature ="websocket"]
+        #![feature = "websocket"]
         pub use salvo_extra::websocket::WebSocketUpgrade;
     }
     cfg_feature! {
-        #![feature ="request-id"]
+        #![feature = "request-id"]
         pub use salvo_extra::request_id::RequestId;
     }
     cfg_feature! {
-        #![feature ="serve-static"]
+        #![feature = "serve-static"]
         pub use salvo_serve_static::{StaticFile, StaticDir};
     }
     cfg_feature! {
-        #![feature ="acme"]
+        #![feature = "acme"]
         pub use salvo_acme::AcmeListener;
     }
     cfg_feature! {
-        #![feature ="oapi"]
+        #![feature = "oapi"]
         pub use crate::oapi::{endpoint, RouterExt, EndpointArgRegister, EndpointOutRegister, OpenApi, ToParameter, ToParameters, ToSchema, ToResponse, ToResponses};
         pub use crate::oapi::swagger_ui::SwaggerUi;
         pub use crate::oapi::rapidoc::RapiDoc;

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -157,9 +157,9 @@ where
     ///
     /// **Example of generating a secure key:**
     /// ```ignore
-    /// use rand::Rng;
+    /// use rand::RngCore;
     /// let mut key = [0u8; 64];
-    /// rand::rngs::SysRng.fill_bytes(&mut key);
+    /// rand::rngs::OsRng.fill_bytes(&mut key);
     /// ```
     #[inline]
     #[must_use]
@@ -175,9 +175,9 @@ where
     ///
     /// **Example of generating a secure key:**
     /// ```ignore
-    /// use rand::Rng;
+    /// use rand::RngCore;
     /// let mut key = [0u8; 64];
-    /// rand::rngs::SysRng.fill_bytes(&mut key);
+    /// rand::rngs::OsRng.fill_bytes(&mut key);
     /// ```
     #[inline]
     pub fn try_new(store: S, secret: &[u8]) -> Result<Self, KeyError> {


### PR DESCRIPTION
## Summary

Two related threads bundled here, both surfaced from the same naming/docs audit. Mostly documentation; the one API change is purely additive (new builder method + deprecation alias on the old one).

### `Parameter::location` (replaces the `parameter_in` builder setter)

`oapi::Parameter` has a public field `parameter_in: ParameterIn` **and** a builder method with the same name. The field + setter sharing a name is confusing, so:

- Add `Parameter::location(loc)` as the canonical builder setter.
- Mark the old `Parameter::parameter_in(loc)` setter `#[deprecated]` — it now forwards to `location`, so existing callers keep compiling with a pointer to the new name.
- Update every internal caller, doctest, and macro-emitted token stream in `salvo-oapi` / `salvo-oapi-macros` to emit `.location(...)` — the workspace itself stays warning-free; only out-of-tree users see the deprecation.

### Documentation cleanup (audit report section "四")

- **salvo umbrella crate**: the rustdoc feature table was missing ~15 features that exist in `Cargo.toml` (`cache`, `cors`, `csrf`, `flash`, `jwt-auth`, `oapi`, `otel`, `proxy`, `rate-limiter`, `serve-static`, `session`, `tus`, `compression`, plus the lower-level `socket2`, `tls12`, `aws-lc-rs`, `ring`, `server-handle`, `fix-http1-request-uri`, `matched-path`). Added them.
- **salvo umbrella crate**: `#![feature =\"...\"]` formatting was inconsistent. Normalized to the rustfmt-style spacing everywhere.
- **salvo_extra**: the rustdoc Quick Start hard-coded `version = \"0.88\"`, five minor versions stale. Bumped to `0.93`.
- **session**: the `HandlerBuilder::new` / `try_new` examples referenced `rand::rngs::SysRng`, which does not exist in any modern `rand`. Switched to `rand::rngs::OsRng` + `RngCore::fill_bytes`.
- **core `Response::render`**: clarified that body-rendering failures are routed into a 5xx response by the `Scribe` impl rather than surfacing here.
- **core `FlowCtrl::call_next`**: rewrote the doc so the return-value semantics and the interaction with `is_stamped` / catcher mode are explicit.
- **oapi `naming::assign_name`**: documented that this function never panics and that the rule is ignored on a name hit.
- **cors `CallNext`**: expanded the variant docs so `Before` vs `After` clearly explains *when each fires* and which one to pick. Variant names left unchanged.
- **flash `Flash`**: the tuple struct exposed `pub Vec<FlashMessage>` with no field-level doc; added one.

## Test plan

- [x] \`cargo check --workspace --all-features\` — clean
- [x] \`cargo check --workspace --all-features --tests --examples\` — clean
- [x] \`cargo doc --workspace --all-features --no-deps\` — warning count unchanged vs. \`main\` (19 → 19; no new broken links introduced)
- [ ] Visual spot-check of the regenerated rustdoc for the salvo umbrella crate's feature table

🤖 Generated with [Claude Code](https://claude.com/claude-code)