### PR TITLE
docs+refactor: explain `is_stamped`, rename `stop_forcible` → `stop_forceful`

### DIFF
--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -20,6 +20,27 @@ use crate::http::{StatusCode, StatusError};
 use crate::{BoxedError, Error, Scribe};
 
 /// Represents an HTTP response.
+///
+/// # Terminal responses ("stamped")
+///
+/// Several parts of Salvo (notably [`FlowCtrl::call_next`] and the built-in
+/// catcher logic) treat a response as **terminal** — historically called
+/// *stamped* in this codebase — once a status code has been set that signals
+/// the request is finished:
+///
+/// - any 4xx client error,
+/// - any 5xx server error, or
+/// - any 3xx redirection.
+///
+/// When that happens, the remaining handlers in the chain are skipped so a
+/// downstream handler cannot accidentally overwrite the response. [`is_stamped`]
+/// is the predicate used to test this condition; the name is kept for backwards
+/// compatibility, but read it as "is this response in a terminal state?".
+/// Successful (2xx), informational (1xx), and unset status codes are *not*
+/// considered terminal.
+///
+/// [`FlowCtrl::call_next`]: crate::routing::FlowCtrl::call_next
+/// [`is_stamped`]: Response::is_stamped
 #[non_exhaustive]
 pub struct Response {
     /// The HTTP status code.
@@ -202,8 +223,21 @@ impl Response {
         self.replace_body(ResBody::None)
     }
 
-    /// If returns `true`, it means this response is ready for write back and the reset handlers
-    /// should be skipped.
+    /// Returns `true` when this response is in a *terminal* state — i.e. it
+    /// already has a status code that signals the request is finished, so the
+    /// remaining handlers in the chain should be skipped.
+    ///
+    /// A response is considered terminal when its status code is set to any of:
+    ///
+    /// - a 4xx client error,
+    /// - a 5xx server error, or
+    /// - a 3xx redirection.
+    ///
+    /// Successful (2xx), informational (1xx), and unset status codes return
+    /// `false`. The method name uses "stamped" — internal terminology for
+    /// "this response has had its outcome stamped on it" — and is kept for
+    /// backwards compatibility. See the [type-level docs](Response#terminal-responses-stamped)
+    /// for more.
     #[inline]
     pub fn is_stamped(&self) -> bool {
         self.status_code.is_some_and(|code| {

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -48,11 +48,23 @@ cfg_feature! {
 
 #[cfg(feature = "server-handle")]
 impl ServerHandle {
-    /// Force stop server.
-    ///
-    /// Call this function will stop server immediately.
-    pub fn stop_forcible(&self) {
+    /// Forcefully stops the server immediately, without waiting for in-flight
+    /// requests to finish. For a clean shutdown use [`Self::stop_graceful`]
+    /// instead.
+    pub fn force_stop(&self) {
         let _ = self.tx_cmd.send(ServerCommand::StopForcible);
+    }
+
+    /// Deprecated alias for [`Self::force_stop`].
+    ///
+    /// The old name reads awkwardly (`forcible` is normally an adjective and
+    /// does not parallel the adjective in `stop_graceful`). Use [`force_stop`]
+    /// for new code; this shim keeps existing callers compiling.
+    ///
+    /// [`force_stop`]: Self::force_stop
+    #[deprecated(since = "0.94.0", note = "use `ServerHandle::force_stop` instead")]
+    pub fn stop_forcible(&self) {
+        self.force_stop();
     }
 
     /// Graceful stop server.
@@ -171,11 +183,17 @@ impl<A: Acceptor + Send> Server<A> {
             }
         }
 
-        /// Force stop server.
-        ///
-        /// Call this function will stop server immediately.
-        pub fn stop_forcible(&self) {
+        /// Forcefully stops the server immediately, without waiting for in-flight
+        /// requests to finish. For a clean shutdown use [`Self::stop_graceful`]
+        /// instead.
+        pub fn force_stop(&self) {
             let _ = self.tx_cmd.send(ServerCommand::StopForcible);
+        }
+
+        /// Deprecated alias for [`Self::force_stop`].
+        #[deprecated(since = "0.94.0", note = "use `Server::force_stop` instead")]
+        pub fn stop_forcible(&self) {
+            self.force_stop();
         }
 
         /// Graceful stop server.
@@ -519,7 +537,7 @@ mod tests {
         // Give server a moment to start
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        handle.stop_forcible();
+        handle.force_stop();
 
         let result = timeout(Duration::from_secs(1), server_task).await;
         assert!(

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -49,22 +49,23 @@ cfg_feature! {
 #[cfg(feature = "server-handle")]
 impl ServerHandle {
     /// Forcefully stops the server immediately, without waiting for in-flight
-    /// requests to finish. For a clean shutdown use [`Self::stop_graceful`]
-    /// instead.
-    pub fn force_stop(&self) {
+    /// requests to finish. The adjective parallels [`Self::stop_graceful`];
+    /// reach for that one when you want a clean shutdown.
+    pub fn stop_forceful(&self) {
         let _ = self.tx_cmd.send(ServerCommand::StopForcible);
     }
 
-    /// Deprecated alias for [`Self::force_stop`].
+    /// Deprecated alias for [`Self::stop_forceful`].
     ///
-    /// The old name reads awkwardly (`forcible` is normally an adjective and
-    /// does not parallel the adjective in `stop_graceful`). Use [`force_stop`]
-    /// for new code; this shim keeps existing callers compiling.
+    /// The old name reads awkwardly (`forcible` is an adjective for things
+    /// that *can* be forced, not for the act of forcing, and it does not
+    /// parallel the adjective in `stop_graceful`). Use [`stop_forceful`] for
+    /// new code; this shim keeps existing callers compiling.
     ///
-    /// [`force_stop`]: Self::force_stop
-    #[deprecated(since = "0.94.0", note = "use `ServerHandle::force_stop` instead")]
+    /// [`stop_forceful`]: Self::stop_forceful
+    #[deprecated(since = "0.94.0", note = "use `ServerHandle::stop_forceful` instead")]
     pub fn stop_forcible(&self) {
-        self.force_stop();
+        self.stop_forceful();
     }
 
     /// Graceful stop server.
@@ -184,16 +185,16 @@ impl<A: Acceptor + Send> Server<A> {
         }
 
         /// Forcefully stops the server immediately, without waiting for in-flight
-        /// requests to finish. For a clean shutdown use [`Self::stop_graceful`]
-        /// instead.
-        pub fn force_stop(&self) {
+        /// requests to finish. The adjective parallels [`Self::stop_graceful`];
+        /// reach for that one when you want a clean shutdown.
+        pub fn stop_forceful(&self) {
             let _ = self.tx_cmd.send(ServerCommand::StopForcible);
         }
 
-        /// Deprecated alias for [`Self::force_stop`].
-        #[deprecated(since = "0.94.0", note = "use `Server::force_stop` instead")]
+        /// Deprecated alias for [`Self::stop_forceful`].
+        #[deprecated(since = "0.94.0", note = "use `Server::stop_forceful` instead")]
         pub fn stop_forcible(&self) {
-            self.force_stop();
+            self.stop_forceful();
         }
 
         /// Graceful stop server.
@@ -537,7 +538,7 @@ mod tests {
         // Give server a moment to start
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        handle.force_stop();
+        handle.stop_forceful();
 
         let result = timeout(Duration::from_secs(1), server_task).await;
         assert!(


### PR DESCRIPTION
## Summary

Two unrelated audit findings on `salvo_core`, bundled because both touch terminology consumed by handler-chain code.

### 1. `Response::is_stamped` — documentation only, no rename

`stamped` is internal jargon for "this response has had its outcome written, so downstream handlers should be skipped." The method has been referenced from `FlowCtrl::call_next` and the catcher logic for a long time without ever being defined in the crate docs.

- Added a "Terminal responses (\"stamped\")" section to the `Response` type-level docs spelling out which status codes count (3xx redirect, 4xx, 5xx) and why the term exists.
- Expanded the `is_stamped` doc comment to call out the same definition and link to the type-level section.

The name `is_stamped` is **not** changed — preserving it keeps every existing caller compiling and the diff scoped to docs.

### 2. `ServerHandle::stop_forceful` / `Server::stop_forceful` — rename + deprecated alias

`stop_forcible` reads awkwardly: `forcible` is an adjective for things that *can* be forced, not for the act of forcing, and it does not parallel the adjective in `stop_graceful`.

Renamed to `stop_forceful` so that:
- `forceful` (adjective) parallels `graceful` (adjective)
- Both methods share the `stop_` prefix, so they sort together in docs and IDE completion lists
- Reads naturally as "graceful stop" / "forceful stop"

(An earlier draft of this PR used `force_stop`, which is the common UI/CLI idiom — but the parallelism with the pre-existing `stop_graceful` wins.)

The old names are kept as `#[deprecated]` shims that forward to the new name, so:

- Out-of-tree callers keep compiling, and get a deprecation warning pointing at `stop_forceful`.
- The internal test caller (`server::tests::test_server_handle_stop`) is updated so the workspace itself stays warning-free.

Both `ServerHandle::stop_forcible` and `Server::stop_forcible` get the same treatment.

## Test plan

- [x] \`cargo check --workspace --all-features --tests --examples\` — clean (no internal deprecation warnings)
- [x] \`cargo doc -p salvo_core --all-features --no-deps\` — same 11 pre-existing warnings as \`main\`; no new broken intra-doc links
- [x] \`cargo test -p salvo_core --lib server::tests\` — 3 passed (incl. \`test_server_handle_stop\`, which now calls \`stop_forceful\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)