### PR TITLE
Fix documentation wording and naming issues

### DIFF
--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -162,7 +162,7 @@ pub struct Catcher {
     hoops: Vec<Arc<dyn Handler>>,
 }
 impl Default for Catcher {
-    /// Create new `Catcher` with its goal handler is [`DefaultGoal`].
+    /// Creates a new `Catcher` with [`DefaultGoal`] as its handler.
     fn default() -> Self {
         Self {
             goal: Arc::new(DefaultGoal::new()),
@@ -229,8 +229,8 @@ impl Catcher {
 
 /// Default [`Handler`] used as goal for [`Catcher`].
 ///
-/// If http status is error, and all custom handlers is not catch it and write body,
-/// `DefaultGoal` will used to catch them.
+/// If the HTTP status is an error, and no custom handler catches it or writes a body,
+/// `DefaultGoal` is used to handle it.
 ///
 /// `DefaultGoal` supports sending error pages in `XML`, `JSON`, `HTML`, `Text` formats.
 #[derive(Default, Debug)]

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -370,8 +370,7 @@ impl HoopedHandler {
         self
     }
 
-    /// Add a handler as middleware. It runs the handler when an error is caught,
-    /// but only when the filter returns `true`.
+    /// Add a handler as middleware. It runs this middleware only when the filter returns `true`.
     #[inline]
     #[must_use]
     pub fn hoop_when<H, F>(mut self, hoop: H, filter: F) -> Self
@@ -407,7 +406,7 @@ impl Handler for HoopedHandler {
     }
 }
 
-/// `none_skipper` will skipper nothing.
+/// `none_skipper` skips nothing.
 ///
 /// It can be used as default `Skipper` in middleware.
 pub fn none_skipper(_req: &mut Request, _depot: &Depot) -> bool {

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -108,7 +108,7 @@ where
 }
 
 impl Response {
-    /// Creates a new blank `Response`.
+    /// Creates a new blank `Response` with the provided cookie jar.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -156,9 +156,9 @@ impl Response {
 
     /// Modify a header for this response.
     ///
-    /// When `overwrite` is set to `true`, If the header is already present, the value will be
-    /// replaced. When `overwrite` is set to `false`, The new header is always appended to the
-    /// request, even if the header already exists.
+    /// When `overwrite` is set to `true`, if the header is already present, the value will be
+    /// replaced. When `overwrite` is set to `false`, the new header is always appended to the
+    /// response, even if the header already exists.
     pub fn add_header<N, V>(
         &mut self,
         name: N,
@@ -386,17 +386,18 @@ impl Response {
         }
     }
 
-    /// Get content type..
+    /// Returns the response `Content-Type`.
     ///
     /// # Example
     ///
     /// ```
-    /// use salvo_core::http::{Response, StatusCode};
+    /// use salvo_core::http::Response;
     ///
     /// let mut res = Response::new();
     /// assert_eq!(None, res.content_type());
     /// res.headers_mut().insert("content-type", "text/plain".parse().unwrap());
     /// assert_eq!(Some(mime::TEXT_PLAIN), res.content_type());
+    /// ```
     #[inline]
     pub fn content_type(&self) -> Option<Mime> {
         self.headers

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -204,7 +204,7 @@ impl WispBuilder for CharsWispBuilder {
                     .parse::<usize>()
                     .map_err(|_| format!("parse range for {name} failed"))?;
                 if min < 1 {
-                    return Err("min_width must greater or equal to 1".to_owned());
+                    return Err("min_width must be greater than or equal to 1".to_owned());
                 }
                 min
             };
@@ -221,7 +221,7 @@ impl WispBuilder for CharsWispBuilder {
                             .parse::<usize>()
                             .map_err(|_| format!("parse range for {name} failed"))?;
                         if max <= 1 {
-                            return Err("min_width must greater than 1".to_owned());
+                            return Err("max_width must be greater than 1".to_owned());
                         }
                         max - 1
                     } else {
@@ -229,7 +229,7 @@ impl WispBuilder for CharsWispBuilder {
                             .parse::<usize>()
                             .map_err(|_| format!("parse range for {name} failed"))?;
                         if max < 1 {
-                            return Err("min_width must greater or equal to 1".to_owned());
+                            return Err("max_width must be greater than or equal to 1".to_owned());
                         }
                         max
                     };
@@ -324,7 +324,7 @@ impl CombWisp {
     /// Create new `CombWisp`.
     ///
     /// # Panics
-    /// If contains unsupported `WispKind``.
+    /// If it contains an unsupported `WispKind`.
     pub fn new(wisps: Vec<WispKind>) -> Result<Self, String> {
         let mut comb_regex = "^".to_owned();
         let mut names = Vec::with_capacity(wisps.len());
@@ -332,7 +332,7 @@ impl CombWisp {
         let mut is_greedy = false;
         let mut wild_start = None;
         let mut wild_regex = None;
-        let any_chars_regex = Regex::new(".*").expect("regex should worked");
+        let any_chars_regex = Regex::new(".*").expect("regex should compile");
         for wisp in wisps {
             match wisp {
                 WispKind::Const(wisp) => {

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -293,8 +293,8 @@ impl Router {
         self
     }
 
-    /// When you want write router chain, this function will be useful,
-    /// You can write your custom logic in FnOnce.
+    /// Runs a closure with this router and returns the closure result.
+    /// Useful for composing router chains conditionally.
     #[inline]
     #[must_use]
     pub fn then<F>(self, func: F) -> Self
@@ -306,7 +306,7 @@ impl Router {
 
     /// Add a [`SchemeFilter`] to current router.
     ///
-    /// [`SchemeFilter`]: super::filters::HostFilter
+    /// [`SchemeFilter`]: super::filters::SchemeFilter
     #[inline]
     #[must_use]
     pub fn scheme(self, scheme: Scheme) -> Self {

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -64,7 +64,7 @@ impl Service {
     }
 
     /// When the response code is 400-599 and the body is empty, capture and set the error page
-    /// content. If catchers is not set, the default error page will be used.
+    /// content. If no catcher is set, the default error page will be used.
     ///
     /// # Example
     ///

--- a/crates/csrf/src/ccp_cipher.rs
+++ b/crates/csrf/src/ccp_cipher.rs
@@ -17,7 +17,7 @@ pub struct CcpCipher {
 }
 
 impl CcpCipher {
-    /// Given an aead key, return an `CcpCipher` instance.
+    /// Given an AEAD key, returns a `CcpCipher` instance.
     #[inline]
     #[must_use]
     pub fn new(aead_key: [u8; 32]) -> Self {

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -46,7 +46,8 @@ cfg_feature! {
     pub use cookie_store::CookieStore;
 
     /// Helper function to create a `CookieStore`.
-    #[must_use] pub fn cookie_store<>() -> CookieStore {
+    #[must_use]
+    pub fn cookie_store() -> CookieStore {
         CookieStore::new()
     }
 }
@@ -102,15 +103,15 @@ cfg_feature! {
 cfg_feature! {
     #![all(feature = "hmac-cipher", feature = "cookie-store")]
     /// Helper function to create a `Csrf` use `HmacCipher` and `CookieStore`.
-    pub fn hmac_cookie_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, CookieStore> {
-        Csrf::new(HmacCipher::new(aead_key), CookieStore::new(), finder)
+    pub fn hmac_cookie_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, CookieStore> {
+        Csrf::new(HmacCipher::new(hmac_key), CookieStore::new(), finder)
     }
 }
 cfg_feature! {
     #![all(feature = "hmac-cipher", feature = "session-store")]
     /// Helper function to create a `Csrf` use `HmacCipher` and `SessionStore`.
-    pub fn hmac_session_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, SessionStore> {
-        Csrf::new(HmacCipher::new(aead_key), SessionStore::new(), finder)
+    pub fn hmac_session_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, SessionStore> {
+        Csrf::new(HmacCipher::new(hmac_key), SessionStore::new(), finder)
     }
 }
 
@@ -166,7 +167,7 @@ cfg_feature! {
     }
 }
 
-/// key used to insert auth decoded data to depot.
+/// Key used to store the CSRF token in [`Depot`].
 pub const CSRF_TOKEN_KEY: &str = "salvo.csrf.token";
 
 /// Controls when a CSRF token is rotated.

--- a/crates/oapi-macros/src/operation/request_body.rs
+++ b/crates/oapi-macros/src/operation/request_body.rs
@@ -38,14 +38,14 @@ use crate::{AnyValue, Array, DiagResult, Required, TryToTokens, parse_utils};
 ///    request_body = Foo,
 /// )]
 /// ```
-/// 
+///
 /// Or the request body content can also be an array as well by surrounding it with brackets `[..]`.
 /// ```text
 /// #[salvo_oapi::endpoint(
 ///    request_body = [Foo],
 /// )]
 /// ```
-/// 
+///
 /// To define optional request body just wrap the type in `Option<type>`.
 /// ```text
 /// #[salvo_oapi::endpoint(

--- a/crates/oapi/docs/derive_to_parameters.md
+++ b/crates/oapi/docs/derive_to_parameters.md
@@ -10,7 +10,7 @@ within `parameters(...)` section if description or other than default configurat
 You can use the Rust's own `#[deprecated]` attribute on field to mark it as
 deprecated and it will reflect to the generated OpenAPI spec.
 
-`#[deprecated]` attribute supports adding additional details such as a reason and or since version
+`#[deprecated]` attribute supports adding additional details such as a reason or the `since` version,
 but this is not supported in OpenAPI. OpenAPI has only a boolean flag to determine deprecation.
 While it is totally okay to declare deprecated with reason
 `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
@@ -26,14 +26,14 @@ struct Query {
 
 # ToParameters Container Attributes for `#[salvo(parameters(...))]`
 
-The following attributes are available for use in on the container attribute `#[salvo(parameters(...))]` for the struct
+The following attributes are available on the container attribute `#[salvo(parameters(...))]` for the struct
 deriving `ToParameters`:
 
 * `names(...)` Define comma separated list of names for unnamed fields of struct used as a path parameter.
   __Only__ supported on __unnamed structs__.
 * `style = ...` Defines how all parameters are serialized by [`ParameterStyle`][style]. Default
   values are based on _`parameter_in`_ attribute.
-* `default_parameter_in = ...` =  Defines default where the parameters of this field are used with a value from
+* `default_parameter_in = ...` Defines the default location for parameters of this field with a value from
   [`parameter::ParameterIn`][in_enum]. If this attribute is not supplied, then the default value is from query.
 * `rename_all = ...` Can be provided to alternatively to the serde's `rename_all` attribute. Effectively provides same functionality.
 
@@ -61,7 +61,7 @@ The following attributes are available for use in the `#[salvo(parameter(...))]`
 
 * `style = ...` Defines how the parameter is serialized by [`ParameterStyle`][style]. Default values are based on _`parameter_in`_ attribute.
 
-* `parameter_in = ...` =  Defines where the parameters of this field are used with a value from
+* `parameter_in = ...` Defines where parameters of this field are used with a value from
   [`parameter::ParameterIn`][in_enum]. If this attribute is not supplied, then the default value is from query.
 
 * `explode` Defines whether new _`parameter=value`_ pair is created for each parameter within _`object`_ or _`array`_.
@@ -74,7 +74,7 @@ The following attributes are available for use in the `#[salvo(parameter(...))]`
 * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
   This is useful in cases where the default type does not correspond to the actual type e.g. when
   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-  Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
+  Value can be any Rust type that normally could be used to serialize to JSON or a custom type such as _`Object`_.
   _`Object`_ will be rendered as generic OpenAPI object.
 
 * `inline` If set, the schema for this field's type needs to be a [`ToSchema`][to_schema], and

--- a/crates/oapi/docs/derive_to_schema.md
+++ b/crates/oapi/docs/derive_to_schema.md
@@ -10,7 +10,7 @@ not have any effect.
 You can use the Rust's own `#[deprecated]` attribute on any struct, enum or field to mark it as deprecated and it will
 reflect to the generated OpenAPI spec.
 
-`#[deprecated]` attribute supports adding additional details such as a reason and or since version but this is not supported in
+`#[deprecated]` attribute supports adding additional details such as a reason or the `since` version, but this is not supported in
 OpenAPI. OpenAPI has only a boolean flag to determine deprecation. While it is totally okay to declare deprecated with reason
 `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
 
@@ -112,7 +112,7 @@ enum Card {
 * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
   This is useful in cases where the default type does not correspond to the actual type e.g. when
   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-   Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
+   Value can be any Rust type that normally could be used to serialize to JSON or a custom type such as _`Object`_.
    _`Object`_ will be rendered as generic OpenAPI object _(`type: object`)_.
 * `name = ...` Literal string value. Can be used to define alternative path and name for the schema what will be used in
   the OpenAPI. E.g _`name = "path::to::Pet"`_. This would make the schema appear in the generated
@@ -146,7 +146,7 @@ enum Card {
 * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
   This is useful in cases where the default type does not correspond to the actual type e.g. when
   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-   Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
+   Value can be any Rust type that normally could be used to serialize to JSON or a custom type such as _`Object`_.
    _`Object`_ will be rendered as generic OpenAPI object _(`type: object`)_.
 * `inline` If the type of this field implements [`ToSchema`][to_schema], then the schema definition
   will be inlined. **warning:** Don't use this for recursive data types!

--- a/crates/oapi/docs/endpoint.md
+++ b/crates/oapi/docs/endpoint.md
@@ -5,7 +5,7 @@ Macro accepts set of attributes that can be used to configure and override defau
 You can use the Rust's own `#[deprecated]` attribute on functions to mark it as deprecated and it will
 reflect to the generated OpenAPI spec. Only **parameters** has a special **deprecated** attribute to define them as deprecated.
 
-`#[deprecated]` attribute supports adding additional details such as a reason and or since version but this is not supported in
+`#[deprecated]` attribute supports adding additional details such as a reason or the `since` version, but this is not supported in
 OpenAPI. OpenAPI has only a boolean flag to determine deprecation. While it is totally okay to declare deprecated with reason
 `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
 

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -70,7 +70,7 @@ extern crate self as salvo_oapi;
 ///
 /// Generated schemas can be referenced or reused in path operations.
 ///
-/// This trait is derivable and can be used with `[#derive]` attribute. For a details of
+/// This trait is derivable and can be used with the `#[derive]` attribute. For details of
 /// `#[derive(ToSchema)]` refer to [derive documentation][derive].
 ///
 /// [derive]: derive.ToSchema.html
@@ -89,7 +89,7 @@ extern crate self as salvo_oapi;
 /// }
 /// ```
 ///
-/// Following manual implementation is equal to above derive one.
+/// The following manual implementation is equivalent to the derived one above.
 /// ```
 /// use salvo_oapi::{Components, ToSchema, RefOr, Schema, SchemaFormat, BasicType, SchemaType, KnownFormat, Object};
 /// # struct Pet {

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -535,18 +535,18 @@ impl OpenApi {
         self
     }
 
-    /// Consusmes the [`OpenApi`] and returns [`Router`] with the [`OpenApi`] as handler.
+    /// Consumes the [`OpenApi`] and returns [`Router`] with the [`OpenApi`] as handler.
     pub fn into_router(self, path: impl Into<String>) -> Router {
         Router::with_path(path.into()).goal(self)
     }
 
-    /// Consusmes the [`OpenApi`] and information from a [`Router`].
+    /// Consumes the [`OpenApi`] and information from a [`Router`].
     #[must_use]
     pub fn merge_router(self, router: &Router) -> Self {
         self.merge_router_with_base(router, "/")
     }
 
-    /// Consusmes the [`OpenApi`] and information from a [`Router`] with base path.
+    /// Consumes the [`OpenApi`] and information from a [`Router`] with base path.
     #[must_use]
     pub fn merge_router_with_base(mut self, router: &Router, base: impl AsRef<str>) -> Self {
         let mut node = NormNode::new(router, Default::default());

--- a/crates/oapi/src/rapidoc.rs
+++ b/crates/oapi/src/rapidoc.rs
@@ -93,7 +93,7 @@ impl RapiDoc {
         self
     }
 
-    /// Consusmes the [`RapiDoc`] and returns [`Router`] with the [`RapiDoc`] as handler.
+    /// Consumes the [`RapiDoc`] and returns [`Router`] with the [`RapiDoc`] as handler.
     pub fn into_router(self, path: impl Into<String>) -> Router {
         Router::with_path(path.into()).goal(self)
     }

--- a/crates/oapi/src/redoc.rs
+++ b/crates/oapi/src/redoc.rs
@@ -45,7 +45,7 @@ const INDEX_TMPL: &str = r#"
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct ReDoc {
-    /// The title of the html page. The default title is "Scalar".
+    /// The title of the html page. The default title is "ReDoc".
     pub title: Cow<'static, str>,
     /// The version of the html page.
     pub keywords: Option<Cow<'static, str>>,
@@ -80,7 +80,7 @@ impl ReDoc {
         }
     }
 
-    /// Set title of the html page. The default title is "Scalar".
+    /// Set title of the html page. The default title is "ReDoc".
     #[must_use]
     pub fn title(mut self, title: impl Into<Cow<'static, str>>) -> Self {
         self.title = title.into();
@@ -108,7 +108,7 @@ impl ReDoc {
         self
     }
 
-    /// Consusmes the [`ReDoc`] and returns [`Router`] with the [`ReDoc`] as handler.
+    /// Consumes the [`ReDoc`] and returns [`Router`] with the [`ReDoc`] as handler.
     pub fn into_router(self, path: impl Into<String>) -> Router {
         Router::with_path(path.into()).goal(self)
     }

--- a/crates/oapi/src/scalar.rs
+++ b/crates/oapi/src/scalar.rs
@@ -104,7 +104,7 @@ impl Scalar {
         self
     }
 
-    /// Consusmes the [`Scalar`] and returns [`Router`] with the [`Scalar`] as handler.
+    /// Consumes the [`Scalar`] and returns [`Router`] with the [`Scalar`] as handler.
     pub fn into_router(self, path: impl Into<String>) -> Router {
         Router::with_path(path.into()).goal(self)
     }

--- a/crates/oapi/src/swagger_ui.rs
+++ b/crates/oapi/src/swagger_ui.rs
@@ -200,7 +200,7 @@ impl SwaggerUi {
         self
     }
 
-    /// Consusmes the [`SwaggerUi`] and returns [`Router`] with the [`SwaggerUi`] as handler.
+    /// Consumes the [`SwaggerUi`] and returns [`Router`] with the [`SwaggerUi`] as handler.
     pub fn into_router(self, path: impl Into<String>) -> Router {
         Router::with_path(format!("{}/{{**}}", path.into())).goal(self)
     }

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -164,7 +164,7 @@ where
     #[inline]
     #[must_use]
     pub fn new(store: S, secret: &[u8]) -> Self {
-        Self::try_new(store, secret).expect("secret key must be at least 32 bytes")
+        Self::try_new(store, secret).expect("secret key must be at least 64 bytes")
     }
 
     /// Try creating new `HandlerBuilder`


### PR DESCRIPTION
## What changed

- Fixed low-risk rustdoc and Markdown wording issues from the naming audit report.
- Corrected stale copy-paste docs for response headers, cookies, CSRF token storage, ReDoc defaults, and OAPI helpers.
- Fixed small low-risk naming/text issues: removed the empty `cookie_store<>` generic list, renamed HMAC helper parameters from `aead_key` to `hmac_key`, and aligned the session secret panic message with its 64-byte requirement.
- Cleaned up several typo and grammar issues in OAPI docs, UI router docs, path matcher messages, and middleware docs.

## Why

The audit found several public docs and error messages that were misleading, stale, or grammatically incorrect. These changes keep the public API behavior intact while improving generated documentation and diagnostics.

## Impact

No intended behavior change. The only source-level changes are low-risk parameter-name/text cleanup and removing an empty generic parameter list from `cookie_store`.

## Validation

- `cargo fmt --check`
- `cargo check -p salvo_core -p salvo-csrf -p salvo-session -p salvo-oapi --all-features`
- `cargo test -p salvo_core --doc --all-features`
- `cargo test -p salvo-oapi --doc --all-features`
- `typos --format brief` on changed files