### PR TITLE
Enable workspace lints for salvo-tus

### DIFF
--- a/crates/tus/Cargo.toml
+++ b/crates/tus/Cargo.toml
@@ -37,3 +37,6 @@ salvo_core    = { workspace = true, features = ["test"] }
 tempfile      = { workspace = true }
 tokio         = { workspace = true, features = ["rt", "macros", "time"] }
 tracing-test  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tus/src/error.rs
+++ b/crates/tus/src/error.rs
@@ -1,74 +1,105 @@
 use salvo_core::http::StatusCode;
 
+/// Result type used by the tus crate.
 pub type TusResult<T> = Result<T, TusError>;
 
+/// Protocol-level validation failures from tus requests.
 #[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
     #[error("missing tus-resumable")]
+    /// The required `Tus-Resumable` header is missing.
     MissingTusResumable,
     #[error("unsupported tus version: {0}")]
+    /// The request declares a tus version this crate does not support.
     UnsupportedTusVersion(String),
     #[error("missing header: {0}")]
+    /// A required header is missing.
     MissingHeader(&'static str),
     #[error("invalid integer header: {0}")]
+    /// A numeric header could not be parsed as an integer.
     InvalidInt(&'static str),
     #[error("invalid content-type")]
+    /// The request `Content-Type` is not valid for the current tus operation.
     InvalidContentType,
 
     #[error(
         "Concatenation extension is not (yet) supported. Disable parallel uploads in the tus client."
     )]
+    /// The request uses the unsupported concatenation extension.
     UnsupportedConcatenationExtension,
     #[error("creation-defer-length extension is not (yet) supported.")]
+    /// The request uses the unsupported creation-defer-length extension.
     UnsupportedCreationDeferLengthExtension,
     #[error("creation-with-upload extension is not (yet) supported.")]
+    /// The request uses the unsupported creation-with-upload extension.
     UnsupportedCreationWithUploadExtension,
     #[error("termination extension is not (yet) supported.")]
+    /// The request uses the unsupported termination extension.
     UnsupportedTerminationExtension,
     #[error("Upload-Length or Upload-Defer-Length header required.")]
+    /// The upload length was missing or otherwise invalid.
     InvalidLength,
     #[error(
         "Upload-Metadata is invalid. It MUST consist of one or more comma-separated key-value pairs. The key and value MUST be separated by a space. The key MUST NOT contain spaces and commas and MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST be Base64 encoded. All keys MUST be unique"
     )]
+    /// The `Upload-Metadata` header is not valid tus metadata.
     InvalidMetadata,
     #[error("Maximum size exceeded")]
+    /// The request exceeds the configured upload size limit.
     ErrMaxSizeExceeded,
 }
 
+/// Errors returned by tus request handling and storage operations.
 #[derive(Debug, thiserror::Error)]
 pub enum TusError {
     #[error(transparent)]
+    /// A tus protocol validation error.
     Protocol(#[from] ProtocolError),
 
     #[error("upload not found")]
+    /// The requested upload ID does not exist.
     NotFound,
 
     #[error("Upload-Offset conflict")]
+    /// The request offset is not valid for the current upload state.
     InvalidOffset,
 
     #[error("offset mismatch: expected {expected}, got {got}")]
-    OffsetMismatch { expected: u64, got: u64 },
+    /// The request offset differs from the stored upload offset.
+    OffsetMismatch {
+        /// Offset stored by the server.
+        expected: u64,
+        /// Offset supplied by the client.
+        got: u64,
+    },
 
     #[error("payload too large")]
+    /// The request body is larger than the allowed upload size.
     PayloadTooLarge,
 
     #[error("failed to generate upload id")]
+    /// The upload ID generator failed.
     GenerateIdError,
 
     #[error("failed to generate upload url, check your generate url function")]
+    /// The upload URL generator failed.
     GenerateUploadURLError,
 
     #[error("failed to get file id")]
+    /// The upload ID could not be extracted from the request.
     FileIdError,
 
     #[error("file no longer exists")]
+    /// The upload previously existed but is no longer available.
     FileNoLongerExists,
 
     #[error("internal: {0}")]
+    /// Internal error message.
     Internal(String),
 }
 
 impl TusError {
+    /// Maps this error to the HTTP status returned to the client.
     pub fn status(&self) -> StatusCode {
         match self {
             TusError::Protocol(ProtocolError::MissingTusResumable) => {

--- a/crates/tus/src/handlers/delete.rs
+++ b/crates/tus/src/handlers/delete.rs
@@ -72,6 +72,6 @@ async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 }
 
-pub fn delete_handler() -> Router {
+pub(crate) fn delete_handler() -> Router {
     Router::with_path("{id}").delete(delete)
 }

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -82,6 +82,6 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     res.send_file(storage.path, req.headers()).await;
 }
 
-pub fn get_handler() -> Router {
+pub(crate) fn get_handler() -> Router {
     Router::with_path("{id}").get(get)
 }

--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -132,6 +132,6 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 }
 
-pub fn head_handler() -> Router {
+pub(crate) fn head_handler() -> Router {
     Router::with_path("{id}").head(head)
 }

--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -10,12 +10,12 @@ use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
 use base64::Engine;
-pub use delete::delete_handler;
-pub use get::get_handler;
-pub use head::head_handler;
-pub use options::options_handler;
-pub use patch::patch_handler;
-pub use post::post_handler;
+pub(crate) use delete::delete_handler;
+pub(crate) use get::get_handler;
+pub(crate) use head::head_handler;
+pub(crate) use options::options_handler;
+pub(crate) use patch::patch_handler;
+pub(crate) use post::post_handler;
 use salvo_core::Request;
 use salvo_core::http::{HeaderMap, HeaderValue};
 
@@ -117,10 +117,15 @@ pub(crate) fn insert_joined_header(
     }
 }
 
+/// Parsed tus `Upload-Metadata` values.
 #[derive(Clone, Debug, Default)]
-pub struct Metadata(pub HashMap<String, Option<String>>);
+pub struct Metadata(
+    /// Parsed `Upload-Metadata` values keyed by metadata name.
+    pub HashMap<String, Option<String>>,
+);
 
 impl Metadata {
+    /// Parses a tus `Upload-Metadata` header value.
     pub fn parse_metadata(raw: &str) -> Result<Metadata, ProtocolError> {
         if raw.trim().is_empty() {
             return Err(ProtocolError::InvalidMetadata);
@@ -161,6 +166,7 @@ impl Metadata {
         Ok(Metadata(map))
     }
 
+    /// Serializes metadata into a tus `Upload-Metadata` header value.
     pub fn stringify(metadata: Metadata) -> String {
         metadata
             .0
@@ -212,18 +218,23 @@ impl DerefMut for Metadata {
     }
 }
 
+/// Context passed to a custom upload URL generator.
 #[derive(Clone, Copy, Debug)]
 pub struct GenerateUrlCtx<'a> {
+    /// Request protocol used for the generated URL.
     pub proto: &'a str,
+    /// Request host used for the generated URL.
     pub host: &'a str,
+    /// Base tus route path.
     pub path: &'a str,
+    /// Upload ID being linked.
     pub id: &'a str,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct HostProto<'a> {
-    pub proto: &'a str,
-    pub host: &'a str,
+pub(crate) struct HostProto<'a> {
+    pub(crate) proto: &'a str,
+    pub(crate) host: &'a str,
 }
 
 #[cfg(test)]

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -61,7 +61,7 @@ async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     res.status_code(StatusCode::NO_CONTENT);
 }
 
-pub fn options_handler() -> Router {
+pub(crate) fn options_handler() -> Router {
     Router::new()
         .options(options)
         .push(Router::with_path("{id}").options(options))

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -261,6 +261,6 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         .insert(H_UPLOAD_OFFSET, HeaderValue::from(new_offset));
 }
 
-pub fn patch_handler() -> Router {
+pub(crate) fn patch_handler() -> Router {
     Router::with_path("{id}").patch(patch)
 }

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -349,6 +349,6 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 }
 
-pub fn post_handler() -> Router {
+pub(crate) fn post_handler() -> Router {
     Router::new().post(create)
 }

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -87,10 +87,15 @@ use crate::utils::normalize_path;
 
 mod handlers;
 
+/// Error types returned by the tus implementation.
 pub mod error;
+/// Lock abstractions used to serialize upload access.
 pub mod lockers;
+/// Configuration types and hooks for [`Tus`].
 pub mod options;
+/// Storage abstractions and built-in storage backends.
 pub mod stores;
+/// Utility helpers for tus headers, paths, and upload IDs.
 pub mod utils;
 
 pub use error::{ProtocolError, TusError, TusResult};
@@ -100,52 +105,78 @@ pub use lockers::{LockGuard, Locker};
 use salvo_core::{Depot, Request, Router, handler};
 pub use stores::{ByteStream, DataStore, DiskStore, Extension, StoreInfo, UploadInfo};
 
+/// Supported tus protocol version.
 pub const TUS_VERSION: &str = "1.0.0";
+/// `Tus-Resumable` header name.
 pub const H_TUS_RESUMABLE: &str = "tus-resumable";
+/// `Tus-Version` header name.
 pub const H_TUS_VERSION: &str = "tus-version";
+/// `Tus-Extension` header name.
 pub const H_TUS_EXTENSION: &str = "tus-extension";
+/// `Tus-Max-Size` header name.
 pub const H_TUS_MAX_SIZE: &str = "tus-max-size";
 
+/// `Access-Control-Allow-Methods` header name.
 pub const H_ACCESS_CONTROL_ALLOW_METHODS: &str = "access-control-allow-methods";
+/// `Access-Control-Allow-Headers` header name.
 pub const H_ACCESS_CONTROL_ALLOW_HEADERS: &str = "access-control-allow-headers";
+/// `Access-Control-Request-Headers` header name.
 pub const H_ACCESS_CONTROL_REQUEST_HEADERS: &str = "access-control-request-headers";
+/// `Access-Control-Max-Age` header name.
 pub const H_ACCESS_CONTROL_MAX_AGE: &str = "access-control-max-age";
 
+/// `Upload-Length` header name.
 pub const H_UPLOAD_LENGTH: &str = "upload-length";
+/// `Upload-Offset` header name.
 pub const H_UPLOAD_OFFSET: &str = "upload-offset";
+/// `Upload-Metadata` header name.
 pub const H_UPLOAD_METADATA: &str = "upload-metadata";
+/// `Upload-Concat` header name.
 pub const H_UPLOAD_CONCAT: &str = "upload-concat";
+/// `Upload-Defer-Length` header name.
 pub const H_UPLOAD_DEFER_LENGTH: &str = "upload-defer-length";
+/// `Upload-Expires` header name.
 pub const H_UPLOAD_EXPIRES: &str = "upload-expires";
 
+/// `Content-Type` header name.
 pub const H_CONTENT_TYPE: &str = "content-type";
+/// `Content-Length` header name.
 pub const H_CONTENT_LENGTH: &str = "content-length";
+/// Content type for tus `PATCH` request bodies.
 pub const CT_OFFSET_OCTET_STREAM: &str = "application/offset+octet-stream";
 
+/// Reason a tus request was interrupted.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CancellationReason {
+    /// The request was aborted by the client or transport.
     Abort,
+    /// The request was cancelled by local control flow.
     Cancel,
 }
 
+/// Receiver side of a cancellation notification.
 #[derive(Clone, Debug)]
 pub struct CancellationSignal {
     receiver: watch::Receiver<Option<CancellationReason>>,
 }
 
 impl CancellationSignal {
+    /// Returns the current cancellation reason, if cancellation has happened.
     pub fn reason(&self) -> Option<CancellationReason> {
         *self.receiver.borrow()
     }
 
+    /// Returns `true` when this signal has been cancelled or aborted.
     pub fn is_cancelled(&self) -> bool {
         self.reason().is_some()
     }
 
+    /// Returns `true` when the signal was cancelled because the request aborted.
     pub fn is_aborted(&self) -> bool {
         matches!(self.reason(), Some(CancellationReason::Abort))
     }
 
+    /// Waits until cancellation is observed and returns its reason.
     pub async fn cancelled(&mut self) -> CancellationReason {
         loop {
             if let Some(reason) = *self.receiver.borrow() {
@@ -158,13 +189,16 @@ impl CancellationSignal {
     }
 }
 
+/// Shared cancellation state for a tus request.
 #[derive(Clone, Debug)]
 pub struct CancellationContext {
+    /// Signal observed by async operations that should stop when the request is cancelled.
     pub signal: CancellationSignal,
     sender: watch::Sender<Option<CancellationReason>>,
 }
 
 impl CancellationContext {
+    /// Creates a new cancellation context.
     pub fn new() -> Self {
         let (sender, receiver) = watch::channel(None);
         Self {
@@ -173,10 +207,12 @@ impl CancellationContext {
         }
     }
 
+    /// Marks the request as aborted.
     pub fn abort(&self) {
         let _ = self.sender.send(Some(CancellationReason::Abort));
     }
 
+    /// Marks the request as cancelled.
     pub fn cancel(&self) {
         let _ = self.sender.send(Some(CancellationReason::Cancel));
     }
@@ -200,10 +236,18 @@ impl TusStateHoop {
     }
 }
 
+/// Builder and router factory for tus resumable upload endpoints.
 #[derive(Clone)]
 pub struct Tus {
     options: TusOptions,
     store: Arc<dyn DataStore>,
+}
+impl std::fmt::Debug for Tus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tus")
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
 }
 impl Default for Tus {
     fn default() -> Self {
@@ -213,6 +257,7 @@ impl Default for Tus {
 
 // Tus service Configuration
 impl Tus {
+    /// Creates a tus service with default options and a [`DiskStore`].
     pub fn new() -> Self {
         Self {
             options: TusOptions::default(),
@@ -220,26 +265,31 @@ impl Tus {
         }
     }
 
+    /// Sets the route path where tus endpoints are mounted.
     pub fn path(mut self, path: impl Into<String>) -> Self {
         self.options.path = path.into();
         self
     }
 
+    /// Sets the maximum upload size policy.
     pub fn max_size(mut self, max_size: MaxSize) -> Self {
         self.options.max_size = Some(max_size);
         self
     }
 
+    /// Controls whether generated `Location` headers use relative URLs.
     pub fn relative_location(mut self, yes: bool) -> Self {
         self.options.relative_location = yes;
         self
     }
 
+    /// Sets the trusted origin used for absolute `Location` headers.
     pub fn canonical_origin(mut self, origin: impl Into<String>) -> Self {
         self.options.canonical_origin = Some(origin.into());
         self
     }
 
+    /// Sets the allowed CORS origins for tus responses.
     pub fn allowed_origins<I, S>(mut self, origins: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -249,6 +299,7 @@ impl Tus {
         self
     }
 
+    /// Adds extra request headers accepted by CORS preflight responses.
     pub fn allowed_headers<I, S>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -258,6 +309,7 @@ impl Tus {
         self
     }
 
+    /// Adds extra response headers exposed to browsers by CORS.
     pub fn exposed_headers<I, S>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -267,6 +319,7 @@ impl Tus {
         self
     }
 
+    /// Controls whether CORS responses allow credentials.
     pub fn allow_credentials(mut self, yes: bool) -> Self {
         self.options.allowed_credentials = yes;
         self
@@ -302,6 +355,7 @@ impl Tus {
         self
     }
 
+    /// Builds the Salvo router that serves the configured tus endpoints.
     pub fn into_router(self) -> Router {
         let base_path = normalize_path(&self.options.path);
         if !self.options.relative_location && self.options.canonical_origin.is_none() {

--- a/crates/tus/src/lockers/memory_locker.rs
+++ b/crates/tus/src/lockers/memory_locker.rs
@@ -7,7 +7,8 @@ use tokio::sync::{Mutex, RwLock};
 use crate::error::TusResult;
 use crate::lockers::{LockGuard, Locker};
 
-#[derive(Clone)]
+/// In-memory [`Locker`] implementation backed by Tokio locks.
+#[derive(Clone, Debug)]
 pub struct MemoryLocker {
     inner: Arc<Mutex<HashMap<String, Arc<RwLock<()>>>>>,
 }
@@ -19,6 +20,7 @@ impl Default for MemoryLocker {
 }
 
 impl MemoryLocker {
+    /// Creates an empty in-memory locker.
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/tus/src/lockers/mod.rs
+++ b/crates/tus/src/lockers/mod.rs
@@ -1,23 +1,35 @@
 use salvo_core::async_trait;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard};
 
+/// In-memory upload locker.
 pub mod memory_locker;
 
 use crate::error::TusResult;
 
+/// Lock provider used to serialize access to an upload ID.
 #[async_trait]
 pub trait Locker: Send + Sync + 'static {
+    /// Acquires an exclusive lock for `id`.
     async fn lock(&self, id: &str) -> TusResult<LockGuard>;
+    /// Acquires a shared read lock for `id`.
     async fn read_lock(&self, id: &str) -> TusResult<LockGuard> {
         self.lock(id).await
     }
+    /// Acquires an exclusive write lock for `id`.
     async fn write_lock(&self, id: &str) -> TusResult<LockGuard> {
         self.lock(id).await
     }
 }
 
+/// RAII guard that keeps an upload lock held until it is dropped.
 pub struct LockGuard {
     _guard: LockGuardInner,
+}
+
+impl std::fmt::Debug for LockGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LockGuard").finish_non_exhaustive()
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
@@ -13,20 +14,35 @@ use crate::lockers::{LockGuard, Locker, memory_locker};
 use crate::stores::UploadInfo;
 use crate::utils::is_safe_upload_id;
 
+/// Optional tus upload ID passed to size and URL callbacks.
 pub type UploadId = Option<String>;
 
 static RE_FILE_ID: OnceLock<Regex> = OnceLock::new();
+/// Returns the regex used to extract an upload ID from a request path.
 pub fn file_id_regex() -> &'static Regex {
     RE_FILE_ID.get_or_init(|| Regex::new(r"([^/]+)/?$").expect("Invalid regex pattern"))
 }
 
+/// Maximum allowed upload size policy.
 #[derive(Clone)]
 pub enum MaxSize {
+    /// Fixed maximum number of bytes accepted for an upload.
     Fixed(u64),
+    /// Callback that computes the maximum number of bytes for each request.
     #[allow(clippy::type_complexity)]
     Dynamic(Arc<dyn Fn(&Request, UploadId) -> BoxFuture<'static, u64> + Send + Sync>),
 }
 
+impl fmt::Debug for MaxSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fixed(size) => f.debug_tuple("Fixed").field(size).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<callback>").finish(),
+        }
+    }
+}
+
+/// Callback used to generate a new tus upload ID.
 pub type NamingFunction = Arc<
     dyn Fn(
             &Request,
@@ -35,11 +51,14 @@ pub type NamingFunction = Arc<
         + Send
         + Sync,
 >;
+/// Callback used to generate the `Location` URL for a created upload.
 pub type GenerateUrlFunction =
     Arc<dyn Fn(&Request, GenerateUrlCtx) -> Result<String, TusError> + Send + Sync>;
 
+/// Hook invoked at the start of each tus request with the resolved upload ID.
 pub type OnIncomingRequest =
     Arc<dyn Fn(&Request, String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+/// Hook invoked before a new upload is persisted.
 pub type OnUploadCreate = Arc<
     dyn Fn(
             &Request,
@@ -48,6 +67,7 @@ pub type OnUploadCreate = Arc<
         + Send
         + Sync,
 >;
+/// Hook invoked after an upload reaches completion.
 pub type OnUploadFinish = Arc<
     dyn Fn(
             &Request,
@@ -57,17 +77,25 @@ pub type OnUploadFinish = Arc<
         + Sync,
 >;
 
+/// Changes that an upload-create hook can apply to a newly created upload.
 #[derive(Clone, Debug, Default)]
 pub struct UploadPatch {
+    /// Replacement metadata to store for the upload.
     pub metadata: Option<Metadata>,
 }
 
+/// Custom response returned by an upload-finish hook.
 #[derive(Clone, Debug, Default)]
 pub struct UploadFinishPatch {
+    /// HTTP status code to return.
     pub status_code: Option<StatusCode>,
+    /// Additional response headers to return.
     pub headers: Option<HeaderMap>,
+    /// Response body bytes to return.
     pub body: Option<Vec<u8>>,
 }
+
+/// Configuration shared by all tus route handlers.
 #[derive(Clone)]
 pub struct TusOptions {
     /// The route to accept requests.
@@ -82,45 +110,89 @@ pub struct TusOptions {
     /// Canonical origin used for absolute `Location` headers.
     pub canonical_origin: Option<String>,
 
-    /// Allow forwarded headers override Location
+    /// Allows trusted forwarded headers to override the host and protocol used for `Location`.
     pub respect_forwarded_headers: bool,
 
-    /// Additional headers sent in Access-Control-Allow-Headers
+    /// Additional headers sent in `Access-Control-Allow-Headers`.
     pub allowed_headers: Vec<String>,
 
-    /// Additional headers sent in Access-Control-Expose-Headers
+    /// Additional headers sent in `Access-Control-Expose-Headers`.
     pub exposed_headers: Vec<String>,
 
-    /// Set Access-Control-Allow-Credentials
+    /// Whether to set `Access-Control-Allow-Credentials`.
     pub allowed_credentials: bool,
 
-    /// Trusted origins for Access-Control-Allow-Origin
+    /// Trusted origins for `Access-Control-Allow-Origin`.
     pub allowed_origins: Vec<String>,
 
-    /// Interval in milliseconds for sending progress
+    /// Interval in milliseconds for sending receive progress notifications.
     pub post_receive_interval: Option<u64>,
 
-    /// The Lock interface / provider (required)
+    /// Lock provider used to serialize access to the same upload.
     pub locker: Arc<dyn Locker>,
 
-    /// Lock cleanup timeout
+    /// Lock cleanup timeout in milliseconds.
     pub lock_drain_timeout: Option<u64>,
 
     /// Disallow termination for finished uploads
     pub disable_termination_for_finished_uploads: bool,
 
-    /// Function to generate upload IDs
+    /// Function to generate upload IDs.
     pub upload_id_naming_function: NamingFunction,
 
     /// Function to generate the upload URL.
     pub generate_url_function: Option<GenerateUrlFunction>,
 
+    /// Optional hook invoked at the start of each tus request.
     pub on_incoming_request: Option<OnIncomingRequest>,
+    /// Optional hook invoked when a new upload is created.
     pub on_upload_create: Option<OnUploadCreate>,
+    /// Optional hook invoked when an upload is completed.
     pub on_upload_finish: Option<OnUploadFinish>,
 }
 
+impl fmt::Debug for TusOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TusOptions")
+            .field("path", &self.path)
+            .field("max_size", &self.max_size)
+            .field("relative_location", &self.relative_location)
+            .field("canonical_origin", &self.canonical_origin)
+            .field("respect_forwarded_headers", &self.respect_forwarded_headers)
+            .field("allowed_headers", &self.allowed_headers)
+            .field("exposed_headers", &self.exposed_headers)
+            .field("allowed_credentials", &self.allowed_credentials)
+            .field("allowed_origins", &self.allowed_origins)
+            .field("post_receive_interval", &self.post_receive_interval)
+            .field("locker", &"<locker>")
+            .field("lock_drain_timeout", &self.lock_drain_timeout)
+            .field(
+                "disable_termination_for_finished_uploads",
+                &self.disable_termination_for_finished_uploads,
+            )
+            .field("upload_id_naming_function", &"<callback>")
+            .field(
+                "generate_url_function",
+                &self.generate_url_function.as_ref().map(|_| "<callback>"),
+            )
+            .field(
+                "on_incoming_request",
+                &self.on_incoming_request.as_ref().map(|_| "<callback>"),
+            )
+            .field(
+                "on_upload_create",
+                &self.on_upload_create.as_ref().map(|_| "<callback>"),
+            )
+            .field(
+                "on_upload_finish",
+                &self.on_upload_finish.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
+    }
+}
+
 impl TusOptions {
+    /// Acquires a write lock for the given upload ID.
     pub async fn acquire_lock(
         &self,
         _req: &Request,
@@ -130,6 +202,7 @@ impl TusOptions {
         self.acquire_write_lock(_req, upload_id, context).await
     }
 
+    /// Acquires a read lock for the given upload ID.
     pub async fn acquire_read_lock(
         &self,
         _req: &Request,
@@ -143,6 +216,7 @@ impl TusOptions {
         }
     }
 
+    /// Acquires a write lock for the given upload ID.
     pub async fn acquire_write_lock(
         &self,
         _req: &Request,
@@ -156,6 +230,7 @@ impl TusOptions {
         }
     }
 
+    /// Extracts and validates the upload ID from the request path.
     pub fn extract_file_id_from_request(&self, req: &Request) -> TusResult<String> {
         let path = req.uri().path();
         let re = file_id_regex();
@@ -167,6 +242,7 @@ impl TusOptions {
             .ok_or(TusError::FileIdError)
     }
 
+    /// Returns the configured maximum upload size for this request.
     pub async fn get_configured_max_size(&self, req: &Request, upload_id: Option<String>) -> u64 {
         match &self.max_size {
             Some(MaxSize::Fixed(size)) => *size,
@@ -178,6 +254,7 @@ impl TusOptions {
         }
     }
 
+    /// Generates the upload URL returned in the `Location` header.
     pub fn generate_upload_url(
         &self,
         req: &mut Request,

--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -77,7 +77,8 @@ impl From<MetaUpload> for UploadInfo {
     }
 }
 
-#[derive(Clone)]
+/// Disk-backed storage for tus uploads.
+#[derive(Debug, Clone)]
 pub struct DiskStore {
     root: PathBuf,
 }
@@ -89,6 +90,7 @@ impl Default for DiskStore {
 }
 
 impl DiskStore {
+    /// Creates a disk store rooted at `./tus-upload-files`.
     pub fn new() -> Self {
         Self {
             root: "./tus-upload-files".into(),

--- a/crates/tus/src/stores/mod.rs
+++ b/crates/tus/src/stores/mod.rs
@@ -15,6 +15,7 @@ use salvo_core::http::HeaderValue;
 use crate::error::{TusError, TusResult};
 use crate::handlers::Metadata;
 
+/// Async byte stream consumed by storage backends when writing upload chunks.
 pub type ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static>>;
 const UPLOAD_SIZE_LIMIT_EXCEEDED: &str = "tus upload size limit exceeded";
 
@@ -56,39 +57,59 @@ fn limit_stream(
 //     Disk,
 // }
 
+/// Storage location metadata for an upload.
 #[derive(Debug, Clone)]
 pub struct StoreInfo {
+    /// Storage backend type name, such as `file`.
     pub type_name: String,
+    /// Backend-specific path or object key for the upload.
     pub path: String,
+    /// Optional storage bucket name for object-storage backends.
     pub bucket: Option<String>,
 }
+/// Metadata describing a tus upload.
 #[derive(Debug, Clone)]
 pub struct UploadInfo {
+    /// Upload ID.
     pub id: String,
+    /// Total upload size, or `None` when the client deferred the length.
     pub size: Option<u64>,
+    /// Current upload offset in bytes.
     pub offset: Option<u64>,
+    /// Optional tus `Upload-Metadata` values.
     pub metadata: Option<Metadata>,
+    /// Storage location for the upload data.
     pub storage: Option<StoreInfo>,
+    /// Upload creation timestamp.
     pub creation_date: String,
 }
 
 impl UploadInfo {
+    /// Returns `true` when the upload length has not been declared yet.
     pub fn is_size_deferred(&self) -> bool {
         self.size.is_none()
     }
 }
 
+/// Tus protocol extension advertised by a storage backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Extension {
+    /// Upload creation extension.
     Creation,
+    /// Upload expiration extension.
     Expiration,
+    /// Creation-with-upload extension.
     CreationWithUpload,
+    /// Creation-defer-length extension.
     CreationDeferLength,
+    /// Concatenation extension.
     Concatenation,
+    /// Termination extension.
     Termination,
 }
 
 impl Extension {
+    /// Returns the tus header token for this extension.
     pub fn as_str(&self) -> &'static str {
         match self {
             Extension::Creation => "creation",
@@ -100,6 +121,7 @@ impl Extension {
         }
     }
 
+    /// Converts a set of extensions into a `Tus-Extension` header value.
     pub fn to_header_value(extensions: &HashSet<Extension>) -> Option<HeaderValue> {
         if extensions.is_empty() {
             return None;
@@ -123,17 +145,23 @@ impl Extension {
 /// responding with the Tus-Extension header. See more details: https://tus.io/protocols/resumable-upload#protocol-extensions
 #[async_trait]
 pub trait DataStore: Send + Sync + 'static {
+    /// Returns the tus extensions supported by this storage backend.
     fn extensions(&self) -> HashSet<Extension> {
         HashSet::new()
     }
 
+    /// Returns `true` when this backend supports `ext`.
     fn has_extension(&self, ext: Extension) -> bool {
         self.extensions().contains(&ext)
     }
 
+    /// Creates metadata and storage for a new upload.
     async fn create(&self, file: UploadInfo) -> TusResult<UploadInfo>;
+    /// Removes an upload and its metadata.
     async fn remove(&self, id: &str) -> TusResult<()>;
+    /// Writes a chunk stream at `offset` and returns the number of bytes written.
     async fn write(&self, id: &str, offset: u64, stream: ByteStream) -> TusResult<u64>;
+    /// Writes a chunk stream while enforcing an optional maximum byte count.
     async fn write_limited(
         &self,
         id: &str,
@@ -148,12 +176,16 @@ pub trait DataStore: Send + Sync + 'static {
             result => result,
         }
     }
+    /// Returns metadata for an existing upload.
     async fn get_upload_file_info(&self, id: &str) -> TusResult<UploadInfo>;
+    /// Declares the final upload length for an upload created with deferred length.
     async fn declare_upload_length(&self, id: &str, length: u64) -> TusResult<()>;
 
+    /// Deletes expired uploads and returns the number of removed uploads.
     async fn delete_expired(&self) -> TusResult<u32> {
         Ok(0)
     }
+    /// Returns the upload expiration duration configured by this backend.
     fn get_expiration(&self) -> Option<std::time::Duration> {
         None
     }

--- a/crates/tus/src/stores/mod.rs
+++ b/crates/tus/src/stores/mod.rs
@@ -139,10 +139,12 @@ impl Extension {
 
 /// Store-supported tus protocol extensions.
 ///
-/// The default extension set is empty.
-/// Clients and Servers are encouraged to implement as many of the extensions as possible.
-/// Feature detection SHOULD be achieved by the Client sending an OPTIONS request and the Server
-/// responding with the Tus-Extension header. See more details: https://tus.io/protocols/resumable-upload#protocol-extensions
+/// The default extension set is empty. Clients and servers are encouraged to
+/// implement as many extensions as possible. Feature detection should use an
+/// `OPTIONS` request and a `Tus-Extension` response header.
+///
+/// See the tus protocol extension docs:
+/// <https://tus.io/protocols/resumable-upload#protocol-extensions>
 #[async_trait]
 pub trait DataStore: Send + Sync + 'static {
     /// Returns the tus extensions supported by this storage backend.

--- a/crates/tus/src/utils.rs
+++ b/crates/tus/src/utils.rs
@@ -3,6 +3,7 @@ use salvo_core::http::HeaderValue;
 use crate::TUS_VERSION;
 use crate::error::ProtocolError;
 
+/// Validates a `Tus-Resumable` header value.
 pub fn check_tus_version(v: Option<&str>) -> Result<(), ProtocolError> {
     let v = v.ok_or(ProtocolError::MissingTusResumable)?;
     if v != TUS_VERSION {
@@ -11,12 +12,14 @@ pub fn check_tus_version(v: Option<&str>) -> Result<(), ProtocolError> {
     Ok(())
 }
 
+/// Parses a required unsigned integer header.
 pub fn parse_u64(v: Option<&str>, name: &'static str) -> Result<u64, ProtocolError> {
     let s = v.ok_or(ProtocolError::MissingHeader(name))?;
     s.parse::<u64>()
         .map_err(|_| ProtocolError::InvalidInt(name))
 }
 
+/// Normalizes a route path to start with `/` and omit trailing slashes.
 pub fn normalize_path(p: &str) -> String {
     if p.is_empty() {
         return "/".to_owned();
@@ -76,6 +79,7 @@ pub fn sanitize_path_component(component: &str) -> Option<&str> {
     Some(component)
 }
 
+/// Returns `true` when `value` matches the expected header value.
 pub fn validate_header(name: &'static str, value: Option<&HeaderValue>) -> bool {
     match value {
         Some(v) => {


### PR DESCRIPTION
## What changed

- Added `[lints] workspace = true` to `crates/tus/Cargo.toml`.
- Added rustdoc for `salvo-tus` public modules, constants, types, fields, callbacks, and public methods that became covered by workspace `missing_docs`.
- Added `Debug` coverage for public tus types that were missing it, using manual implementations where callback or trait-object fields cannot derive `Debug`.
- Reduced private tus handler route helpers and `HostProto` from `pub` to `pub(crate)` to satisfy workspace `unreachable_pub`.

## Why

`salvo-tus` was not inheriting the workspace lint policy, so missing public docs and unreachable public items were not visible during normal checks. This brings it under the same governance as the rest of the workspace while keeping the public tus API behavior intact.

## Notes

I did not raise workspace `missing_docs` from `warn` to `deny` in this PR. After these changes, `salvo-tus` passes workspace rust lints cleanly, so that can be considered separately.

## Validation

- `cargo check -p salvo-tus --all-features`
- `cargo check -p salvo-tus --all-features --all-targets`
- `cargo check --all --bins --examples --tests`
- `cargo test -p salvo-tus --all-features`
- `cargo test -p salvo-tus --doc --all-features`
- `cargo fmt --check`
- `cargo +nightly fmt --package salvo-tus -- --check`
- `typos --format brief crates/tus/Cargo.toml crates/tus/src`
- `git diff --check`