### PR TITLE
Add clearer response render API

### DIFF
--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -177,9 +177,9 @@ pub trait Handler: Send + Sync + 'static {
         ArcHandler(Arc::new(self))
     }
 
-    /// Wrap to `HoopedHandler`.
+    /// Wraps this handler in a [`HoopedHandler`].
     #[inline]
-    fn hooped<H: Handler>(self) -> HoopedHandler
+    fn hooped(self) -> HoopedHandler
     where
         Self: Sized,
     {
@@ -484,5 +484,16 @@ mod tests {
             .await;
         assert_eq!(res.status_code, Some(StatusCode::OK));
         assert_eq!(res.take_string().await.unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_hooped_handler_without_type_parameter() {
+        #[handler]
+        async fn hello(res: &mut Response) {
+            res.status_code(StatusCode::OK);
+            res.render("hello");
+        }
+
+        let _handler: HoopedHandler = hello.hooped();
     }
 }

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -395,7 +395,8 @@ impl Response {
     ///
     /// let mut res = Response::new();
     /// assert_eq!(None, res.content_type());
-    /// res.headers_mut().insert("content-type", "text/plain".parse().unwrap());
+    /// res.headers_mut()
+    ///     .insert("content-type", "text/plain".parse().unwrap());
     /// assert_eq!(Some(mime::TEXT_PLAIN), res.content_type());
     /// ```
     #[inline]
@@ -445,14 +446,24 @@ impl Response {
         scribe.render(self);
     }
 
-    /// Render content with status code.
+    /// Sets the status code and renders content into this response.
     #[inline]
-    pub fn stuff<P>(&mut self, code: StatusCode, scribe: P)
+    pub fn render_with_status<P>(&mut self, code: StatusCode, scribe: P)
     where
         P: Scribe,
     {
         self.status_code = Some(code);
         scribe.render(self);
+    }
+
+    /// Sets the status code and renders content into this response.
+    #[deprecated(since = "0.94.0", note = "use `Response::render_with_status` instead")]
+    #[inline]
+    pub fn stuff<P>(&mut self, code: StatusCode, scribe: P)
+    where
+        P: Scribe,
+    {
+        self.render_with_status(code, scribe);
     }
 
     /// Attempts to send a file. If file not exists, not found error will occur.
@@ -622,6 +633,20 @@ mod test {
         }
 
         assert_eq!("Hello World", &result)
+    }
+
+    #[test]
+    fn test_render_with_status_sets_status_and_body() {
+        let mut res = Response::new();
+        res.render_with_status(StatusCode::CREATED, "created");
+
+        assert_eq!(res.status_code, Some(StatusCode::CREATED));
+        let content_type = res.content_type().expect("content type");
+        assert_eq!(content_type.essence_str(), "text/plain");
+        match res.take_body() {
+            ResBody::Once(bytes) => assert_eq!(bytes, Bytes::from_static(b"created")),
+            body => panic!("expected once body, got {body:?}"),
+        }
     }
 
     #[cfg(feature = "cookie")]


### PR DESCRIPTION
## What changed

- Removed the unused generic parameter from `Handler::hooped`.
- Added `Response::render_with_status` to clearly express setting a status code and rendering a body.
- Kept `Response::stuff` as a deprecated transition alias to preserve compatibility.
- Added focused tests for the updated handler helper and response rendering API.

## Validation

- `cargo fmt`
- `cargo check -p salvo_core --all-features`
- `cargo test -p salvo_core --all-features`
- `cargo test -p salvo_core --doc --all-features`
- `cargo +nightly fmt --package salvo_core -- --check`
- `typos --format brief crates/core/src/handler.rs crates/core/src/http/response.rs`
- `git diff --check`