### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1033,9 +1033,8 @@ mod tests {
     #[test]
     fn in_flight_limit_bypasses_new_keys_when_full() {
         let in_flight = Arc::new(InFlight::new(1));
-        let first = match in_flight.enter("a") {
-            FlightPermit::Leader(guard) => guard,
-            _ => panic!("first key should lead an in-flight request"),
+        let FlightPermit::Leader(first) = in_flight.enter("a") else {
+            panic!("first key should lead an in-flight request");
         };
 
         assert!(matches!(in_flight.enter("a"), FlightPermit::Follower(_)));

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -171,6 +171,17 @@ impl ConstDecoder {
     }
 }
 
+impl JwtAuthDecoder for ConstDecoder {
+    type Error = JwtError;
+
+    async fn decode<C>(&self, token: &str, _depot: &mut Depot) -> Result<TokenData<C>, Self::Error>
+    where
+        C: for<'de> Deserialize<'de> + Clone,
+    {
+        decode::<C>(token, &self.decoding_key, &self.validation)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -180,16 +191,5 @@ mod tests {
         let decoder = ConstDecoder::from_rsa_raw_components(&[1, 2, 3], &[1, 0, 1]);
 
         assert_eq!(decoder.validation.algorithms, [Algorithm::RS256]);
-    }
-}
-
-impl JwtAuthDecoder for ConstDecoder {
-    type Error = JwtError;
-
-    async fn decode<C>(&self, token: &str, _depot: &mut Depot) -> Result<TokenData<C>, Self::Error>
-    where
-        C: for<'de> Deserialize<'de> + Clone,
-    {
-        decode::<C>(token, &self.decoding_key, &self.validation)
     }
 }

--- a/crates/tus/src/error.rs
+++ b/crates/tus/src/error.rs
@@ -100,44 +100,41 @@ pub enum TusError {
 
 impl TusError {
     /// Maps this error to the HTTP status returned to the client.
+    #[must_use]
     pub fn status(&self) -> StatusCode {
         match self {
-            TusError::Protocol(ProtocolError::MissingTusResumable) => {
+            Self::Protocol(ProtocolError::MissingTusResumable) => StatusCode::PRECONDITION_FAILED, /* 412 */
+            Self::Protocol(ProtocolError::UnsupportedTusVersion(_)) => {
                 StatusCode::PRECONDITION_FAILED
-            } // 412
-            TusError::Protocol(ProtocolError::UnsupportedTusVersion(_)) => {
-                StatusCode::PRECONDITION_FAILED
-            } // 412
+            } /* 412 */
 
-            TusError::Protocol(ProtocolError::UnsupportedConcatenationExtension) => {
+            Self::Protocol(ProtocolError::UnsupportedConcatenationExtension) => {
                 StatusCode::NOT_IMPLEMENTED
             } // 501
-            TusError::Protocol(ProtocolError::UnsupportedCreationDeferLengthExtension) => {
+            Self::Protocol(ProtocolError::UnsupportedCreationDeferLengthExtension) => {
                 StatusCode::NOT_IMPLEMENTED
             } // 501
-            TusError::Protocol(ProtocolError::UnsupportedCreationWithUploadExtension) => {
+            Self::Protocol(ProtocolError::UnsupportedCreationWithUploadExtension) => {
                 StatusCode::NOT_IMPLEMENTED
             } // 501
-            TusError::Protocol(ProtocolError::UnsupportedTerminationExtension) => {
+            Self::Protocol(ProtocolError::UnsupportedTerminationExtension) => {
                 StatusCode::NOT_IMPLEMENTED
             } // 501
-            TusError::Protocol(ProtocolError::InvalidLength) => StatusCode::BAD_REQUEST, // 400
-            TusError::Protocol(ProtocolError::InvalidMetadata) => StatusCode::BAD_REQUEST, // 400
-            TusError::Protocol(ProtocolError::ErrMaxSizeExceeded) => StatusCode::PAYLOAD_TOO_LARGE, /* 413 */
-            TusError::Protocol(ProtocolError::InvalidContentType) => {
-                StatusCode::UNSUPPORTED_MEDIA_TYPE
-            } /* 415 */
-            TusError::Protocol(_) => StatusCode::BAD_REQUEST, // 400
+            Self::Protocol(ProtocolError::InvalidLength) => StatusCode::BAD_REQUEST, // 400
+            Self::Protocol(ProtocolError::InvalidMetadata) => StatusCode::BAD_REQUEST, // 400
+            Self::Protocol(ProtocolError::ErrMaxSizeExceeded) => StatusCode::PAYLOAD_TOO_LARGE, /* 413 */
+            Self::Protocol(ProtocolError::InvalidContentType) => StatusCode::UNSUPPORTED_MEDIA_TYPE, /* 415 */
+            Self::Protocol(_) => StatusCode::BAD_REQUEST, // 400
 
-            TusError::FileNoLongerExists => StatusCode::GONE, // 410
-            TusError::FileIdError => StatusCode::BAD_REQUEST, // 400
-            TusError::NotFound => StatusCode::NOT_FOUND,
-            TusError::OffsetMismatch { .. } => StatusCode::CONFLICT, // 409
-            TusError::InvalidOffset => StatusCode::CONFLICT,         // 409
-            TusError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE, // 413
-            TusError::GenerateIdError => StatusCode::INTERNAL_SERVER_ERROR, // 500
-            TusError::GenerateUploadURLError => StatusCode::INTERNAL_SERVER_ERROR, // 500
-            TusError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::FileNoLongerExists => StatusCode::GONE, // 410
+            Self::FileIdError => StatusCode::BAD_REQUEST, // 400
+            Self::NotFound => StatusCode::NOT_FOUND,
+            Self::OffsetMismatch { .. } => StatusCode::CONFLICT, // 409
+            Self::InvalidOffset => StatusCode::CONFLICT,         // 409
+            Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE, // 413
+            Self::GenerateIdError => StatusCode::INTERNAL_SERVER_ERROR, // 500
+            Self::GenerateUploadURLError => StatusCode::INTERNAL_SERVER_ERROR, // 500
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -59,13 +59,10 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             }
         };
 
-        let storage = match info.storage {
-            Some(storage) => storage,
-            None => {
-                res.status_code =
-                    Some(TusError::Internal("upload storage info missing".into()).status());
-                return;
-            }
+        let Some(storage) = info.storage else {
+            res.status_code =
+                Some(TusError::Internal("upload storage info missing".into()).status());
+            return;
         };
 
         if storage.type_name != "file" {

--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -104,17 +104,13 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     if let Some(metadata) = upload_info.metadata {
-        match HeaderValue::from_str(&Metadata::stringify(metadata)) {
-            Ok(v) => {
-                headers.insert("Upload-Metadata", v);
-            }
-            Err(_) => {
-                res.status_code = Some(
-                    TusError::Internal("Stored Upload-Metadata is not a valid header".into())
-                        .status(),
-                );
-                return;
-            }
+        if let Ok(v) = HeaderValue::from_str(&Metadata::stringify(metadata)) {
+            headers.insert("Upload-Metadata", v);
+        } else {
+            res.status_code = Some(
+                TusError::Internal("Stored Upload-Metadata is not a valid header".into()).status(),
+            );
+            return;
         }
     }
 

--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -126,7 +126,7 @@ pub struct Metadata(
 
 impl Metadata {
     /// Parses a tus `Upload-Metadata` header value.
-    pub fn parse_metadata(raw: &str) -> Result<Metadata, ProtocolError> {
+    pub fn parse_metadata(raw: &str) -> Result<Self, ProtocolError> {
         if raw.trim().is_empty() {
             return Err(ProtocolError::InvalidMetadata);
         }
@@ -163,11 +163,12 @@ impl Metadata {
             map.insert(key.to_owned(), Some(decoded_value));
         }
 
-        Ok(Metadata(map))
+        Ok(Self(map))
     }
 
     /// Serializes metadata into a tus `Upload-Metadata` header value.
-    pub fn stringify(metadata: Metadata) -> String {
+    #[must_use]
+    pub fn stringify(metadata: Self) -> String {
         metadata
             .0
             .iter()
@@ -175,7 +176,7 @@ impl Metadata {
                 Some(value) => {
                     let encoded =
                         base64::engine::general_purpose::STANDARD.encode(value.as_bytes());
-                    format!("{} {}", key, encoded)
+                    format!("{key} {encoded}")
                 }
                 None => key.to_owned(),
             })

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -70,7 +70,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         on_incoming_request(req, id.clone()).await;
     }
 
-    let max_file_size = opts.get_configured_max_size(req, Some(id.to_owned())).await;
+    let max_file_size = opts.get_configured_max_size(req, Some(id.clone())).await;
     let _lock = match opts
         .acquire_write_lock(req, &id, CancellationContext::new())
         .await
@@ -133,19 +133,18 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     if let Some(raw_length) = req.headers().get(H_UPLOAD_LENGTH) {
-        let size = match raw_length.to_str() {
-            Ok(value) => match parse_u64(Some(value), H_UPLOAD_LENGTH) {
+        let size = if let Ok(value) = raw_length.to_str() {
+            match parse_u64(Some(value), H_UPLOAD_LENGTH) {
                 Ok(size) => size,
                 Err(e) => {
                     res.status_code = Some(TusError::Protocol(e).status());
                     return;
                 }
-            },
-            Err(_) => {
-                res.status_code =
-                    Some(TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status());
-                return;
             }
+        } else {
+            res.status_code =
+                Some(TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status());
+            return;
         };
 
         if !store.has_extension(Extension::CreationDeferLength) {
@@ -176,20 +175,21 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     let content_length = match req.headers().get(H_CONTENT_LENGTH) {
-        Some(value) => match value.to_str() {
-            Ok(v) => match parse_u64(Some(v), H_CONTENT_LENGTH) {
-                Ok(size) => Some(size),
-                Err(e) => {
-                    res.status_code = Some(TusError::Protocol(e).status());
-                    return;
+        Some(value) => {
+            if let Ok(v) = value.to_str() {
+                match parse_u64(Some(v), H_CONTENT_LENGTH) {
+                    Ok(size) => Some(size),
+                    Err(e) => {
+                        res.status_code = Some(TusError::Protocol(e).status());
+                        return;
+                    }
                 }
-            },
-            Err(_) => {
+            } else {
                 res.status_code =
                     Some(TusError::Protocol(ProtocolError::InvalidInt(H_CONTENT_LENGTH)).status());
                 return;
             }
-        },
+        }
         None => None,
     };
 

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -55,14 +55,11 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         return;
     }
 
-    if let Some(value) = upload_defer_length {
-        match value.to_str() {
-            Ok("1") => {}
-            _ => {
-                res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
-                return;
-            }
-        }
+    if let Some(value) = upload_defer_length
+        && !matches!(value.to_str(), Ok("1"))
+    {
+        res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
+        return;
     }
 
     // Must provide either Upload-Length or Upload-Defer-Length, but not both or neither
@@ -120,25 +117,26 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     let upload_length_value = match upload_length {
-        Some(value) => match value.to_str() {
-            Ok(v) => match parse_u64(Some(v), H_UPLOAD_LENGTH) {
-                Ok(size) => Some(size),
-                Err(e) => {
-                    res.status_code = Some(TusError::Protocol(e).status());
-                    return;
+        Some(value) => {
+            if let Ok(v) = value.to_str() {
+                match parse_u64(Some(v), H_UPLOAD_LENGTH) {
+                    Ok(size) => Some(size),
+                    Err(e) => {
+                        res.status_code = Some(TusError::Protocol(e).status());
+                        return;
+                    }
                 }
-            },
-            Err(_) => {
+            } else {
                 res.status_code =
                     Some(TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status());
                 return;
             }
-        },
+        }
         None => None,
     };
 
     let max_file_size = opts
-        .get_configured_max_size(req, Some(upload_id.to_owned()))
+        .get_configured_max_size(req, Some(upload_id.clone()))
         .await;
 
     if let Some(size) = upload_length_value
@@ -197,22 +195,23 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
 
         if creation_with_upload {
             let content_length = match req.headers().get(H_CONTENT_LENGTH) {
-                Some(value) => match value.to_str() {
-                    Ok(v) => match parse_u64(Some(v), H_CONTENT_LENGTH) {
-                        Ok(size) => Some(size),
-                        Err(e) => {
-                            res.status_code = Some(TusError::Protocol(e).status());
-                            return;
+                Some(value) => {
+                    if let Ok(v) = value.to_str() {
+                        match parse_u64(Some(v), H_CONTENT_LENGTH) {
+                            Ok(size) => Some(size),
+                            Err(e) => {
+                                res.status_code = Some(TusError::Protocol(e).status());
+                                return;
+                            }
                         }
-                    },
-                    Err(_) => {
+                    } else {
                         res.status_code = Some(
                             TusError::Protocol(ProtocolError::InvalidInt(H_CONTENT_LENGTH))
                                 .status(),
                         );
                         return;
                     }
-                },
+                }
                 None => None,
             };
 
@@ -253,12 +252,9 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             || creation_with_upload && upload.size.is_some_and(|x| x == upload.offset.unwrap_or(0))
     };
 
-    let url = match opts.generate_upload_url(req, &upload_id) {
-        Ok(url) => url,
-        Err(_) => {
-            res.status_code = Some(TusError::GenerateUploadURLError.status());
-            return;
-        }
+    let Ok(url) = opts.generate_upload_url(req, &upload_id) else {
+        res.status_code = Some(TusError::GenerateUploadURLError.status());
+        return;
     };
 
     tracing::info!("Generated file url: {}", &url);
@@ -322,17 +318,14 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let should_set_location = matches!(res.status_code, Some(StatusCode::CREATED))
         || res.status_code.is_some_and(|s| s.is_redirection());
     if should_set_location {
-        match HeaderValue::from_str(&url) {
-            Ok(v) => {
-                res.headers.insert("Location", v);
-            }
-            Err(_) => {
-                res.status_code = Some(
-                    TusError::Internal("Generated upload URL is not a valid header value".into())
-                        .status(),
-                );
-                return;
-            }
+        if let Ok(v) = HeaderValue::from_str(&url) {
+            res.headers.insert("Location", v);
+        } else {
+            res.status_code = Some(
+                TusError::Internal("Generated upload URL is not a valid header value".into())
+                    .status(),
+            );
+            return;
         }
     }
 

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -162,16 +162,19 @@ pub struct CancellationSignal {
 
 impl CancellationSignal {
     /// Returns the current cancellation reason, if cancellation has happened.
+    #[must_use]
     pub fn reason(&self) -> Option<CancellationReason> {
         *self.receiver.borrow()
     }
 
     /// Returns `true` when this signal has been cancelled or aborted.
+    #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.reason().is_some()
     }
 
     /// Returns `true` when the signal was cancelled because the request aborted.
+    #[must_use]
     pub fn is_aborted(&self) -> bool {
         matches!(self.reason(), Some(CancellationReason::Abort))
     }
@@ -199,6 +202,7 @@ pub struct CancellationContext {
 
 impl CancellationContext {
     /// Creates a new cancellation context.
+    #[must_use]
     pub fn new() -> Self {
         let (sender, receiver) = watch::channel(None);
         Self {
@@ -258,6 +262,7 @@ impl Default for Tus {
 // Tus service Configuration
 impl Tus {
     /// Creates a tus service with default options and a [`DiskStore`].
+    #[must_use]
     pub fn new() -> Self {
         Self {
             options: TusOptions::default(),
@@ -266,30 +271,35 @@ impl Tus {
     }
 
     /// Sets the route path where tus endpoints are mounted.
+    #[must_use]
     pub fn path(mut self, path: impl Into<String>) -> Self {
         self.options.path = path.into();
         self
     }
 
     /// Sets the maximum upload size policy.
+    #[must_use]
     pub fn max_size(mut self, max_size: MaxSize) -> Self {
         self.options.max_size = Some(max_size);
         self
     }
 
     /// Controls whether generated `Location` headers use relative URLs.
+    #[must_use]
     pub fn relative_location(mut self, yes: bool) -> Self {
         self.options.relative_location = yes;
         self
     }
 
     /// Sets the trusted origin used for absolute `Location` headers.
+    #[must_use]
     pub fn canonical_origin(mut self, origin: impl Into<String>) -> Self {
         self.options.canonical_origin = Some(origin.into());
         self
     }
 
     /// Sets the allowed CORS origins for tus responses.
+    #[must_use]
     pub fn allowed_origins<I, S>(mut self, origins: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -300,6 +310,7 @@ impl Tus {
     }
 
     /// Adds extra request headers accepted by CORS preflight responses.
+    #[must_use]
     pub fn allowed_headers<I, S>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -310,6 +321,7 @@ impl Tus {
     }
 
     /// Adds extra response headers exposed to browsers by CORS.
+    #[must_use]
     pub fn exposed_headers<I, S>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -320,12 +332,14 @@ impl Tus {
     }
 
     /// Controls whether CORS responses allow credentials.
+    #[must_use]
     pub fn allow_credentials(mut self, yes: bool) -> Self {
         self.options.allowed_credentials = yes;
         self
     }
 
     /// Sets the [`DataStore`] used to persist uploads.
+    #[must_use]
     pub fn store(mut self, store: impl DataStore) -> Self {
         self.store = Arc::new(store);
         self
@@ -345,11 +359,13 @@ impl Tus {
     ///
     /// let tus = Tus::new().storage_root("/var/uploads/tus");
     /// ```
+    #[must_use]
     pub fn storage_root(self, root: impl Into<PathBuf>) -> Self {
         self.store(DiskStore::new().disk_root(root))
     }
 
     /// Sets the [`Locker`] used to serialize concurrent writes to the same upload.
+    #[must_use]
     pub fn locker(mut self, locker: impl Locker) -> Self {
         self.options.locker = Arc::new(locker);
         self
@@ -369,9 +385,7 @@ impl Tus {
         let state = Arc::new(self);
 
         Router::with_path(base_path)
-            .hoop(TusStateHoop {
-                state: state.clone(),
-            })
+            .hoop(TusStateHoop { state })
             .push(handlers::options_handler())
             .push(handlers::post_handler())
             .push(handlers::head_handler())
@@ -384,6 +398,7 @@ impl Tus {
 // Hooks
 impl Tus {
     /// Sets the function used to derive the upload ID from an incoming `POST`.
+    #[must_use]
     pub fn upload_id_naming_function<F, Fut>(mut self, f: F) -> Self
     where
         F: Fn(&Request, Option<Metadata>) -> Fut + Send + Sync + 'static,
@@ -395,6 +410,7 @@ impl Tus {
 
     /// Sets the function that generates the upload location URL returned in the
     /// `Location` header.
+    #[must_use]
     pub fn generate_url_function<F>(mut self, f: F) -> Self
     where
         F: Fn(&Request, GenerateUrlCtx) -> Result<String, TusError> + Send + Sync + 'static,
@@ -407,6 +423,7 @@ impl Tus {
 // Lifecycle
 impl Tus {
     /// Sets an async hook that runs at the start of every tus request.
+    #[must_use]
     pub fn on_incoming_request<F, Fut>(mut self, f: F) -> Self
     where
         F: Fn(&Request, String) -> Fut + Send + Sync + 'static,
@@ -417,6 +434,7 @@ impl Tus {
     }
 
     /// Sets a synchronous hook that runs at the start of every tus request.
+    #[must_use]
     pub fn on_incoming_request_sync<F>(mut self, f: F) -> Self
     where
         F: Fn(&Request, String) + Send + Sync + 'static,
@@ -429,6 +447,7 @@ impl Tus {
     }
 
     /// Sets the hook invoked when a new upload is being created.
+    #[must_use]
     pub fn on_upload_create<F, Fut>(mut self, f: F) -> Self
     where
         F: Fn(&Request, UploadInfo) -> Fut + Send + Sync + 'static,
@@ -439,6 +458,7 @@ impl Tus {
     }
 
     /// Sets the hook invoked when an upload completes.
+    #[must_use]
     pub fn on_upload_finish<F, Fut>(mut self, f: F) -> Self
     where
         F: Fn(&Request, UploadInfo) -> Fut + Send + Sync + 'static,
@@ -611,7 +631,7 @@ mod tests {
     #[test]
     fn test_cancellation_context_debug() {
         let ctx = CancellationContext::new();
-        let debug = format!("{:?}", ctx);
+        let debug = format!("{ctx:?}");
         assert!(debug.contains("CancellationContext"));
     }
 
@@ -726,7 +746,7 @@ mod tests {
     #[test]
     fn test_tus_clone() {
         let tus = Tus::new().path("/test");
-        let cloned = tus.clone();
+        let cloned = tus;
         assert_eq!(cloned.options.path, "/test");
     }
 
@@ -812,7 +832,7 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
 
         let called = Arc::new(AtomicBool::new(false));
-        let called_clone = called.clone();
+        let called_clone = called;
 
         let tus = Tus::new().on_incoming_request_sync(move |_req, _id| {
             called_clone.store(true, Ordering::SeqCst);

--- a/crates/tus/src/lockers/memory_locker.rs
+++ b/crates/tus/src/lockers/memory_locker.rs
@@ -21,6 +21,7 @@ impl Default for MemoryLocker {
 
 impl MemoryLocker {
     /// Creates an empty in-memory locker.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),
@@ -236,7 +237,7 @@ mod tests {
         // Create locks for many different IDs
         let mut guards = Vec::new();
         for i in 0..100 {
-            let guard = locker.write_lock(&format!("id-{}", i)).await.unwrap();
+            let guard = locker.write_lock(&format!("id-{i}")).await.unwrap();
             guards.push(guard);
         }
 

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -369,7 +369,7 @@ impl TusOptions {
 
 impl Default for TusOptions {
     fn default() -> Self {
-        TusOptions {
+        Self {
             path: "/tus-files".to_owned(),
             max_size: Some(MaxSize::Fixed(2 * 1024 * 1024 * 1024)), // Default max size 2GiB
             relative_location: true,
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn test_max_size_clone() {
         let max_size1 = MaxSize::Fixed(2048);
-        let max_size2 = max_size1.clone();
+        let max_size2 = max_size1;
         match max_size2 {
             MaxSize::Fixed(size) => assert_eq!(size, 2048),
             _ => panic!("Expected Fixed variant"),
@@ -593,7 +593,7 @@ mod tests {
         let patch = UploadPatch {
             metadata: Some(Metadata::default()),
         };
-        let cloned = patch.clone();
+        let cloned = patch;
         assert!(cloned.metadata.is_some());
     }
 
@@ -604,7 +604,7 @@ mod tests {
             headers: Some(HeaderMap::new()),
             body: Some(vec![1, 2, 3]),
         };
-        let cloned = patch.clone();
+        let cloned = patch;
         assert_eq!(cloned.status_code, Some(StatusCode::OK));
         assert!(cloned.headers.is_some());
         assert_eq!(cloned.body, Some(vec![1, 2, 3]));
@@ -613,14 +613,14 @@ mod tests {
     #[test]
     fn test_upload_patch_debug() {
         let patch = UploadPatch::default();
-        let debug = format!("{:?}", patch);
+        let debug = format!("{patch:?}");
         assert!(debug.contains("UploadPatch"));
     }
 
     #[test]
     fn test_upload_finish_patch_debug() {
         let patch = UploadFinishPatch::default();
-        let debug = format!("{:?}", patch);
+        let debug = format!("{patch:?}");
         assert!(debug.contains("UploadFinishPatch"));
     }
 

--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -91,6 +91,7 @@ impl Default for DiskStore {
 
 impl DiskStore {
     /// Creates a disk store rooted at `./tus-upload-files`.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             root: "./tus-upload-files".into(),
@@ -100,6 +101,7 @@ impl DiskStore {
     /// Sets the local disk root directory where uploaded files are written.
     ///
     /// Defaults to `./tus-upload-files`.
+    #[must_use]
     pub fn disk_root(mut self, root: impl Into<PathBuf>) -> Self {
         self.root = root.into();
         self
@@ -165,9 +167,8 @@ impl DiskStore {
         path.starts_with(root)
     }
 
-    fn resolve_data_path(&self, id: &str, storage: &Option<MetaStoreInfo>) -> PathBuf {
+    fn resolve_data_path(&self, id: &str, storage: Option<&MetaStoreInfo>) -> PathBuf {
         if let Some(path) = storage
-            .as_ref()
             .map(|info| PathBuf::from(&info.path))
             .filter(|path| self.path_is_within_root(path))
         {
@@ -206,7 +207,7 @@ impl DiskStore {
     async fn resolve_existing_data_path(
         &self,
         id: &str,
-        storage: &Option<MetaStoreInfo>,
+        storage: Option<&MetaStoreInfo>,
     ) -> TusResult<PathBuf> {
         let path = self.resolve_data_path(id, storage);
         if self.existing_path_is_within_root(&path).await {
@@ -224,7 +225,7 @@ impl DiskStore {
 
     async fn resolve_meta_data_path(&self, meta: &mut MetaUpload) -> TusResult<PathBuf> {
         let path = self
-            .resolve_existing_data_path(&meta.id, &meta.storage)
+            .resolve_existing_data_path(&meta.id, meta.storage.as_ref())
             .await?;
         if let Some(storage) = &mut meta.storage {
             storage.path = path.to_string_lossy().into_owned();
@@ -288,7 +289,7 @@ impl DiskStore {
                 )
             }
             (Some(stem), None) => format!("{}-{}", stem.to_string_lossy(), id),
-            _ => format!("{}-{}", name, id),
+            _ => format!("{name}-{id}"),
         }
     }
 
@@ -878,7 +879,7 @@ mod tests {
             path: stored_path.to_string_lossy().into_owned(),
             bucket: None,
         });
-        let path = store.resolve_data_path("test-id", &storage);
+        let path = store.resolve_data_path("test-id", storage.as_ref());
         assert_eq!(path, stored_path);
     }
 
@@ -892,14 +893,14 @@ mod tests {
             bucket: None,
         });
 
-        let path = store.resolve_data_path("test-id", &storage);
+        let path = store.resolve_data_path("test-id", storage.as_ref());
         assert_eq!(path, store.data_path("test-id"));
     }
 
     #[test]
     fn test_resolve_data_path_without_storage() {
         let store = DiskStore::new().disk_root("/uploads");
-        let path = store.resolve_data_path("test-id", &None);
+        let path = store.resolve_data_path("test-id", None);
         assert_eq!(path, PathBuf::from("/uploads/test-id.bin"));
     }
 
@@ -1314,7 +1315,7 @@ mod tests {
         assert_eq!(info.offset, Some(0));
 
         let meta = store.read_meta("test-write-limited").await.unwrap();
-        let data_path = store.resolve_data_path("test-write-limited", &meta.storage);
+        let data_path = store.resolve_data_path("test-write-limited", meta.storage.as_ref());
         let data_len = fs::metadata(data_path).await.unwrap().len();
         assert_eq!(data_len, 0);
     }

--- a/crates/tus/src/stores/mod.rs
+++ b/crates/tus/src/stores/mod.rs
@@ -86,6 +86,7 @@ pub struct UploadInfo {
 
 impl UploadInfo {
     /// Returns `true` when the upload length has not been declared yet.
+    #[must_use]
     pub fn is_size_deferred(&self) -> bool {
         self.size.is_none()
     }
@@ -110,19 +111,21 @@ pub enum Extension {
 
 impl Extension {
     /// Returns the tus header token for this extension.
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
-            Extension::Creation => "creation",
-            Extension::Expiration => "expiration",
-            Extension::CreationWithUpload => "creation-with-upload",
-            Extension::CreationDeferLength => "creation-defer-length",
-            Extension::Concatenation => "concatenation",
-            Extension::Termination => "termination",
+            Self::Creation => "creation",
+            Self::Expiration => "expiration",
+            Self::CreationWithUpload => "creation-with-upload",
+            Self::CreationDeferLength => "creation-defer-length",
+            Self::Concatenation => "concatenation",
+            Self::Termination => "termination",
         }
     }
 
     /// Converts a set of extensions into a `Tus-Extension` header value.
-    pub fn to_header_value(extensions: &HashSet<Extension>) -> Option<HeaderValue> {
+    #[must_use]
+    pub fn to_header_value(extensions: &HashSet<Self>) -> Option<HeaderValue> {
         if extensions.is_empty() {
             return None;
         }
@@ -307,7 +310,7 @@ mod tests {
             creation_date: "2024-01-01T00:00:00Z".to_owned(),
         };
 
-        let cloned = info.clone();
+        let cloned = info;
         assert_eq!(cloned.id, "test-id");
         assert_eq!(cloned.size, Some(2048));
         assert_eq!(cloned.offset, Some(512));
@@ -325,7 +328,7 @@ mod tests {
             bucket: Some("my-bucket".to_owned()),
         };
 
-        let cloned = info.clone();
+        let cloned = info;
         assert_eq!(cloned.type_name, "s3");
         assert_eq!(cloned.path, "uploads/file.bin");
         assert_eq!(cloned.bucket, Some("my-bucket".to_owned()));
@@ -357,7 +360,7 @@ mod tests {
     #[test]
     fn test_extension_debug() {
         let ext = Extension::Creation;
-        let debug_str = format!("{:?}", ext);
+        let debug_str = format!("{ext:?}");
         assert_eq!(debug_str, "Creation");
     }
 
@@ -368,7 +371,7 @@ mod tests {
             path: "/uploads/test.bin".to_owned(),
             bucket: None,
         };
-        let debug_str = format!("{:?}", info);
+        let debug_str = format!("{info:?}");
         assert!(debug_str.contains("disk"));
         assert!(debug_str.contains("/uploads/test.bin"));
     }
@@ -383,7 +386,7 @@ mod tests {
             storage: None,
             creation_date: "2024-01-01".to_owned(),
         };
-        let debug_str = format!("{:?}", info);
+        let debug_str = format!("{info:?}");
         assert!(debug_str.contains("abc123"));
         assert!(debug_str.contains("1024"));
         assert!(debug_str.contains("512"));

--- a/crates/tus/src/utils.rs
+++ b/crates/tus/src/utils.rs
@@ -20,13 +20,14 @@ pub fn parse_u64(v: Option<&str>, name: &'static str) -> Result<u64, ProtocolErr
 }
 
 /// Normalizes a route path to start with `/` and omit trailing slashes.
+#[must_use]
 pub fn normalize_path(p: &str) -> String {
     if p.is_empty() {
         return "/".to_owned();
     }
     let mut out = p.to_owned();
     if !out.starts_with('/') {
-        out = format!("/{}", out);
+        out = format!("/{out}");
     }
     if out.len() > 1 {
         out = out.trim_end_matches('/').to_owned();
@@ -37,6 +38,7 @@ pub fn normalize_path(p: &str) -> String {
 /// Validate that an upload ID is safe to use in file paths.
 /// Returns true if the ID contains only safe characters (alphanumeric, dash, underscore).
 /// This prevents path traversal attacks via malicious upload IDs.
+#[must_use]
 pub fn is_safe_upload_id(id: &str) -> bool {
     if id.is_empty() {
         return false;
@@ -48,6 +50,7 @@ pub fn is_safe_upload_id(id: &str) -> bool {
 
 /// Sanitize a path component to remove potentially dangerous sequences.
 /// Returns None if the path component is unsafe.
+#[must_use]
 pub fn sanitize_path_component(component: &str) -> Option<&str> {
     let component = component.trim();
 
@@ -80,6 +83,7 @@ pub fn sanitize_path_component(component: &str) -> Option<&str> {
 }
 
 /// Returns `true` when `value` matches the expected header value.
+#[must_use]
 pub fn validate_header(name: &'static str, value: Option<&HeaderValue>) -> bool {
     match value {
         Some(v) => {


### PR DESCRIPTION
## What changed

- Fixed workspace clippy warnings under strict `-D warnings`.
- Applied mechanical clippy cleanups in `salvo-tus`, including `#[must_use]`, `Self` paths, inline format args, redundant clone removals, and control-flow simplifications.
- Fixed the `salvo-cache` in-flight test to use `let...else`.
- Moved the `salvo-jwt-auth` test module after implementation items to satisfy clippy item ordering.

## Validation

- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p salvo-tus --all-features`
- `cargo test -p salvo-cache --all-features`
- `cargo test -p salvo-jwt-auth --all-features`
- `cargo test -p salvo-oapi-macros --all-features`
- `cargo +nightly fmt --all -- --check`
- `typos --format brief crates/cache/src/lib.rs crates/jwt-auth/src/decoder.rs crates/oapi-macros/src/operation/request_body.rs crates/tus/src`
- `git diff --check`