### PR TITLE
Disable HTTP/3 GREASE by default

### DIFF
--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -51,7 +51,9 @@ impl Builder {
             .enable_extended_connect(true)
             .enable_datagram(true)
             .max_webtransport_sessions(1)
-            .send_grease(true);
+            // h3 0.0.8 can leave aioquic/curl clients waiting for stream end
+            // when a GREASE frame is sent just before finishing the response.
+            .send_grease(false);
         Self(builder)
     }
 }


### PR DESCRIPTION
## Summary

Disable HTTP/3 GREASE frames by default in the Quinn server builder.

## Why

Issue #1122 can be reproduced locally with the `hello-h3` example and an aioquic client: the response headers and body arrive, but the client does not observe `stream_ended` while GREASE is enabled. Disabling GREASE avoids that interop problem and allows the stream to finish normally.

## Validation

- `cargo check -p salvo_core --features quinn`
- `rustfmt --edition 2024 --check crates/core/src/conn/quinn/builder.rs`
- local `examples/hello-h3` HTTP/3 smoke test with aioquic: `DataReceived(... stream_ended=True)` after disabling GREASE

Related: #1122, #1259, hyperium/h3#330, hyperium/h3#331