### PR TITLE
docs: fix inconsistencies and grammar in doc comments

### DIFF
--- a/crates/core/src/extract/metadata.rs
+++ b/crates/core/src/extract/metadata.rs
@@ -7,18 +7,18 @@ use crate::extract::RenameRule;
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum SourceFrom {
-    /// The field will extracted from url param.
+    /// The field will be extracted from url param.
     Param,
-    /// The field will extracted from url query.
+    /// The field will be extracted from url query.
     Query,
-    /// The field will extracted from http header.
+    /// The field will be extracted from http header.
     Header,
-    /// The field will extracted from http cookie.
+    /// The field will be extracted from http cookie.
     #[cfg(feature = "cookie")]
     Cookie,
-    /// The field will extracted from http payload.
+    /// The field will be extracted from http payload.
     Body,
-    /// The field will extracted from depot.
+    /// The field will be extracted from depot.
     Depot,
 }
 
@@ -160,9 +160,9 @@ impl Metadata {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Field {
-    /// Field declare name in struct definition.
+    /// The field's declared name in the struct definition.
     pub decl_name: &'static str,
-    /// Field flatten, this field will extracted from request.
+    /// Whether the field is flattened; this field will be extracted from the request.
     pub flatten: bool,
     /// Field sources.
     pub sources: Vec<Source>,
@@ -176,13 +176,13 @@ pub struct Field {
     pub metadata: Option<&'static Metadata>,
 }
 impl Field {
-    /// Create a new field with the given name and kind.
+    /// Create a new field with the given name.
     #[must_use]
     pub fn new(decl_name: &'static str) -> Self {
         Self::with_sources(decl_name, vec![])
     }
 
-    /// Create a new field with the given name and kind, and the given sources.
+    /// Create a new field with the given name and sources.
     #[must_use]
     pub fn with_sources(decl_name: &'static str, sources: Vec<Source>) -> Self {
         Self {
@@ -224,7 +224,7 @@ impl Field {
         self
     }
 
-    /// Add a alias to aliases list.
+    /// Add an alias to the aliases list.
     #[must_use]
     pub fn add_alias(mut self, alias: &'static str) -> Self {
         self.aliases.push(alias);

--- a/crates/core/src/http/range.rs
+++ b/crates/core/src/http/range.rs
@@ -15,7 +15,7 @@ static PREFIX: &str = "bytes=";
 impl HttpRange {
     /// Parses Range HTTP header string as per RFC 2616.
     ///
-    /// `header` is HTTP Range header (e.g. `bytes=bytes=0-9`).
+    /// `header` is HTTP Range header (e.g. `bytes=0-9`).
     /// `size` is full size of response (file).
     pub fn parse(header: &str, size: u64) -> Result<Vec<Self>, ParseError> {
         if header.is_empty() {

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -327,8 +327,8 @@ impl Request {
 
     /// Returns a mutable reference to the associated URI.
     ///
-    /// *Notice: If you using this mutable reference to change the uri, you should change the
-    /// `params` and `queries` manually.*
+    /// **Note**: If you use this mutable reference to change the URI, you should change the
+    /// `params` and `queries` manually.
     ///
     /// # Examples
     ///
@@ -345,7 +345,7 @@ impl Request {
 
     /// Set the associated URI. `queries` will be reset.
     ///
-    /// *Notice: `params` will not reset.*
+    /// **Note**: `params` will not be reset.
     #[inline]
     pub fn set_uri(&mut self, uri: Uri) {
         self.uri = uri;

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -348,7 +348,7 @@ impl Response {
         pub fn cookies_mut(&mut self) -> &mut CookieJar {
             &mut self.cookies
         }
-        /// Helper function for get cookie.
+        /// Gets a cookie by name from the response.
         #[inline]
         pub fn cookie<T>(&self, name: T) -> Option<&Cookie<'static>>
         where
@@ -356,14 +356,14 @@ impl Response {
         {
             self.cookies.get(name.as_ref())
         }
-        /// Helper function for add cookie.
+        /// Adds a cookie to the response.
         #[inline]
-        pub fn add_cookie(&mut self, cookie: Cookie<'static>)-> &mut Self {
+        pub fn add_cookie(&mut self, cookie: Cookie<'static>) -> &mut Self {
             self.cookies.add(cookie);
             self
         }
 
-        /// Helper function for remove cookie.
+        /// Removes a cookie from the response.
         ///
         /// Removes `cookie` from this [`CookieJar`]. If an _original_ cookie with the same
         /// name as `cookie` is present in the jar, a _removal_ cookie will be

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -71,7 +71,7 @@ where
                 let _ = res.write_body(bytes);
             }
             Err(e) => {
-                tracing::error!(error = ?e, "JsonContent write error");
+                tracing::error!(error = ?e, "JSON serialize error");
                 res.render(StatusError::internal_server_error());
             }
         }


### PR DESCRIPTION
@
## What

First round of cleanups from an internal naming & documentation review. This PR is **documentation-only** — it fixes grammar, typos, and inconsistencies in doc comments and one log message. No public API, signatures, or behavior change.

## Changes

- **extract/metadata.rs**
  - `The field will extracted from ...` → `... will be extracted from ...` (7 occurrences)
  - `Add a alias` → `Add an alias`
  - `Field::new` / `with_sources` docs referenced a nonexistent `kind` parameter — removed
  - Reworded `decl_name` and `flatten` field docs for grammar
- **http/range.rs** — example header had a duplicated prefix: `bytes=bytes=0-9` → `bytes=0-9`
- **http/request.rs** — unified `*Notice: ...*` to the project-standard `**Note**: ...` and fixed `If you using` grammar (2 places)
- **http/response.rs** — replaced `Helper function for {get,add,remove} cookie.` with proper sentences; fixed missing space in `add_cookie(...)-> &mut Self`
- **writing/json.rs** — error log referenced a nonexistent `JsonContent` type → `JSON serialize error`

## Notes

This is the first of several planned follow-ups from the review. Subsequent rounds (identifier renames such as `Depot` method naming, `issue`/`elect`, etc.) are intentionally **not** included here since they are breaking changes that need a deprecation cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@