### PR TITLE
fix: correct internal typos and naming flagged in review

### DIFF
--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -52,7 +52,7 @@ impl ServerHandle {
     /// requests to finish. The adjective parallels [`Self::stop_graceful`];
     /// reach for that one when you want a clean shutdown.
     pub fn stop_forceful(&self) {
-        let _ = self.tx_cmd.send(ServerCommand::StopForcible);
+        let _ = self.tx_cmd.send(ServerCommand::StopForceful);
     }
 
     /// Deprecated alias for [`Self::stop_forceful`].
@@ -109,7 +109,7 @@ impl ServerHandle {
 
 #[cfg(feature = "server-handle")]
 enum ServerCommand {
-    StopForcible,
+    StopForceful,
     StopGraceful(Option<Duration>),
 }
 
@@ -188,7 +188,7 @@ impl<A: Acceptor + Send> Server<A> {
         /// requests to finish. The adjective parallels [`Self::stop_graceful`];
         /// reach for that one when you want a clean shutdown.
         pub fn stop_forceful(&self) {
-            let _ = self.tx_cmd.send(ServerCommand::StopForcible);
+            let _ = self.tx_cmd.send(ServerCommand::StopForceful);
         }
 
         /// Deprecated alias for [`Self::stop_forceful`].
@@ -361,7 +361,7 @@ impl<A: Acceptor + Send> Server<A> {
                                     tracing::info!("initiate graceful stop server");
                                 }
                             },
-                            ServerCommand::StopForcible => {
+                            ServerCommand::StopForceful => {
                                 tracing::info!("force stop server");
                                 force_stop_token.cancel();
                             },

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -70,21 +70,21 @@ cfg_feature! {
     pub use bcrypt_cipher::BcryptCipher;
 
     /// Helper function to create a `Csrf` use `BcryptCipher`.
-    pub fn bcrypt_csrf<S>(store: S, finder: impl CsrfTokenFinder ) -> Csrf<BcryptCipher, S> where S: CsrfStore {
+    pub fn bcrypt_csrf<S>(store: S, finder: impl CsrfTokenFinder) -> Csrf<BcryptCipher, S> where S: CsrfStore {
         Csrf::new(BcryptCipher::new(), store, finder)
     }
 }
 cfg_feature! {
     #![all(feature = "bcrypt-cipher", feature = "cookie-store")]
     /// Helper function to create a `Csrf` use `BcryptCipher` and `CookieStore`.
-    pub fn bcrypt_cookie_csrf(finder: impl CsrfTokenFinder ) -> Csrf<BcryptCipher, CookieStore> {
+    pub fn bcrypt_cookie_csrf(finder: impl CsrfTokenFinder) -> Csrf<BcryptCipher, CookieStore> {
         Csrf::new(BcryptCipher::new(), CookieStore::new(), finder)
     }
 }
 cfg_feature! {
     #![all(feature = "bcrypt-cipher", feature = "session-store")]
     /// Helper function to create a `Csrf` use `BcryptCipher` and `SessionStore`.
-    pub fn bcrypt_session_csrf(finder: impl CsrfTokenFinder ) -> Csrf<BcryptCipher, SessionStore> {
+    pub fn bcrypt_session_csrf(finder: impl CsrfTokenFinder) -> Csrf<BcryptCipher, SessionStore> {
         Csrf::new(BcryptCipher::new(), SessionStore::new(), finder)
     }
 }
@@ -96,21 +96,21 @@ cfg_feature! {
     pub use hmac_cipher::HmacCipher;
 
     /// Helper function to create a `Csrf` use `HmacCipher`.
-    pub fn hmac_csrf<S>(hmac_key: [u8; 32], store: S, finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, S> where S: CsrfStore {
+    pub fn hmac_csrf<S>(hmac_key: [u8; 32], store: S, finder: impl CsrfTokenFinder) -> Csrf<HmacCipher, S> where S: CsrfStore {
         Csrf::new(HmacCipher::new(hmac_key), store, finder)
     }
 }
 cfg_feature! {
     #![all(feature = "hmac-cipher", feature = "cookie-store")]
     /// Helper function to create a `Csrf` use `HmacCipher` and `CookieStore`.
-    pub fn hmac_cookie_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, CookieStore> {
+    pub fn hmac_cookie_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<HmacCipher, CookieStore> {
         Csrf::new(HmacCipher::new(hmac_key), CookieStore::new(), finder)
     }
 }
 cfg_feature! {
     #![all(feature = "hmac-cipher", feature = "session-store")]
     /// Helper function to create a `Csrf` use `HmacCipher` and `SessionStore`.
-    pub fn hmac_session_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<HmacCipher, SessionStore> {
+    pub fn hmac_session_csrf(hmac_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<HmacCipher, SessionStore> {
         Csrf::new(HmacCipher::new(hmac_key), SessionStore::new(), finder)
     }
 }
@@ -122,21 +122,21 @@ cfg_feature! {
     pub use aes_gcm_cipher::AesGcmCipher;
 
     /// Helper function to create a `Csrf` use `AesGcmCipher`.
-    pub fn aes_gcm_csrf<S>(aead_key: [u8; 32], store: S, finder: impl CsrfTokenFinder ) -> Csrf<AesGcmCipher, S> where S: CsrfStore {
+    pub fn aes_gcm_csrf<S>(aead_key: [u8; 32], store: S, finder: impl CsrfTokenFinder) -> Csrf<AesGcmCipher, S> where S: CsrfStore {
         Csrf::new(AesGcmCipher::new(aead_key), store, finder)
     }
 }
 cfg_feature! {
     #![all(feature = "aes-gcm-cipher", feature = "cookie-store")]
     /// Helper function to create a `Csrf` use `AesGcmCipher` and `CookieStore`.
-    pub fn aes_gcm_cookie_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<AesGcmCipher, CookieStore> {
+    pub fn aes_gcm_cookie_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<AesGcmCipher, CookieStore> {
         Csrf::new(AesGcmCipher::new(aead_key), CookieStore::new(), finder)
     }
 }
 cfg_feature! {
     #![all(feature = "aes-gcm-cipher", feature = "session-store")]
     /// Helper function to create a `Csrf` use `AesGcmCipher` and `SessionStore`.
-    pub fn aes_gcm_session_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<AesGcmCipher, SessionStore> {
+    pub fn aes_gcm_session_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<AesGcmCipher, SessionStore> {
         Csrf::new(AesGcmCipher::new(aead_key), SessionStore::new(), finder)
     }
 }
@@ -148,21 +148,21 @@ cfg_feature! {
     pub use ccp_cipher::CcpCipher;
 
     /// Helper function to create a `Csrf` use `CcpCipher`.
-    pub fn ccp_csrf<S>(aead_key: [u8; 32], store: S, finder: impl CsrfTokenFinder ) -> Csrf<CcpCipher, S> where S: CsrfStore {
+    pub fn ccp_csrf<S>(aead_key: [u8; 32], store: S, finder: impl CsrfTokenFinder) -> Csrf<CcpCipher, S> where S: CsrfStore {
         Csrf::new(CcpCipher::new(aead_key), store, finder)
     }
 }
 cfg_feature! {
     #![all(feature = "ccp-cipher", feature = "cookie-store")]
     /// Helper function to create a `Csrf` use `CcpCipher` and `CookieStore`.
-    pub fn ccp_cookie_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<CcpCipher, CookieStore> {
+    pub fn ccp_cookie_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<CcpCipher, CookieStore> {
         Csrf::new(CcpCipher::new(aead_key), CookieStore::new(), finder)
     }
 }
 cfg_feature! {
     #![all(feature = "ccp-cipher", feature = "session-store")]
     /// Helper function to create a `Csrf` use `CcpCipher` and `SessionStore`.
-    pub fn ccp_session_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder ) -> Csrf<CcpCipher, SessionStore> {
+    pub fn ccp_session_csrf(aead_key: [u8; 32], finder: impl CsrfTokenFinder) -> Csrf<CcpCipher, SessionStore> {
         Csrf::new(CcpCipher::new(aead_key), SessionStore::new(), finder)
     }
 }

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -78,7 +78,7 @@ cfg_feature! {
 type HyperRequest = hyper::Request<ReqBody>;
 type HyperResponse = hyper::Response<ResBody>;
 
-const X_FORWARDER_FOR_HEADER_NAME: &str = "x-forwarded-for";
+const X_FORWARDED_FOR_HEADER_NAME: &str = "x-forwarded-for";
 const HOP_BY_HOP_HEADERS: &[&str] = &[
     "connection",
     "keep-alive",
@@ -563,7 +563,7 @@ where
         }
 
         if self.client_ip_forwarding_enabled {
-            let xff_header_name = HeaderName::from_static(X_FORWARDER_FOR_HEADER_NAME);
+            let xff_header_name = HeaderName::from_static(X_FORWARDED_FOR_HEADER_NAME);
             if let Some(client_ip) = req.remote_addr().ip() {
                 match HeaderValue::from_str(&client_ip.to_string()) {
                     Ok(xff) => {
@@ -1123,7 +1123,7 @@ Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
 
     #[tokio::test]
     async fn test_client_ip_forwarding() {
-        let xff_header_name = HeaderName::from_static(X_FORWARDER_FOR_HEADER_NAME);
+        let xff_header_name = HeaderName::from_static(X_FORWARDED_FOR_HEADER_NAME);
 
         let mut request = Request::new();
         let depot = Depot::new();


### PR DESCRIPTION
@
## What

Second round of cleanups from the internal naming & documentation review (follow-up to #1512). These are the remaining **P0** items: clear typos / mis-names. Every identifier changed here is **private** (no `pub`), so there is **no public API or behavior change**.

## Changes

- **proxy** — `const X_FORWARDER_FOR_HEADER_NAME` → `X_FORWARDED_FOR_HEADER_NAME`. The HTTP header is `X-Forwarded-For`; the constant name had `FORWARDER`. The value string `"x-forwarded-for"` was already correct, so behavior is unchanged.
- **core/server** — internal enum variant `ServerCommand::StopForcible` → `StopForceful`, matching the already-migrated public `stop_forceful()` method (`stop_forcible()` is the deprecated alias). The enum is private.
- **csrf** — removed a stray space in `impl CsrfTokenFinder )` across the cipher/store helper constructors.

## Verification

`cargo check -p salvo_core -p salvo-proxy -p salvo-csrf --all-features` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@