### PR TITLE
Refine Depot typed storage APIs

### DIFF
--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -1,4 +1,4 @@
-use std::any::{Any, TypeId};
+use std::any::{Any, TypeId, type_name};
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 
@@ -37,11 +37,22 @@ use std::fmt::{self, Debug, Formatter};
 #[derive(Default)]
 pub struct Depot {
     map: HashMap<String, Box<dyn Any + Send + Sync>>,
+    typed: HashMap<TypeId, TypedEntry>,
 }
 
-#[inline]
-fn type_key<T: 'static>() -> String {
-    format!("{:?}", TypeId::of::<T>())
+struct TypedEntry {
+    type_name: &'static str,
+    value: Box<dyn Any + Send + Sync>,
+}
+
+impl TypedEntry {
+    #[inline]
+    fn new<T: Any + Send + Sync>(value: T) -> Self {
+        Self {
+            type_name: type_name::<T>(),
+            value: Box::new(value),
+        }
+    }
 }
 
 impl Depot {
@@ -54,39 +65,122 @@ impl Depot {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
+            typed: HashMap::new(),
         }
     }
 
-    /// Get reference to depot inner map.
+    /// Returns the named values stored in this `Depot`.
+    ///
+    /// This only exposes values inserted with explicit string keys. Values inserted through typed
+    /// storage are intentionally kept separate.
+    #[inline]
+    #[must_use]
+    pub fn named_entries(&self) -> &HashMap<String, Box<dyn Any + Send + Sync>> {
+        &self.map
+    }
+
+    /// Returns the named values stored in this `Depot`.
+    ///
+    /// This is a legacy alias for [`Depot::named_entries`].
     #[inline]
     #[must_use]
     pub fn inner(&self) -> &HashMap<String, Box<dyn Any + Send + Sync>> {
-        &self.map
+        self.named_entries()
     }
 
     /// Creates an empty `Depot` with the specified capacity.
     ///
-    /// The depot will be able to hold at least capacity elements without reallocating. If capacity
-    /// is 0, the depot will not allocate.
+    /// The named storage will be able to hold at least capacity elements without reallocating. If
+    /// capacity is 0, the depot will not allocate.
     #[inline]
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             map: HashMap::with_capacity(capacity),
+            typed: HashMap::new(),
         }
     }
-    /// Returns the number of elements the depot can hold without reallocating.
+    /// Returns the total number of named and typed values the depot can hold without reallocating.
     #[inline]
     #[must_use]
     pub fn capacity(&self) -> usize {
-        self.map.capacity()
+        self.map.capacity() + self.typed.capacity()
+    }
+
+    /// Returns a read-only view of values stored with explicit string keys.
+    #[inline]
+    #[must_use]
+    pub fn named(&self) -> NamedDepot<'_> {
+        NamedDepot { map: &self.map }
+    }
+
+    /// Returns a mutable view of values stored with explicit string keys.
+    #[inline]
+    #[must_use]
+    pub fn named_mut(&mut self) -> NamedDepotMut<'_> {
+        NamedDepotMut { map: &mut self.map }
+    }
+
+    /// Returns a read-only view of values stored by type.
+    #[inline]
+    #[must_use]
+    pub fn typed(&self) -> TypedDepot<'_> {
+        TypedDepot { map: &self.typed }
+    }
+
+    /// Returns a mutable view of values stored by type.
+    #[inline]
+    #[must_use]
+    pub fn typed_mut(&mut self) -> TypedDepotMut<'_> {
+        TypedDepotMut {
+            map: &mut self.typed,
+        }
+    }
+
+    /// Inserts a typed value into the depot.
+    ///
+    /// The value is stored by its [`TypeId`], separately from string-keyed values.
+    #[inline]
+    pub fn insert_typed<V: Any + Send + Sync>(&mut self, value: V) -> &mut Self {
+        self.typed.insert(TypeId::of::<V>(), TypedEntry::new(value));
+        self
+    }
+
+    /// Returns a reference to a typed value stored in the depot.
+    #[inline]
+    #[must_use]
+    pub fn get_typed<T: Any + Send + Sync>(&self) -> Option<&T> {
+        self.typed
+            .get(&TypeId::of::<T>())
+            .and_then(|entry| entry.value.downcast_ref::<T>())
+    }
+
+    /// Returns a mutable reference to a typed value stored in the depot.
+    #[inline]
+    #[must_use]
+    pub fn get_typed_mut<T: Any + Send + Sync>(&mut self) -> Option<&mut T> {
+        self.typed
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|entry| entry.value.downcast_mut::<T>())
+    }
+
+    /// Returns true if a typed value is stored in the depot.
+    #[inline]
+    #[must_use]
+    pub fn contains_typed<T: Any + Send + Sync>(&self) -> bool {
+        self.typed().contains::<T>()
+    }
+
+    /// Removes and returns a typed value from the depot.
+    #[inline]
+    pub fn remove_typed<T: Any + Send + Sync>(&mut self) -> Option<T> {
+        self.typed_mut().remove::<T>()
     }
 
     /// Inject a value into the depot.
     #[inline]
     pub fn inject<V: Any + Send + Sync>(&mut self, value: V) -> &mut Self {
-        self.map.insert(type_key::<V>(), Box::new(value));
-        self
+        self.insert_typed(value)
     }
 
     /// Obtain a reference to a value previously injected into the depot.
@@ -96,7 +190,11 @@ impl Depot {
     /// failed.
     #[inline]
     pub fn obtain<T: Any + Send + Sync>(&self) -> Result<&T, Option<&Box<dyn Any + Send + Sync>>> {
-        self.get(&type_key::<T>())
+        if let Some(entry) = self.typed.get(&TypeId::of::<T>()) {
+            entry.value.downcast_ref::<T>().ok_or(Some(&entry.value))
+        } else {
+            Err(None)
+        }
     }
 
     /// Obtain a mutable reference to a value previously injected into the depot.
@@ -108,7 +206,18 @@ impl Depot {
     pub fn obtain_mut<T: Any + Send + Sync>(
         &mut self,
     ) -> Result<&mut T, Option<&mut Box<dyn Any + Send + Sync>>> {
-        self.get_mut(&type_key::<T>())
+        if let Some(entry) = self.typed.get_mut(&TypeId::of::<T>()) {
+            if entry.value.is::<T>() {
+                Ok(entry
+                    .value
+                    .downcast_mut::<T>()
+                    .expect("typed depot value should downcast"))
+            } else {
+                Err(Some(&mut entry.value))
+            }
+        } else {
+            Err(None)
+        }
     }
 
     /// Inserts a key-value pair into the depot.
@@ -134,7 +243,7 @@ impl Depot {
     #[inline]
     #[must_use]
     pub fn contains<T: Any + Send + Sync>(&self) -> bool {
-        self.map.contains_key(&type_key::<T>())
+        self.contains_typed::<T>()
     }
 
     /// Immutably borrows value from depot.
@@ -192,7 +301,13 @@ impl Depot {
     /// Delete the key from depot, if the key is not present, return `false`.
     #[inline]
     pub fn delete(&mut self, key: &str) -> bool {
-        self.map.remove(key).is_some()
+        self.remove_any(key).is_some()
+    }
+
+    /// Removes and returns any value stored under the given key without downcasting it.
+    #[inline]
+    pub fn remove_any(&mut self, key: &str) -> Option<Box<dyn Any + Send + Sync>> {
+        self.map.remove(key)
     }
 
     /// Remove the injected value of the given type from the depot and return it, if present.
@@ -200,14 +315,255 @@ impl Depot {
     pub fn scrape<T: Any + Send + Sync>(
         &mut self,
     ) -> Result<T, Option<Box<dyn Any + Send + Sync>>> {
-        self.remove(&type_key::<T>())
+        if let Some(entry) = self.typed.remove(&TypeId::of::<T>()) {
+            entry.value.downcast::<T>().map(|b| *b).map_err(Some)
+        } else {
+            Err(None)
+        }
+    }
+}
+
+/// Read-only access to values stored with explicit string keys.
+pub struct NamedDepot<'a> {
+    map: &'a HashMap<String, Box<dyn Any + Send + Sync>>,
+}
+
+impl<'a> NamedDepot<'a> {
+    /// Returns the raw named entries.
+    #[inline]
+    #[must_use]
+    pub fn entries(&self) -> &'a HashMap<String, Box<dyn Any + Send + Sync>> {
+        self.map
+    }
+
+    /// Returns true if a value is stored under the given key.
+    #[inline]
+    #[must_use]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Returns a reference to a value stored under the given key.
+    #[inline]
+    #[must_use]
+    pub fn get<V: Any + Send + Sync>(&self, key: &str) -> Option<&'a V> {
+        self.map
+            .get(key)
+            .and_then(|value| value.downcast_ref::<V>())
+    }
+}
+
+impl Debug for NamedDepot<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NamedDepot")
+            .field("keys", &self.map.keys())
+            .finish()
+    }
+}
+
+/// Mutable access to values stored with explicit string keys.
+pub struct NamedDepotMut<'a> {
+    map: &'a mut HashMap<String, Box<dyn Any + Send + Sync>>,
+}
+
+impl NamedDepotMut<'_> {
+    /// Returns the raw named entries.
+    #[inline]
+    #[must_use]
+    pub fn entries(&self) -> &HashMap<String, Box<dyn Any + Send + Sync>> {
+        self.map
+    }
+
+    /// Returns true if a value is stored under the given key.
+    #[inline]
+    #[must_use]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Inserts a key-value pair and returns the old boxed value, if present.
+    #[inline]
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<Box<dyn Any + Send + Sync>>
+    where
+        K: Into<String>,
+        V: Any + Send + Sync,
+    {
+        self.map.insert(key.into(), Box::new(value))
+    }
+
+    /// Returns a reference to a value stored under the given key.
+    #[inline]
+    #[must_use]
+    pub fn get<V: Any + Send + Sync>(&self, key: &str) -> Option<&V> {
+        self.map
+            .get(key)
+            .and_then(|value| value.downcast_ref::<V>())
+    }
+
+    /// Returns a mutable reference to a value stored under the given key.
+    #[inline]
+    #[must_use]
+    pub fn get_mut<V: Any + Send + Sync>(&mut self, key: &str) -> Option<&mut V> {
+        self.map
+            .get_mut(key)
+            .and_then(|value| value.downcast_mut::<V>())
+    }
+
+    /// Removes and returns a value stored under the given key.
+    ///
+    /// If the stored value has a different type, it is left in the depot and `None` is returned.
+    #[inline]
+    pub fn remove<V: Any + Send + Sync>(&mut self, key: &str) -> Option<V> {
+        if self.map.get(key).is_some_and(|value| value.is::<V>()) {
+            self.map
+                .remove(key)
+                .and_then(|value| value.downcast::<V>().ok())
+                .map(|value| *value)
+        } else {
+            None
+        }
+    }
+
+    /// Removes and returns any value stored under the given key without downcasting it.
+    #[inline]
+    pub fn remove_any(&mut self, key: &str) -> Option<Box<dyn Any + Send + Sync>> {
+        self.map.remove(key)
+    }
+}
+
+impl Debug for NamedDepotMut<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NamedDepotMut")
+            .field("keys", &self.map.keys())
+            .finish()
+    }
+}
+
+/// Read-only access to values stored by type.
+pub struct TypedDepot<'a> {
+    map: &'a HashMap<TypeId, TypedEntry>,
+}
+
+impl<'a> TypedDepot<'a> {
+    /// Returns true if a value of this type is stored in the depot.
+    #[inline]
+    #[must_use]
+    pub fn contains<T: Any + Send + Sync>(&self) -> bool {
+        self.map.contains_key(&TypeId::of::<T>())
+    }
+
+    /// Returns a reference to a value stored by type.
+    #[inline]
+    #[must_use]
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<&'a T> {
+        self.map
+            .get(&TypeId::of::<T>())
+            .and_then(|entry| entry.value.downcast_ref::<T>())
+    }
+
+    /// Returns the Rust type names of values stored by type.
+    #[inline]
+    pub fn type_names(&self) -> impl Iterator<Item = &'static str> + 'a {
+        self.map.values().map(|entry| entry.type_name)
+    }
+}
+
+impl Debug for TypedDepot<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let typed = self
+            .map
+            .values()
+            .map(|entry| entry.type_name)
+            .collect::<Vec<_>>();
+        f.debug_struct("TypedDepot").field("types", &typed).finish()
+    }
+}
+
+/// Mutable access to values stored by type.
+pub struct TypedDepotMut<'a> {
+    map: &'a mut HashMap<TypeId, TypedEntry>,
+}
+
+impl TypedDepotMut<'_> {
+    /// Returns true if a value of this type is stored in the depot.
+    #[inline]
+    #[must_use]
+    pub fn contains<T: Any + Send + Sync>(&self) -> bool {
+        self.map.contains_key(&TypeId::of::<T>())
+    }
+
+    /// Inserts a typed value and returns the old value of the same type, if present.
+    #[inline]
+    pub fn insert<T: Any + Send + Sync>(&mut self, value: T) -> Option<T> {
+        self.map
+            .insert(TypeId::of::<T>(), TypedEntry::new(value))
+            .map(|entry| {
+                *entry
+                    .value
+                    .downcast::<T>()
+                    .expect("typed depot value should downcast")
+            })
+    }
+
+    /// Returns a reference to a value stored by type.
+    #[inline]
+    #[must_use]
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
+        self.map
+            .get(&TypeId::of::<T>())
+            .and_then(|entry| entry.value.downcast_ref::<T>())
+    }
+
+    /// Returns a mutable reference to a value stored by type.
+    #[inline]
+    #[must_use]
+    pub fn get_mut<T: Any + Send + Sync>(&mut self) -> Option<&mut T> {
+        self.map
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|entry| entry.value.downcast_mut::<T>())
+    }
+
+    /// Removes and returns a value stored by type.
+    #[inline]
+    pub fn remove<T: Any + Send + Sync>(&mut self) -> Option<T> {
+        self.map.remove(&TypeId::of::<T>()).map(|entry| {
+            *entry
+                .value
+                .downcast::<T>()
+                .expect("typed depot value should downcast")
+        })
+    }
+
+    /// Returns the Rust type names of values stored by type.
+    #[inline]
+    pub fn type_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.map.values().map(|entry| entry.type_name)
+    }
+}
+
+impl Debug for TypedDepotMut<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let typed = self
+            .map
+            .values()
+            .map(|entry| entry.type_name)
+            .collect::<Vec<_>>();
+        f.debug_struct("TypedDepotMut")
+            .field("types", &typed)
+            .finish()
     }
 }
 
 impl Debug for Depot {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let typed = self
+            .typed
+            .values()
+            .map(|entry| entry.type_name)
+            .collect::<Vec<_>>();
         f.debug_struct("Depot")
-            .field("keys", &self.map.keys())
+            .field("named_keys", &self.map.keys())
+            .field("typed", &typed)
             .finish()
     }
 }
@@ -225,12 +581,54 @@ mod test {
 
         depot.insert("one", "ONE".to_owned());
         assert!(depot.contains_key("one"));
+        assert!(depot.named().contains_key("one"));
 
         assert_eq!(depot.get::<String>("one").unwrap(), &"ONE".to_owned());
+        assert_eq!(depot.named().get::<String>("one").unwrap(), "ONE");
         assert_eq!(
             depot.get_mut::<String>("one").unwrap(),
             &mut "ONE".to_owned()
         );
+        assert_eq!(
+            depot.named_mut().get_mut::<String>("one").unwrap(),
+            &mut "ONE".to_owned()
+        );
+    }
+
+    #[test]
+    fn test_typed_depot() {
+        let mut depot = Depot::new();
+
+        assert!(depot.get_typed::<String>().is_none());
+        depot.insert_typed("typed".to_owned());
+        assert!(depot.contains_typed::<String>());
+        assert!(depot.contains::<String>());
+        assert_eq!(depot.get_typed::<String>().unwrap(), "typed");
+        assert_eq!(depot.typed().get::<String>().unwrap(), "typed");
+        assert_eq!(depot.obtain::<String>().unwrap(), "typed");
+
+        let old = depot.typed_mut().insert("new typed".to_owned());
+        assert_eq!(old.as_deref(), Some("typed"));
+        assert_eq!(depot.get_typed::<String>().unwrap(), "new typed");
+
+        assert_eq!(depot.remove_typed::<String>().unwrap(), "new typed");
+        assert!(depot.obtain::<String>().is_err());
+    }
+
+    #[test]
+    fn test_named_and_typed_storage_are_separate() {
+        let mut depot = Depot::new();
+
+        depot.insert("value", "named".to_owned());
+        depot.insert_typed("typed".to_owned());
+
+        assert_eq!(depot.get::<String>("value").unwrap(), "named");
+        assert_eq!(depot.get_typed::<String>().unwrap(), "typed");
+        assert_eq!(depot.named_entries().len(), 1);
+
+        let removed = depot.remove_any("value").unwrap();
+        assert_eq!(*removed.downcast::<String>().unwrap(), "named");
+        assert_eq!(depot.remove_typed::<String>().unwrap(), "typed");
     }
 
     #[tokio::test]

--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -139,7 +139,25 @@ impl Depot {
 
     /// Inserts a typed value into the depot.
     ///
-    /// The value is stored by its [`TypeId`], separately from string-keyed values.
+    /// The value is stored by its [`TypeId`], separately from string-keyed values. Any existing
+    /// value of the same type is replaced.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use salvo_core::Depot;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Config {
+    ///     debug: bool,
+    /// }
+    ///
+    /// let mut depot = Depot::new();
+    /// depot.insert_typed(Config { debug: true });
+    /// assert_eq!(depot.get_typed::<Config>(), Some(&Config { debug: true }));
+    /// assert_eq!(depot.remove_typed::<Config>(), Some(Config { debug: true }));
+    /// assert!(!depot.contains_typed::<Config>());
+    /// ```
     #[inline]
     pub fn insert_typed<V: Any + Send + Sync>(&mut self, value: V) -> &mut Self {
         self.typed.insert(TypeId::of::<V>(), TypedEntry::new(value));
@@ -168,16 +186,23 @@ impl Depot {
     #[inline]
     #[must_use]
     pub fn contains_typed<T: Any + Send + Sync>(&self) -> bool {
-        self.typed().contains::<T>()
+        self.typed.contains_key(&TypeId::of::<T>())
     }
 
     /// Removes and returns a typed value from the depot.
     #[inline]
     pub fn remove_typed<T: Any + Send + Sync>(&mut self) -> Option<T> {
-        self.typed_mut().remove::<T>()
+        self.typed.remove(&TypeId::of::<T>()).map(|entry| {
+            *entry
+                .value
+                .downcast::<T>()
+                .expect("typed depot value should downcast")
+        })
     }
 
     /// Inject a value into the depot.
+    ///
+    /// This is an alias for [`Depot::insert_typed`].
     #[inline]
     pub fn inject<V: Any + Send + Sync>(&mut self, value: V) -> &mut Self {
         self.insert_typed(value)
@@ -188,6 +213,8 @@ impl Depot {
     /// Returns `Err(None)` if the value is not present in the depot.
     /// Returns `Err(Some(Box<dyn Any + Send + Sync>))` if the value is present but downcasting
     /// failed.
+    ///
+    /// Consider [`Depot::get_typed`], which returns an `Option` instead.
     #[inline]
     pub fn obtain<T: Any + Send + Sync>(&self) -> Result<&T, Option<&Box<dyn Any + Send + Sync>>> {
         if let Some(entry) = self.typed.get(&TypeId::of::<T>()) {
@@ -202,6 +229,8 @@ impl Depot {
     /// Returns `Err(None)` if value is not present in depot.
     /// Returns `Err(Some(Box<dyn Any + Send + Sync>))` if value is present in depot but downcasting
     /// failed.
+    ///
+    /// Consider [`Depot::get_typed_mut`], which returns an `Option` instead.
     #[inline]
     pub fn obtain_mut<T: Any + Send + Sync>(
         &mut self,
@@ -221,6 +250,8 @@ impl Depot {
     }
 
     /// Inserts a key-value pair into the depot.
+    ///
+    /// Any existing value stored under the same key is replaced.
     #[inline]
     pub fn insert<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
@@ -239,7 +270,9 @@ impl Depot {
     }
     /// Check whether a value of this type has been injected into the depot.
     ///
-    /// **Note**: Only checks values inserted via [`Depot::inject`].
+    /// **Note**: Only checks typed values, i.e. those inserted via [`Depot::inject`],
+    /// [`Depot::insert_typed`] or [`TypedDepotMut::insert`]. This is an alias for
+    /// [`Depot::contains_typed`].
     #[inline]
     #[must_use]
     pub fn contains<T: Any + Send + Sync>(&self) -> bool {
@@ -311,6 +344,8 @@ impl Depot {
     }
 
     /// Remove the injected value of the given type from the depot and return it, if present.
+    ///
+    /// Consider [`Depot::remove_typed`], which returns an `Option` instead.
     #[inline]
     pub fn scrape<T: Any + Send + Sync>(
         &mut self,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,7 +70,7 @@ cfg_feature! {
 }
 
 pub use self::conn::Listener;
-pub use self::depot::Depot;
+pub use self::depot::{Depot, NamedDepot, NamedDepotMut, TypedDepot, TypedDepotMut};
 pub use self::error::{BoxedError, Error};
 pub use self::extract::Extractible;
 pub use self::handler::Handler;

--- a/crates/extra/src/affix_state.rs
+++ b/crates/extra/src/affix_state.rs
@@ -27,9 +27,9 @@
 //!
 //! #[handler]
 //! async fn hello(depot: &mut Depot) -> String {
-//!     let config = depot.obtain::<Config>().unwrap();
-//!     let custom_data = depot.get::<&str>("custom_data").unwrap();
-//!     let state = depot.obtain::<Arc<State>>().unwrap();
+//!     let config = depot.get_typed::<Config>().unwrap();
+//!     let custom_data = depot.named().get::<&str>("custom_data").unwrap();
+//!     let state = depot.get_typed::<Arc<State>>().unwrap();
 //!     let mut fails_ref = state.fails.lock().unwrap();
 //!     fails_ref.push("fail message".into());
 //!     format!("Hello World\nConfig: {config:#?}\nFails: {fails_ref:#?}\nCustom Data: {custom_data}")
@@ -56,7 +56,6 @@
 //!     Server::new(acceptor).serve(router).await;
 //! }
 //! ```
-use std::any::TypeId;
 use std::fmt::{self, Debug, Formatter};
 
 use salvo_core::handler;
@@ -67,30 +66,43 @@ trait AffixState {
 }
 
 #[derive(Default)]
-struct AffixCell<V> {
+struct NamedAffixCell<V> {
     key: String,
     value: V,
 }
-impl<T> AffixState for AffixCell<T>
+impl<T> AffixState for NamedAffixCell<T>
 where
     T: Send + Sync + Clone + 'static,
 {
     fn affix_to(&self, depot: &mut Depot) {
-        depot.insert(self.key.clone(), self.value.clone());
+        depot.named_mut().insert(self.key.clone(), self.value.clone());
     }
 }
 
-/// Inject a typed value into depot using the type's ID as the key.
+#[derive(Default)]
+struct TypedAffixCell<V> {
+    value: V,
+}
+impl<T> AffixState for TypedAffixCell<T>
+where
+    T: Send + Sync + Clone + 'static,
+{
+    fn affix_to(&self, depot: &mut Depot) {
+        depot.typed_mut().insert(self.value.clone());
+    }
+}
+
+/// Injects a typed value into the depot.
 ///
 /// This is useful when you want to access the value by its type rather than by an explicit key.
 ///
 /// View [module level documentation](index.html) for more details.
 #[inline]
 pub fn inject<V: Send + Sync + Clone + 'static>(value: V) -> AffixList {
-    insert(format!("{:?}", TypeId::of::<V>()), value)
+    AffixList::new().inject(value)
 }
 
-/// Insert a key-value pair into depot with an explicit key.
+/// Inserts a key-value pair into the depot with an explicit key.
 ///
 /// Use this when you need to access the value using a specific key string.
 ///
@@ -104,7 +116,7 @@ where
     AffixList::new().insert(key, value)
 }
 
-/// AffixList is used to add any data to depot.
+/// `AffixList` adds typed and named values to the depot.
 ///
 /// View [module level documentation](index.html) for more details.
 #[derive(Default)]
@@ -120,25 +132,26 @@ impl Debug for AffixList {
 
 #[handler]
 impl AffixList {
-    /// Create an empty affix list.
+    /// Creates an empty affix list.
     #[must_use]
     pub fn new() -> Self {
         Self(Vec::new())
     }
-    /// Inject a value into depot.
+    /// Injects a typed value into the depot.
     #[must_use]
-    pub fn inject<V: Send + Sync + Clone + 'static>(self, value: V) -> Self {
-        self.insert(format!("{:?}", TypeId::of::<V>()), value)
+    pub fn inject<V: Send + Sync + Clone + 'static>(mut self, value: V) -> Self {
+        self.0.push(Box::new(TypedAffixCell { value }));
+        self
     }
 
-    /// Insert a key-value pair into depot.
+    /// Inserts a key-value pair into the depot.
     #[must_use]
     pub fn insert<K, V>(mut self, key: K, value: V) -> Self
     where
         K: Into<String>,
         V: Send + Sync + Clone + 'static,
     {
-        let cell = AffixCell {
+        let cell = NamedAffixCell {
             key: key.into(),
             value,
         };
@@ -169,10 +182,14 @@ mod tests {
         format!(
             "{}:{}",
             depot
-                .obtain::<Arc<User>>()
+                .get_typed::<Arc<User>>()
                 .map(|u| u.name.clone())
                 .unwrap_or_default(),
-            depot.get::<&str>("data1").copied().unwrap_or_default()
+            depot
+                .named()
+                .get::<&str>("data1")
+                .copied()
+                .unwrap_or_default()
         )
     }
     #[tokio::test]

--- a/crates/extra/src/affix_state.rs
+++ b/crates/extra/src/affix_state.rs
@@ -75,7 +75,7 @@ where
     T: Send + Sync + Clone + 'static,
 {
     fn affix_to(&self, depot: &mut Depot) {
-        depot.named_mut().insert(self.key.clone(), self.value.clone());
+        depot.insert(self.key.clone(), self.value.clone());
     }
 }
 
@@ -88,7 +88,7 @@ where
     T: Send + Sync + Clone + 'static,
 {
     fn affix_to(&self, depot: &mut Depot) {
-        depot.typed_mut().insert(self.value.clone());
+        depot.insert_typed(self.value.clone());
     }
 }
 

--- a/crates/tus/src/handlers/delete.rs
+++ b/crates/tus/src/handlers/delete.rs
@@ -11,7 +11,7 @@ use crate::{CancellationContext, H_TUS_RESUMABLE, H_TUS_VERSION, TUS_VERSION, Tu
 
 #[handler]
 async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/delete.rs
+++ b/crates/tus/src/handlers/delete.rs
@@ -11,7 +11,7 @@ use crate::{CancellationContext, H_TUS_RESUMABLE, H_TUS_VERSION, TUS_VERSION, Tu
 
 #[handler]
 async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -10,7 +10,7 @@ use crate::{CancellationContext, H_TUS_RESUMABLE, H_TUS_VERSION, TUS_VERSION, Tu
 
 #[handler]
 async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -10,7 +10,7 @@ use crate::{CancellationContext, H_TUS_RESUMABLE, H_TUS_VERSION, TUS_VERSION, Tu
 
 #[handler]
 async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[handler]
 async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[handler]
 async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     let headers = apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -14,7 +14,7 @@ use crate::{
 #[handler]
 /// https://tus.io/protocols/resumable-upload#options
 async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let store = &state.store;
     let opts = &state.options;
     let max_size = opts.get_configured_max_size(req, None).await;

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -14,7 +14,7 @@ use crate::{
 #[handler]
 /// https://tus.io/protocols/resumable-upload#options
 async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let store = &state.store;
     let opts = &state.options;
     let max_size = opts.get_configured_max_size(req, None).await;

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[handler]
 async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[handler]
 async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
     apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Tus-Resumable: 1.0.0
 #[handler]
 async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.obtain::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
     let store = &state.store;
     let opts = &state.options;
     apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Tus-Resumable: 1.0.0
 #[handler]
 async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let state = depot.typed().get::<Arc<Tus>>().expect("missing tus state");
+    let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let store = &state.store;
     let opts = &state.options;
     apply_common_headers(req, opts, &mut res.headers);

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -236,7 +236,7 @@ struct TusStateHoop {
 #[handler]
 impl TusStateHoop {
     async fn handle(&self, depot: &mut Depot) {
-        depot.inject(self.state.clone());
+        depot.typed_mut().insert(self.state.clone());
     }
 }
 

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -236,7 +236,7 @@ struct TusStateHoop {
 #[handler]
 impl TusStateHoop {
     async fn handle(&self, depot: &mut Depot) {
-        depot.typed_mut().insert(self.state.clone());
+        depot.insert_typed(self.state.clone());
     }
 }
 


### PR DESCRIPTION
## Summary

- Split `Depot` named values and typed values into separate internal storage.
- Add `named()` / `named_mut()` and `typed()` / `typed_mut()` views, plus flat typed helpers such as `insert_typed`, `get_typed`, and `remove_typed`.
- Keep the legacy `insert` / `get` / `remove` keyed API and `inject` / `obtain` / `scrape` typed aliases for compatibility.
- Move `affix_state` and tus internals onto the new typed storage path instead of stringifying `TypeId`.

## Validation

- `cargo fmt -p salvo_core -p salvo_extra -p salvo-tus -- --check`
- `cargo test -p salvo_core`
- `cargo test -p salvo-tus --lib`
- `cargo test -p salvo_extra --no-default-features --features affix-state,timeout,salvo_core/aws-lc-rs affix`
- `cargo clippy -p salvo_core --all-targets -- -D warnings`
- `cargo clippy -p salvo-tus --lib -- -D warnings`
- `cargo clippy -p salvo_extra --no-default-features --features affix-state,timeout,salvo_core/aws-lc-rs -- -D warnings`