### PR TITLE
Add CSRF skipper builder

### DIFF
--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -281,6 +281,16 @@ impl<C: CsrfCipher, S: CsrfStore> Csrf<C, S> {
         self
     }
 
+    /// Sets the [`Skipper`] used to bypass CSRF validation for matching requests.
+    ///
+    /// This replaces the default skipper, which skips safe request methods.
+    #[inline]
+    #[must_use]
+    pub fn skipper(mut self, skipper: impl Skipper) -> Self {
+        self.skipper = Box::new(skipper);
+        self
+    }
+
     /// Sets the token rotation policy. Defaults to [`CsrfRotationPolicy::PerSession`].
     #[inline]
     #[must_use]
@@ -586,6 +596,22 @@ mod tests {
             .add_header("cookie", cookie.to_string(), true)
             .send(&service)
             .await;
+        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.take_string().await.unwrap(), "POST");
+    }
+
+    #[tokio::test]
+    async fn test_custom_skipper_bypasses_csrf_validation() {
+        let csrf = Csrf::new(
+            BcryptCipher::new(),
+            CookieStore::new(),
+            HeaderFinder::new("x-csrf-token"),
+        )
+        .skipper(|req: &mut Request, _depot: &Depot| *req.method() == Method::POST);
+        let router = Router::new().hoop(csrf).post(post_index);
+
+        let mut res = TestClient::post("http://127.0.0.1:5801").send(router).await;
+
         assert_eq!(res.status_code.unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }


### PR DESCRIPTION
## Summary

Adds a public `Csrf::skipper(...)` builder method so callers can replace the default CSRF skipper with a custom `Skipper`.

## Motivation

`Csrf` already stores and checks a skipper internally, but there was no public API to configure it. This exposes the same style of builder method used by other middleware.

Closes #1518.

## Validation

- `cargo fmt --package salvo-csrf`
- `cargo test -p salvo-csrf`
- `cargo test -p salvo-csrf --features full`