### PR TITLE
fix(core): skip charset sniffing for precompressed files (mojibake)

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -270,11 +270,19 @@ impl NamedFileBuilder {
         let inferred_mime = content_type
             .clone()
             .or_else(|| mime_infer::from_path(&path).first());
-        let needs_charset = inferred_mime
-            .as_ref()
-            .map(|m| is_charset_required_mime(m) && m.get_param("charset").is_none())
-            .unwrap_or(false);
-        let needs_detect = content_type.is_none() && path.extension().is_none();
+        // When a content encoding is set, the on-disk bytes are the *encoded*
+        // (e.g. gzip) payload of a precompressed sidecar file. Sniffing a charset
+        // or text mime from those compressed bytes yields a bogus result (the
+        // compressed blob is not valid UTF-8), so the wrong `charset=` would be
+        // attached to the `Content-Type` and the client mojibakes the decoded
+        // text. Skip content-based detection in that case.
+        let is_encoded = content_encoding.is_some();
+        let needs_charset = !is_encoded
+            && inferred_mime
+                .as_ref()
+                .map(|m| is_charset_required_mime(m) && m.get_param("charset").is_none())
+                .unwrap_or(false);
+        let needs_detect = !is_encoded && content_type.is_none() && path.extension().is_none();
 
         // Single spawn_blocking: open + metadata + optional preread.
         // This replaces 3-7 separate spawn_blocking calls with just 1.
@@ -808,6 +816,37 @@ mod tests {
         assert_eq!(
             value.to_str().unwrap(),
             r#"attachment; filename="report\"\\__.txt"; filename*=UTF-8''report%22%5C%0D%0A.txt"#
+        );
+    }
+
+    #[tokio::test]
+    async fn precompressed_file_does_not_sniff_charset_from_encoded_bytes() {
+        use std::io::Write as _;
+
+        // Simulate a `.js.gz` sidecar: the on-disk bytes are a gzip payload, which
+        // is not valid UTF-8. Without the fix, charset detection runs on these
+        // compressed bytes and attaches a bogus `charset=` to the text/javascript
+        // content type, causing the client to mojibake the decoded source.
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.write_all(&[
+            0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xab, 0xe2, 0x80, 0x9c,
+            0xc3, 0xa9, 0xb4, 0xd6, 0xfe, 0x00,
+        ])
+        .expect("write gzip-like bytes");
+        file.flush().expect("flush");
+
+        let named = NamedFile::builder(file.path())
+            .content_type("text/javascript".parse().expect("parse mime"))
+            .content_encoding("gzip")
+            .build()
+            .await
+            .expect("build named file");
+
+        // No charset must be sniffed from the encoded payload.
+        assert_eq!(named.content_type().get_param("charset"), None);
+        assert_eq!(
+            named.content_encoding().map(|v| v.to_str().unwrap()),
+            Some("gzip")
         );
     }
 


### PR DESCRIPTION
## Problem

Fixes #1520.

When `StaticDir` serves a precompressed sidecar file (e.g. a `routers-xxx.js.gz` next to `routers-xxx.js`), non-ASCII content such as Chinese is rendered as mojibake in the browser. This is a regression — it worked on older versions, and the workaround was to delete the `.gz` files.

## Root cause

The serving path is:

1. `StaticDir::handle` infers the `Content-Type` from the **original** file (`*.js` → `text/javascript`, no charset) and builds a `NamedFile` pointing at the **`.gz`** file with `Content-Encoding: gzip`.
2. `NamedFileBuilder::build` prereads the on-disk bytes and, for charset-requiring mime types (`text/*`, `javascript`, `json`, `xml`), runs `chardetng` over those bytes to fill in `charset=`.
3. But for an encoded sidecar, the preread bytes are the **gzip payload**, not valid UTF-8. `chardetng` guesses a bogus legacy charset (e.g. `windows-1252`) and attaches it to `Content-Type`.
4. The client transparently gunzips the body, then decodes the resulting (correct UTF-8) text using the wrong charset → mojibake.

This only affects files that have a precompressed sidecar, which matches the reporter's observation (the plain `index.html` with no `.gz` rendered fine; the bundled JS/CSS with `.gz` did not).

## Fix

Skip content-based charset / text-mime detection whenever a `Content-Encoding` is set, because the preread bytes are the encoded payload and do not represent the decoded text. The content type is left without a sniffed `charset` (ES modules default to UTF-8; classic scripts inherit the document encoding).

## Test

Added `precompressed_file_does_not_sniff_charset_from_encoded_bytes`: builds a `NamedFile` from gzip-like (non-UTF-8) bytes with `content_type=text/javascript` and `content_encoding=gzip`, and asserts no `charset` is attached. Verified it fails without the fix and passes with it.
