### PR TITLE
docs(acme): minor patches to fix the `docs.rs` build

### DIFF
--- a/crates/acme/src/config.rs
+++ b/crates/acme/src/config.rs
@@ -259,7 +259,7 @@ impl AcmeConfigBuilder {
 
     /// Sets a custom persistent storage backend.
     ///
-    /// By default, a [`FileStorage`] will be created from the `cache_path`
+    /// By default, a [`certon::FileStorage`] will be created from the `cache_path`
     /// if provided.
     #[inline]
     #[must_use]

--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 //! Automatic HTTPS/TLS certificate management for Salvo via the ACME protocol.
 //!


### PR DESCRIPTION
Fixed `salvo-acme` [docs.rs build failure](https://docs.rs/crate/salvo-acme/0.93.0/builds/3201634)