### PR TITLE
Refactor `salvo-cors`

### DIFF
--- a/crates/cors/src/allow_credentials.rs
+++ b/crates/cors/src/allow_credentials.rs
@@ -1,10 +1,10 @@
-use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
+
+use super::inner::BoolInner;
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Credentials`][mdn] header.
 ///
@@ -12,9 +12,9 @@ use salvo_core::{Depot, Request};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
 /// [`Cors::allow_credentials`]: super::Cors::allow_credentials
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AllowCredentials(AllowCredentialsInner);
+pub struct AllowCredentials(BoolInner);
 
 impl AllowCredentials {
     /// Allow credentials for all requests
@@ -23,7 +23,7 @@ impl AllowCredentials {
     ///
     /// [`Cors::allow_credentials`]: super::Cors::allow_credentials
     pub fn yes() -> Self {
-        Self(AllowCredentialsInner::Yes)
+        Self(BoolInner::Yes)
     }
 
     /// Allow credentials for some requests by a closure
@@ -35,7 +35,7 @@ impl AllowCredentials {
     where
         P: Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync + 'static,
     {
-        Self(AllowCredentialsInner::Dynamic(Arc::new(p)))
+        Self(BoolInner::Dynamic(Arc::new(p)))
     }
 
     /// Allow credentials for some requests by an async closure
@@ -48,13 +48,13 @@ impl AllowCredentials {
         P: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = bool> + Send + 'static,
     {
-        Self(AllowCredentialsInner::DynamicAsync(Arc::new(
+        Self(BoolInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(p(header, req, depot)),
         )))
     }
 
     pub(super) fn is_true(&self) -> bool {
-        matches!(&self.0, AllowCredentialsInner::Yes)
+        matches!(&self.0, BoolInner::Yes)
     }
 
     pub(super) async fn to_header(
@@ -63,14 +63,7 @@ impl AllowCredentials {
         req: &Request,
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
-        let allow_creds = match &self.0 {
-            AllowCredentialsInner::Yes => true,
-            AllowCredentialsInner::No => false,
-            AllowCredentialsInner::Dynamic(p) => p(origin, req, depot),
-            AllowCredentialsInner::DynamicAsync(p) => p(origin, req, depot).await,
-        };
-
-        allow_creds.then_some((
+        self.0.resolve_async(origin, req, depot).await.then_some((
             header::ACCESS_CONTROL_ALLOW_CREDENTIALS,
             HeaderValue::from_static("true"),
         ))
@@ -80,51 +73,22 @@ impl AllowCredentials {
 impl From<bool> for AllowCredentials {
     fn from(v: bool) -> Self {
         match v {
-            true => Self(AllowCredentialsInner::Yes),
-            false => Self(AllowCredentialsInner::No),
+            true => Self(BoolInner::Yes),
+            false => Self(BoolInner::No),
         }
     }
 }
 
-impl Debug for AllowCredentials {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            AllowCredentialsInner::Yes => f.debug_tuple("Yes").finish(),
-            AllowCredentialsInner::No => f.debug_tuple("No").finish(),
-            AllowCredentialsInner::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
-            AllowCredentialsInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
-    }
-}
-
-#[derive(Default, Clone)]
-enum AllowCredentialsInner {
-    Yes,
-    #[default]
-    No,
-    Dynamic(Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync>),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = bool> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
-}
 #[cfg(test)]
 mod tests {
-    use super::{AllowCredentials, AllowCredentialsInner};
+    use super::AllowCredentials;
 
     #[test]
     fn test_from_bool() {
         let creds: AllowCredentials = true.into();
-        assert!(matches!(creds.0, AllowCredentialsInner::Yes));
+        assert!(creds.is_true());
 
         let creds: AllowCredentials = false.into();
-        assert!(matches!(creds.0, AllowCredentialsInner::No));
+        assert!(!creds.is_true());
     }
 }

--- a/crates/cors/src/allow_credentials.rs
+++ b/crates/cors/src/allow_credentials.rs
@@ -33,7 +33,7 @@ impl AllowCredentials {
     /// [`Cors::allow_credentials`]: super::Cors::allow_credentials
     pub fn dynamic<P>(p: P) -> Self
     where
-        P: Fn(&HeaderValue, &Request, &Depot) -> bool + Send + Sync + 'static,
+        P: Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync + 'static,
     {
         Self(AllowCredentialsInner::Dynamic(Arc::new(p)))
     }
@@ -45,7 +45,7 @@ impl AllowCredentials {
     /// [`Cors::allow_credentials`]: super::Cors::allow_credentials
     pub fn dynamic_async<P, Fut>(p: P) -> Self
     where
-        P: Fn(&HeaderValue, &Request, &Depot) -> Fut + Send + Sync + 'static,
+        P: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = bool> + Send + 'static,
     {
         Self(AllowCredentialsInner::DynamicAsync(Arc::new(
@@ -66,8 +66,8 @@ impl AllowCredentials {
         let allow_creds = match &self.0 {
             AllowCredentialsInner::Yes => true,
             AllowCredentialsInner::No => false,
-            AllowCredentialsInner::Dynamic(p) => p(origin?, req, depot),
-            AllowCredentialsInner::DynamicAsync(p) => p(origin?, req, depot).await,
+            AllowCredentialsInner::Dynamic(p) => p(origin, req, depot),
+            AllowCredentialsInner::DynamicAsync(p) => p(origin, req, depot).await,
         };
 
         allow_creds.then_some((
@@ -102,10 +102,14 @@ enum AllowCredentialsInner {
     Yes,
     #[default]
     No,
-    Dynamic(Arc<dyn Fn(&HeaderValue, &Request, &Depot) -> bool + Send + Sync>),
+    Dynamic(Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync>),
     DynamicAsync(
         Arc<
-            dyn Fn(&HeaderValue, &Request, &Depot) -> Pin<Box<dyn Future<Output = bool> + Send>>
+            dyn Fn(
+                    Option<&HeaderValue>,
+                    &Request,
+                    &Depot,
+                ) -> Pin<Box<dyn Future<Output = bool> + Send>>
                 + Send
                 + Sync,
         >,

--- a/crates/cors/src/allow_headers.rs
+++ b/crates/cors/src/allow_headers.rs
@@ -6,7 +6,7 @@ use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
 use super::inner::HeaderInner;
-use super::{separated_by_commas, Any, WILDCARD};
+use super::{Any, WILDCARD, separated_by_commas};
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Headers`][mdn] header.
 ///
@@ -158,7 +158,8 @@ impl From<&Vec<String>> for AllowHeaders {
 mod tests {
     use salvo_core::http::header;
 
-    use super::{super::inner::HeaderInner, AllowHeaders, Any};
+    use super::super::inner::HeaderInner;
+    use super::{AllowHeaders, Any};
 
     #[test]
     fn test_from_any() {

--- a/crates/cors/src/allow_headers.rs
+++ b/crates/cors/src/allow_headers.rs
@@ -1,13 +1,12 @@
-use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
-use super::{Any, WILDCARD, separated_by_commas};
+use super::inner::HeaderInner;
+use super::{separated_by_commas, Any, WILDCARD};
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Headers`][mdn] header.
 ///
@@ -15,9 +14,9 @@ use super::{Any, WILDCARD, separated_by_commas};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 /// [`Cors::allow_headers`]: super::Cors::allow_headers
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AllowHeaders(AllowHeadersInner);
+pub struct AllowHeaders(HeaderInner);
 
 impl AllowHeaders {
     /// Allow any headers by sending a wildcard (`*`)
@@ -26,7 +25,7 @@ impl AllowHeaders {
     ///
     /// [`Cors::allow_headers`]: super::Cors::allow_headers
     pub fn any() -> Self {
-        Self(AllowHeadersInner::Exact(WILDCARD.clone()))
+        Self(HeaderInner::Exact(WILDCARD.clone()))
     }
 
     /// Set multiple allowed headers
@@ -40,8 +39,8 @@ impl AllowHeaders {
     {
         let headers = headers.into_iter().map(Into::into);
         match separated_by_commas(headers) {
-            None => Self(AllowHeadersInner::None),
-            Some(v) => Self(AllowHeadersInner::Exact(v)),
+            None => Self(HeaderInner::None),
+            Some(v) => Self(HeaderInner::Exact(v)),
         }
     }
 
@@ -57,7 +56,7 @@ impl AllowHeaders {
             + Sync
             + 'static,
     {
-        Self(AllowHeadersInner::Dynamic(Arc::new(c)))
+        Self(HeaderInner::Dynamic(Arc::new(c)))
     }
 
     /// Set allowed headers by an async closure.
@@ -70,7 +69,7 @@ impl AllowHeaders {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
     {
-        Self(AllowHeadersInner::DynamicAsync(Arc::new(
+        Self(HeaderInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
@@ -84,11 +83,11 @@ impl AllowHeaders {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers
     pub fn mirror_request() -> Self {
-        Self(AllowHeadersInner::MirrorRequest)
+        Self(HeaderInner::MirrorRequest)
     }
 
     pub(super) fn is_wildcard(&self) -> bool {
-        matches!(&self.0, AllowHeadersInner::Exact(v) if v == WILDCARD)
+        matches!(&self.0, HeaderInner::Exact(v) if v == WILDCARD)
     }
 
     pub(super) async fn to_header(
@@ -97,30 +96,12 @@ impl AllowHeaders {
         req: &Request,
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
-        let allow_headers = match &self.0 {
-            AllowHeadersInner::None => return None,
-            AllowHeadersInner::Exact(v) => v.clone(),
-            AllowHeadersInner::MirrorRequest => req
-                .headers()
-                .get(header::ACCESS_CONTROL_REQUEST_HEADERS)?
-                .clone(),
-            AllowHeadersInner::Dynamic(d) => d(origin, req, depot)?,
-            AllowHeadersInner::DynamicAsync(d) => d(origin, req, depot).await?,
-        };
-
-        Some((header::ACCESS_CONTROL_ALLOW_HEADERS, allow_headers))
-    }
-}
-
-impl Debug for AllowHeaders {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            AllowHeadersInner::None => f.debug_tuple("None").finish(),
-            AllowHeadersInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
-            AllowHeadersInner::MirrorRequest => f.debug_tuple("MirrorRequest").finish(),
-            AllowHeadersInner::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
-            AllowHeadersInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
+        let mirror = req
+            .headers()
+            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)?
+            .clone();
+        let value = self.0.resolve(origin, req, depot, Some(mirror)).await?;
+        Some((header::ACCESS_CONTROL_ALLOW_HEADERS, value))
     }
 }
 
@@ -173,43 +154,21 @@ impl From<&Vec<String>> for AllowHeaders {
     }
 }
 
-#[derive(Clone, Default)]
-enum AllowHeadersInner {
-    #[default]
-    None,
-    Exact(HeaderValue),
-    MirrorRequest,
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
-}
-
 #[cfg(test)]
 mod tests {
     use salvo_core::http::header;
 
-    use super::{AllowHeaders, AllowHeadersInner, Any};
+    use super::{super::inner::HeaderInner, AllowHeaders, Any};
 
     #[test]
     fn test_from_any() {
         let headers: AllowHeaders = Any.into();
-        assert!(matches!(headers.0, AllowHeadersInner::Exact(ref v) if v == "*"));
+        assert!(matches!(headers.0, HeaderInner::Exact(ref v) if v == "*"));
     }
 
     #[test]
     fn test_from_list() {
         let headers: AllowHeaders = vec![header::CONTENT_TYPE, header::ACCEPT].into();
-        assert!(matches!(headers.0, AllowHeadersInner::Exact(ref v) if v == "content-type,accept"));
+        assert!(matches!(headers.0, HeaderInner::Exact(ref v) if v == "content-type,accept"));
     }
 }

--- a/crates/cors/src/allow_headers.rs
+++ b/crates/cors/src/allow_headers.rs
@@ -98,9 +98,9 @@ impl AllowHeaders {
     ) -> Option<(HeaderName, HeaderValue)> {
         let mirror = req
             .headers()
-            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)?
-            .clone();
-        let value = self.0.resolve(origin, req, depot, Some(mirror)).await?;
+            .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+            .cloned();
+        let value = self.0.resolve(origin, req, depot, mirror).await?;
         Some((header::ACCESS_CONTROL_ALLOW_HEADERS, value))
     }
 }
@@ -156,7 +156,8 @@ impl From<&Vec<String>> for AllowHeaders {
 
 #[cfg(test)]
 mod tests {
-    use salvo_core::http::header;
+    use salvo_core::http::header::{self, HeaderValue};
+    use salvo_core::{Depot, Request};
 
     use super::super::inner::HeaderInner;
     use super::{AllowHeaders, Any};
@@ -171,5 +172,32 @@ mod tests {
     fn test_from_list() {
         let headers: AllowHeaders = vec![header::CONTENT_TYPE, header::ACCEPT].into();
         assert!(matches!(headers.0, HeaderInner::Exact(ref v) if v == "content-type,accept"));
+    }
+
+    #[tokio::test]
+    async fn exact_and_dynamic_do_not_require_request_headers() {
+        let req = Request::default();
+        let depot = Depot::new();
+        let origin = HeaderValue::from_static("https://example.com");
+
+        let headers: AllowHeaders = vec![header::CONTENT_TYPE].into();
+        let header = headers.to_header(Some(&origin), &req, &depot).await;
+        assert_eq!(
+            header,
+            Some((
+                header::ACCESS_CONTROL_ALLOW_HEADERS,
+                HeaderValue::from_static("content-type")
+            ))
+        );
+
+        let headers = AllowHeaders::dynamic(|_, _, _| Some(HeaderValue::from_static("x-dynamic")));
+        let header = headers.to_header(Some(&origin), &req, &depot).await;
+        assert_eq!(
+            header,
+            Some((
+                header::ACCESS_CONTROL_ALLOW_HEADERS,
+                HeaderValue::from_static("x-dynamic")
+            ))
+        );
     }
 }

--- a/crates/cors/src/allow_methods.rs
+++ b/crates/cors/src/allow_methods.rs
@@ -143,10 +143,10 @@ impl From<Vec<Method>> for AllowMethods {
 
 #[cfg(test)]
 mod tests {
-    use crate::inner::HeaderInner;
     use salvo_core::http::Method;
 
     use super::{AllowMethods, Any};
+    use crate::inner::HeaderInner;
 
     #[test]
     fn test_from_any() {

--- a/crates/cors/src/allow_methods.rs
+++ b/crates/cors/src/allow_methods.rs
@@ -1,12 +1,11 @@
-use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use salvo_core::http::Method;
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
+use super::inner::HeaderInner;
 use super::{Any, WILDCARD, separated_by_commas};
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Methods`][mdn] header.
@@ -15,9 +14,9 @@ use super::{Any, WILDCARD, separated_by_commas};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
 /// [`Cors::allow_methods`]: super::Cors::allow_methods
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AllowMethods(AllowMethodsInner);
+pub struct AllowMethods(HeaderInner);
 
 impl AllowMethods {
     /// Allow any method by sending a wildcard (`*`)
@@ -26,7 +25,7 @@ impl AllowMethods {
     ///
     /// [`Cors::allow_methods`]: super::Cors::allow_methods
     pub fn any() -> Self {
-        Self(AllowMethodsInner::Exact(WILDCARD.clone()))
+        Self(HeaderInner::Exact(WILDCARD.clone()))
     }
 
     /// Set a single allowed method
@@ -36,7 +35,7 @@ impl AllowMethods {
     /// [`Cors::allow_methods`]: super::Cors::allow_methods
     pub fn exact(method: &Method) -> Self {
         let value = HeaderValue::from_str(method.as_str()).expect("Invalid method.");
-        Self(AllowMethodsInner::Exact(value))
+        Self(HeaderInner::Exact(value))
     }
 
     /// Set multiple allowed methods
@@ -52,8 +51,8 @@ impl AllowMethods {
             .into_iter()
             .map(|m| HeaderValue::from_str(m.as_str()).expect("Invalid method."));
         match separated_by_commas(methods) {
-            None => Self(AllowMethodsInner::None),
-            Some(v) => Self(AllowMethodsInner::Exact(v)),
+            None => Self(HeaderInner::None),
+            Some(v) => Self(HeaderInner::Exact(v)),
         }
     }
 
@@ -69,7 +68,7 @@ impl AllowMethods {
             + Sync
             + 'static,
     {
-        Self(AllowMethodsInner::Dynamic(Arc::new(c)))
+        Self(HeaderInner::Dynamic(Arc::new(c)))
     }
 
     /// Set allowed methods by an async closure.
@@ -82,7 +81,7 @@ impl AllowMethods {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
     {
-        Self(AllowMethodsInner::DynamicAsync(Arc::new(
+        Self(HeaderInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
@@ -96,11 +95,11 @@ impl AllowMethods {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method
     pub fn mirror_request() -> Self {
-        Self(AllowMethodsInner::MirrorRequest)
+        Self(HeaderInner::MirrorRequest)
     }
 
     pub(super) fn is_wildcard(&self) -> bool {
-        matches!(&self.0, AllowMethodsInner::Exact(v) if v == WILDCARD)
+        matches!(&self.0, HeaderInner::Exact(v) if v == WILDCARD)
     }
 
     pub(super) async fn to_header(
@@ -109,30 +108,12 @@ impl AllowMethods {
         req: &Request,
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
-        let allow_methods = match &self.0 {
-            AllowMethodsInner::None => return None,
-            AllowMethodsInner::Exact(v) => v.clone(),
-            AllowMethodsInner::MirrorRequest => req
-                .headers()
-                .get(header::ACCESS_CONTROL_REQUEST_METHOD)?
-                .clone(),
-            AllowMethodsInner::Dynamic(c) => c(origin, req, depot)?,
-            AllowMethodsInner::DynamicAsync(c) => c(origin, req, depot).await?,
-        };
-
-        Some((header::ACCESS_CONTROL_ALLOW_METHODS, allow_methods))
-    }
-}
-
-impl Debug for AllowMethods {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            AllowMethodsInner::None => f.debug_tuple("None").finish(),
-            AllowMethodsInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
-            AllowMethodsInner::MirrorRequest => f.debug_tuple("MirrorRequest").finish(),
-            AllowMethodsInner::Dynamic(_) => f.debug_tuple("Predicate").finish(),
-            AllowMethodsInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
+        let mirror = req
+            .headers()
+            .get(header::ACCESS_CONTROL_REQUEST_METHOD)?
+            .clone();
+        let value = self.0.resolve(origin, req, depot, Some(mirror)).await?;
+        Some((header::ACCESS_CONTROL_ALLOW_METHODS, value))
     }
 }
 
@@ -160,42 +141,22 @@ impl From<Vec<Method>> for AllowMethods {
     }
 }
 
-#[derive(Default, Clone)]
-enum AllowMethodsInner {
-    #[default]
-    None,
-    Exact(HeaderValue),
-    MirrorRequest,
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
-}
 #[cfg(test)]
 mod tests {
+    use crate::inner::HeaderInner;
     use salvo_core::http::Method;
 
-    use super::{AllowMethods, AllowMethodsInner, Any};
+    use super::{AllowMethods, Any};
 
     #[test]
     fn test_from_any() {
         let methods: AllowMethods = Any.into();
-        assert!(matches!(methods.0, AllowMethodsInner::Exact(ref v) if v == "*"));
+        assert!(matches!(methods.0, HeaderInner::Exact(ref v) if v == "*"));
     }
 
     #[test]
     fn test_from_list() {
         let methods: AllowMethods = vec![Method::GET, Method::POST].into();
-        assert!(matches!(methods.0, AllowMethodsInner::Exact(ref v) if v == "GET,POST"));
+        assert!(matches!(methods.0, HeaderInner::Exact(ref v) if v == "GET,POST"));
     }
 }

--- a/crates/cors/src/allow_methods.rs
+++ b/crates/cors/src/allow_methods.rs
@@ -110,9 +110,9 @@ impl AllowMethods {
     ) -> Option<(HeaderName, HeaderValue)> {
         let mirror = req
             .headers()
-            .get(header::ACCESS_CONTROL_REQUEST_METHOD)?
-            .clone();
-        let value = self.0.resolve(origin, req, depot, Some(mirror)).await?;
+            .get(header::ACCESS_CONTROL_REQUEST_METHOD)
+            .cloned();
+        let value = self.0.resolve(origin, req, depot, mirror).await?;
         Some((header::ACCESS_CONTROL_ALLOW_METHODS, value))
     }
 }
@@ -143,7 +143,9 @@ impl From<Vec<Method>> for AllowMethods {
 
 #[cfg(test)]
 mod tests {
-    use salvo_core::http::Method;
+    use salvo_core::http::header::HeaderValue;
+    use salvo_core::http::{Method, header};
+    use salvo_core::{Depot, Request};
 
     use super::{AllowMethods, Any};
     use crate::inner::HeaderInner;
@@ -158,5 +160,32 @@ mod tests {
     fn test_from_list() {
         let methods: AllowMethods = vec![Method::GET, Method::POST].into();
         assert!(matches!(methods.0, HeaderInner::Exact(ref v) if v == "GET,POST"));
+    }
+
+    #[tokio::test]
+    async fn exact_and_dynamic_do_not_require_request_method() {
+        let req = Request::default();
+        let depot = Depot::new();
+        let origin = HeaderValue::from_static("https://example.com");
+
+        let methods: AllowMethods = vec![Method::GET].into();
+        let header = methods.to_header(Some(&origin), &req, &depot).await;
+        assert_eq!(
+            header,
+            Some((
+                header::ACCESS_CONTROL_ALLOW_METHODS,
+                HeaderValue::from_static("GET")
+            ))
+        );
+
+        let methods = AllowMethods::dynamic(|_, _, _| Some(HeaderValue::from_static("PATCH")));
+        let header = methods.to_header(Some(&origin), &req, &depot).await;
+        assert_eq!(
+            header,
+            Some((
+                header::ACCESS_CONTROL_ALLOW_METHODS,
+                HeaderValue::from_static("PATCH")
+            ))
+        );
     }
 }

--- a/crates/cors/src/allow_origin.rs
+++ b/crates/cors/src/allow_origin.rs
@@ -1,11 +1,10 @@
-use std::fmt::{self, Debug, Formatter};
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::sync::Arc;
 
+use super::{Any, WILDCARD};
+use crate::inner::HeaderValueListInner;
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
-
-use super::{Any, WILDCARD};
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Origin`][mdn] header.
 ///
@@ -13,9 +12,9 @@ use super::{Any, WILDCARD};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
 /// [`Cors::allow_origin`]: super::Cors::allow_origin
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AllowOrigin(OriginInner);
+pub struct AllowOrigin(HeaderValueListInner);
 
 impl AllowOrigin {
     /// Allow any origin by sending a wildcard (`*`)
@@ -24,7 +23,7 @@ impl AllowOrigin {
     ///
     /// [`Cors::allow_origin`]: super::Cors::allow_origin
     pub fn any() -> Self {
-        Self(OriginInner::Exact(WILDCARD.clone()))
+        Self(HeaderValueListInner::Exact(WILDCARD.clone()))
     }
 
     /// Set a single allowed origin
@@ -33,7 +32,7 @@ impl AllowOrigin {
     ///
     /// [`Cors::allow_origin`]: super::Cors::allow_origin
     pub fn exact(origin: HeaderValue) -> Self {
-        Self(OriginInner::Exact(origin))
+        Self(HeaderValueListInner::Exact(origin))
     }
 
     /// Set multiple allowed origins
@@ -55,7 +54,7 @@ impl AllowOrigin {
                 "Wildcard origin (`*`) cannot be passed to `AllowOrigin::list`. Use `AllowOrigin::any()` instead"
             );
         } else {
-            Self(OriginInner::List(origins))
+            Self(HeaderValueListInner::List(origins))
         }
     }
 
@@ -71,7 +70,7 @@ impl AllowOrigin {
             + Sync
             + 'static,
     {
-        Self(OriginInner::Dynamic(Arc::new(c)))
+        Self(HeaderValueListInner::Dynamic(Arc::new(c)))
     }
 
     /// Set the allowed origins by an async closure.
@@ -84,7 +83,7 @@ impl AllowOrigin {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
     {
-        Self(OriginInner::DynamicAsync(Arc::new(
+        Self(HeaderValueListInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
@@ -99,7 +98,7 @@ impl AllowOrigin {
     }
 
     pub(super) fn is_wildcard(&self) -> bool {
-        matches!(&self.0, OriginInner::Exact(v) if v == WILDCARD)
+        matches!(&self.0, HeaderValueListInner::Exact(v) if v == WILDCARD)
     }
 
     pub(super) async fn to_header(
@@ -109,24 +108,13 @@ impl AllowOrigin {
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
         let allow_origin = match &self.0 {
-            OriginInner::Exact(v) => v.clone(),
-            OriginInner::List(l) => origin.filter(|o| l.contains(o))?.clone(),
-            OriginInner::Dynamic(c) => c(origin, req, depot)?,
-            OriginInner::DynamicAsync(c) => c(origin, req, depot).await?,
+            HeaderValueListInner::Exact(v) => v.clone(),
+            HeaderValueListInner::List(l) => origin.filter(|o| l.contains(o))?.clone(),
+            HeaderValueListInner::Dynamic(c) => c(origin, req, depot)?,
+            HeaderValueListInner::DynamicAsync(c) => c(origin, req, depot).await?,
         };
 
         Some((header::ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin))
-    }
-}
-
-impl Debug for AllowOrigin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            OriginInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
-            OriginInner::List(inner) => f.debug_tuple("List").field(inner).finish(),
-            OriginInner::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
-            OriginInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
     }
 }
 
@@ -194,49 +182,22 @@ impl From<&Vec<String>> for AllowOrigin {
     }
 }
 
-#[derive(Clone)]
-enum OriginInner {
-    Exact(HeaderValue),
-    List(Vec<HeaderValue>),
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
-}
-
-impl Default for OriginInner {
-    fn default() -> Self {
-        Self::List(Vec::new())
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::{AllowOrigin, Any, HeaderValueListInner, WILDCARD};
     use salvo_core::http::header::HeaderValue;
-
-    use super::{AllowOrigin, Any, OriginInner, WILDCARD};
 
     #[test]
     fn test_from_any() {
         let origin: AllowOrigin = Any.into();
-        assert!(matches!(origin.0, OriginInner::Exact(ref v) if v == "*"));
+        assert!(matches!(origin.0, HeaderValueListInner::Exact(ref v) if v == "*"));
     }
 
     #[test]
     fn test_from_list() {
         let origin: AllowOrigin = vec!["https://example.com"].into();
         assert!(
-            matches!(origin.0, OriginInner::List(ref v) if v == &vec![HeaderValue::from_static("https://example.com")])
+            matches!(origin.0, HeaderValueListInner::List(ref v) if v == &vec![HeaderValue::from_static("https://example.com")])
         );
     }
 

--- a/crates/cors/src/allow_origin.rs
+++ b/crates/cors/src/allow_origin.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use super::{Any, WILDCARD};
-use crate::inner::HeaderValueListInner;
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
+
+use super::{Any, WILDCARD};
+use crate::inner::HeaderValueListInner;
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Origin`][mdn] header.
 ///
@@ -184,8 +185,9 @@ impl From<&Vec<String>> for AllowOrigin {
 
 #[cfg(test)]
 mod tests {
-    use super::{AllowOrigin, Any, HeaderValueListInner, WILDCARD};
     use salvo_core::http::header::HeaderValue;
+
+    use super::{AllowOrigin, Any, HeaderValueListInner, WILDCARD};
 
     #[test]
     fn test_from_any() {

--- a/crates/cors/src/allow_private_network.rs
+++ b/crates/cors/src/allow_private_network.rs
@@ -1,9 +1,9 @@
-use std::fmt;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use salvo_core::http::header::{HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
+
+use super::inner::BoolInner;
 
 /// Holds configuration for how to set the [`Access-Control-Allow-Private-Network`][wicg] header.
 ///
@@ -11,9 +11,9 @@ use salvo_core::{Depot, Request};
 ///
 /// [wicg]: https://wicg.github.io/private-network-access/
 /// [`Cors::allow_private_network`]: super::Cors::allow_private_network
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AllowPrivateNetwork(AllowPrivateNetworkInner);
+pub struct AllowPrivateNetwork(BoolInner);
 
 impl AllowPrivateNetwork {
     /// Allow requests via a more private network than the one used to access the origin
@@ -22,7 +22,7 @@ impl AllowPrivateNetwork {
     ///
     /// [`Cors::allow_private_network`]: super::Cors::allow_private_network
     pub fn yes() -> Self {
-        Self(AllowPrivateNetworkInner::Yes)
+        Self(BoolInner::Yes)
     }
 
     /// Allow requests via private network for some requests by a closure
@@ -34,7 +34,7 @@ impl AllowPrivateNetwork {
     where
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync + 'static,
     {
-        Self(AllowPrivateNetworkInner::Dynamic(Arc::new(c)))
+        Self(BoolInner::Dynamic(Arc::new(c)))
     }
 
     /// Allow private-network requests for some requests by an async closure.
@@ -47,7 +47,7 @@ impl AllowPrivateNetwork {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = bool> + Send + 'static,
     {
-        Self(AllowPrivateNetworkInner::DynamicAsync(Arc::new(
+        Self(BoolInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
@@ -72,54 +72,20 @@ impl AllowPrivateNetwork {
             return None;
         }
 
-        let allow_private_network = match &self.0 {
-            AllowPrivateNetworkInner::Yes => true,
-            AllowPrivateNetworkInner::No => false,
-            AllowPrivateNetworkInner::Dynamic(c) => c(origin, req, depot),
-            AllowPrivateNetworkInner::DynamicAsync(c) => c(origin, req, depot).await,
-        };
-
-        allow_private_network.then_some((ALLOW_PRIVATE_NETWORK, TRUE))
+        self.0
+            .resolve_async(origin, req, depot)
+            .await
+            .then_some((ALLOW_PRIVATE_NETWORK, TRUE))
     }
 }
 
 impl From<bool> for AllowPrivateNetwork {
     fn from(v: bool) -> Self {
         match v {
-            true => Self(AllowPrivateNetworkInner::Yes),
-            false => Self(AllowPrivateNetworkInner::No),
+            true => Self(BoolInner::Yes),
+            false => Self(BoolInner::No),
         }
     }
-}
-
-impl fmt::Debug for AllowPrivateNetwork {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            AllowPrivateNetworkInner::Yes => f.debug_tuple("Yes").finish(),
-            AllowPrivateNetworkInner::No => f.debug_tuple("No").finish(),
-            AllowPrivateNetworkInner::Dynamic(_) => f.debug_tuple("Predicate").finish(),
-            AllowPrivateNetworkInner::DynamicAsync(_) => f.debug_tuple("AsyncPredicate").finish(),
-        }
-    }
-}
-
-#[derive(Clone, Default)]
-enum AllowPrivateNetworkInner {
-    Yes,
-    #[default]
-    No,
-    Dynamic(Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync>),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = bool> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
 }
 
 #[cfg(test)]
@@ -133,7 +99,7 @@ mod tests {
     use salvo_core::prelude::*;
     use salvo_core::test::TestClient;
 
-    use super::{AllowPrivateNetwork, AllowPrivateNetworkInner};
+    use super::{AllowPrivateNetwork, super::inner::BoolInner};
     use crate::Cors;
 
     const REQUEST_PRIVATE_NETWORK: HeaderName =
@@ -150,10 +116,10 @@ mod tests {
     #[test]
     fn test_from_bool() {
         let p: AllowPrivateNetwork = true.into();
-        assert!(matches!(p.0, AllowPrivateNetworkInner::Yes));
+        assert!(matches!(p.0, BoolInner::Yes));
 
         let p: AllowPrivateNetwork = false.into();
-        assert!(matches!(p.0, AllowPrivateNetworkInner::No));
+        assert!(matches!(p.0, BoolInner::No));
     }
 
     #[tokio::test]

--- a/crates/cors/src/allow_private_network.rs
+++ b/crates/cors/src/allow_private_network.rs
@@ -99,7 +99,8 @@ mod tests {
     use salvo_core::prelude::*;
     use salvo_core::test::TestClient;
 
-    use super::{AllowPrivateNetwork, super::inner::BoolInner};
+    use super::super::inner::BoolInner;
+    use super::AllowPrivateNetwork;
     use crate::Cors;
 
     const REQUEST_PRIVATE_NETWORK: HeaderName =

--- a/crates/cors/src/allow_private_network.rs
+++ b/crates/cors/src/allow_private_network.rs
@@ -32,10 +32,7 @@ impl AllowPrivateNetwork {
     /// [`Cors::allow_private_network`]: super::Cors::allow_private_network
     pub fn dynamic<C>(c: C) -> Self
     where
-        C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue>
-            + Send
-            + Sync
-            + 'static,
+        C: Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync + 'static,
     {
         Self(AllowPrivateNetworkInner::Dynamic(Arc::new(c)))
     }
@@ -48,17 +45,13 @@ impl AllowPrivateNetwork {
     pub fn dynamic_async<C, Fut>(c: C) -> Self
     where
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
+        Fut: Future<Output = bool> + Send + 'static,
     {
         Self(AllowPrivateNetworkInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
 
-    #[allow(
-        clippy::declare_interior_mutable_const,
-        clippy::borrow_interior_mutable_const
-    )]
     pub(super) async fn to_header(
         &self,
         origin: Option<&HeaderValue>,
@@ -75,27 +68,18 @@ impl AllowPrivateNetwork {
 
         const TRUE: HeaderValue = HeaderValue::from_static("true");
 
-        // Cheapest fallback: allow_private_network hasn't been set
-        if matches!(&self.0, AllowPrivateNetworkInner::No) {
-            return None;
-        }
-
-        // Access-Control-Allow-Private-Network is only relevant if the request
-        // has the Access-Control-Request-Private-Network header set, else skip
         if req.headers().get(REQUEST_PRIVATE_NETWORK) != Some(&TRUE) {
             return None;
         }
 
-        match &self.0 {
-            AllowPrivateNetworkInner::Yes => Some((ALLOW_PRIVATE_NETWORK, TRUE)),
-            AllowPrivateNetworkInner::No => None,
-            AllowPrivateNetworkInner::Dynamic(c) => {
-                c(origin, req, depot).map(|v| (ALLOW_PRIVATE_NETWORK, v))
-            }
-            AllowPrivateNetworkInner::DynamicAsync(c) => c(origin, req, depot)
-                .await
-                .map(|v| (ALLOW_PRIVATE_NETWORK, v)),
-        }
+        let allow_private_network = match &self.0 {
+            AllowPrivateNetworkInner::Yes => true,
+            AllowPrivateNetworkInner::No => false,
+            AllowPrivateNetworkInner::Dynamic(c) => c(origin, req, depot),
+            AllowPrivateNetworkInner::DynamicAsync(c) => c(origin, req, depot).await,
+        };
+
+        allow_private_network.then_some((ALLOW_PRIVATE_NETWORK, TRUE))
     }
 }
 
@@ -124,16 +108,14 @@ enum AllowPrivateNetworkInner {
     Yes,
     #[default]
     No,
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
+    Dynamic(Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync>),
     DynamicAsync(
         Arc<
             dyn Fn(
                     Option<&HeaderValue>,
                     &Request,
                     &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
+                ) -> Pin<Box<dyn Future<Output = bool> + Send>>
                 + Send
                 + Sync,
         >,
@@ -200,7 +182,7 @@ mod tests {
         assert_eq!(header, None);
 
         // Test `Dynamic`
-        let p = AllowPrivateNetwork::dynamic(|_, _, _| Some(HeaderValue::from_static("true")));
+        let p = AllowPrivateNetwork::dynamic(|_, _, _| true);
         let header = p.to_header(Some(&origin), &req, &depot).await;
         assert_eq!(
             header,
@@ -208,9 +190,7 @@ mod tests {
         );
 
         // Test `DynamicAsync`
-        let p = AllowPrivateNetwork::dynamic_async(|_, _, _| async {
-            Some(HeaderValue::from_static("true"))
-        });
+        let p = AllowPrivateNetwork::dynamic_async(|_, _, _| async { true });
         let header = p.to_header(Some(&origin), &req, &depot).await;
         assert_eq!(
             header,
@@ -245,13 +225,8 @@ mod tests {
     async fn cors_private_network_header_is_added_correctly_with_predicate() {
         let allow_private_network =
             AllowPrivateNetwork::dynamic(|origin: Option<&HeaderValue>, req: &Request, _depot| {
-                if req.uri().path() == "/allow-private"
+                req.uri().path() == "/allow-private"
                     && origin == Some(&HeaderValue::from_static("localhost"))
-                {
-                    Some(TRUE)
-                } else {
-                    None
-                }
             });
         let cors_handler = Cors::new()
             .allow_private_network(allow_private_network)

--- a/crates/cors/src/expose_headers.rs
+++ b/crates/cors/src/expose_headers.rs
@@ -6,7 +6,7 @@ use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
 use super::inner::HeaderValueInner;
-use super::{separated_by_commas, Any, WILDCARD};
+use super::{Any, WILDCARD, separated_by_commas};
 
 /// Holds configuration for how to set the [`Access-Control-Expose-Headers`][mdn] header.
 ///
@@ -139,11 +139,11 @@ impl From<&Vec<String>> for ExposeHeaders {
 
 #[cfg(test)]
 mod tests {
-    use crate::inner::HeaderValueInner;
-use salvo_core::http::header::{self, HeaderValue};
+    use salvo_core::http::header::{self, HeaderValue};
     use salvo_core::{Depot, Request};
 
     use super::{Any, ExposeHeaders};
+    use crate::inner::HeaderValueInner;
 
     #[test]
     fn test_from_any() {

--- a/crates/cors/src/expose_headers.rs
+++ b/crates/cors/src/expose_headers.rs
@@ -1,12 +1,12 @@
-use std::fmt::{self, Debug, Formatter};
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
-use super::{Any, WILDCARD, separated_by_commas};
+use super::inner::HeaderValueInner;
+use super::{separated_by_commas, Any, WILDCARD};
 
 /// Holds configuration for how to set the [`Access-Control-Expose-Headers`][mdn] header.
 ///
@@ -14,9 +14,9 @@ use super::{Any, WILDCARD, separated_by_commas};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
 /// [`Cors::expose_headers`]: super::Cors::expose_headers
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct ExposeHeaders(ExposeHeadersInner);
+pub struct ExposeHeaders(HeaderValueInner);
 
 impl ExposeHeaders {
     /// Expose any / all headers by sending a wildcard (`*`)
@@ -25,7 +25,7 @@ impl ExposeHeaders {
     ///
     /// [`Cors::expose_headers`]: super::Cors::expose_headers
     pub fn any() -> Self {
-        Self(ExposeHeadersInner::Exact(WILDCARD.clone()))
+        Self(HeaderValueInner::Exact(WILDCARD.clone()))
     }
 
     /// Set multiple exposed header names
@@ -38,8 +38,8 @@ impl ExposeHeaders {
         I: IntoIterator<Item = HeaderName>,
     {
         match separated_by_commas(headers.into_iter().map(Into::into)) {
-            None => Self(ExposeHeadersInner::None),
-            Some(value) => Self(ExposeHeadersInner::Exact(value)),
+            None => Self(HeaderValueInner::None),
+            Some(value) => Self(HeaderValueInner::Exact(value)),
         }
     }
 
@@ -55,7 +55,7 @@ impl ExposeHeaders {
             + Sync
             + 'static,
     {
-        Self(ExposeHeadersInner::Dynamic(Arc::new(c)))
+        Self(HeaderValueInner::Dynamic(Arc::new(c)))
     }
 
     /// Allow custom headers by an async closure.
@@ -68,13 +68,13 @@ impl ExposeHeaders {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
     {
-        Self(ExposeHeadersInner::DynamicAsync(Arc::new(
+        Self(HeaderValueInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
 
     pub(super) fn is_wildcard(&self) -> bool {
-        matches!(&self.0, ExposeHeadersInner::Exact(v) if v == WILDCARD)
+        matches!(&self.0, HeaderValueInner::Exact(v) if v == WILDCARD)
     }
 
     pub(super) async fn to_header(
@@ -83,25 +83,8 @@ impl ExposeHeaders {
         req: &Request,
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
-        let expose_headers = match &self.0 {
-            ExposeHeadersInner::None => return None,
-            ExposeHeadersInner::Exact(v) => v.clone(),
-            ExposeHeadersInner::Dynamic(c) => c(origin, req, depot)?,
-            ExposeHeadersInner::DynamicAsync(c) => c(origin, req, depot).await?,
-        };
-
-        Some((header::ACCESS_CONTROL_EXPOSE_HEADERS, expose_headers))
-    }
-}
-
-impl Debug for ExposeHeaders {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            ExposeHeadersInner::None => f.debug_tuple("None").finish(),
-            ExposeHeadersInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
-            ExposeHeadersInner::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
-            ExposeHeadersInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
+        let value = self.0.resolve(origin, req, depot).await?;
+        Some((header::ACCESS_CONTROL_EXPOSE_HEADERS, value))
     }
 }
 
@@ -154,45 +137,24 @@ impl From<&Vec<String>> for ExposeHeaders {
     }
 }
 
-#[derive(Default, Clone)]
-enum ExposeHeadersInner {
-    #[default]
-    None,
-    Exact(HeaderValue),
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
-}
 #[cfg(test)]
 mod tests {
-    use salvo_core::http::header::{self, HeaderValue};
+    use crate::inner::HeaderValueInner;
+use salvo_core::http::header::{self, HeaderValue};
     use salvo_core::{Depot, Request};
 
-    use super::{Any, ExposeHeaders, ExposeHeadersInner};
+    use super::{Any, ExposeHeaders};
 
     #[test]
     fn test_from_any() {
         let headers: ExposeHeaders = Any.into();
-        assert!(matches!(headers.0, ExposeHeadersInner::Exact(ref v) if v == "*"));
+        assert!(matches!(headers.0, HeaderValueInner::Exact(ref v) if v == "*"));
     }
 
     #[test]
     fn test_from_list() {
         let headers: ExposeHeaders = vec![header::CONTENT_TYPE, header::ACCEPT].into();
-        assert!(
-            matches!(headers.0, ExposeHeadersInner::Exact(ref v) if v == "content-type,accept")
-        );
+        assert!(matches!(headers.0, HeaderValueInner::Exact(ref v) if v == "content-type,accept"));
     }
 
     #[tokio::test]

--- a/crates/cors/src/inner.rs
+++ b/crates/cors/src/inner.rs
@@ -1,0 +1,159 @@
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use salvo_core::http::header::HeaderValue;
+use salvo_core::{Depot, Request};
+
+type DynFnBool = dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> bool + Send + Sync;
+type DynFnBoolAsync = dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Pin<Box<dyn Future<Output = bool> + Send>>
+    + Send
+    + Sync;
+type DynFnOptHeaderValue =
+    dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync;
+type DynFnOptHeaderValueAsync = dyn Fn(
+        Option<&HeaderValue>,
+        &Request,
+        &Depot,
+    ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
+    + Send
+    + Sync;
+
+#[derive(Clone, Default)]
+pub(crate) enum BoolInner {
+    Yes,
+    #[default]
+    No,
+    Dynamic(Arc<DynFnBool>),
+    DynamicAsync(Arc<DynFnBoolAsync>),
+}
+
+impl BoolInner {
+    pub(crate) async fn resolve_async(
+        &self,
+        origin: Option<&HeaderValue>,
+        req: &Request,
+        depot: &Depot,
+    ) -> bool {
+        match self {
+            Self::Yes => true,
+            Self::No => false,
+            Self::Dynamic(f) => f(origin, req, depot),
+            Self::DynamicAsync(f) => f(origin, req, depot).await,
+        }
+    }
+}
+
+impl Debug for BoolInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::Yes => f.debug_tuple("Yes").finish(),
+            Self::No => f.debug_tuple("No").finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
+            Self::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) enum HeaderInner {
+    #[default]
+    None,
+    Exact(HeaderValue),
+    MirrorRequest,
+    Dynamic(Arc<DynFnOptHeaderValue>),
+    DynamicAsync(Arc<DynFnOptHeaderValueAsync>),
+}
+
+impl HeaderInner {
+    pub(crate) async fn resolve(
+        &self,
+        origin: Option<&HeaderValue>,
+        req: &Request,
+        depot: &Depot,
+        mirror: Option<HeaderValue>,
+    ) -> Option<HeaderValue> {
+        match self {
+            Self::None => None,
+            Self::Exact(v) => Some(v.clone()),
+            Self::MirrorRequest => mirror,
+            Self::Dynamic(f) => f(origin, req, depot),
+            Self::DynamicAsync(f) => f(origin, req, depot).await,
+        }
+    }
+}
+
+impl Debug for HeaderInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::None => f.debug_tuple("None").finish(),
+            Self::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
+            Self::MirrorRequest => f.debug_tuple("MirrorRequest").finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
+            Self::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) enum HeaderValueInner {
+    #[default]
+    None,
+    Exact(HeaderValue),
+    Dynamic(Arc<DynFnOptHeaderValue>),
+    DynamicAsync(Arc<DynFnOptHeaderValueAsync>),
+}
+
+impl HeaderValueInner {
+    pub(crate) async fn resolve(
+        &self,
+        origin: Option<&HeaderValue>,
+        req: &Request,
+        depot: &Depot,
+    ) -> Option<HeaderValue> {
+        match self {
+            Self::None => None,
+            Self::Exact(v) => Some(v.clone()),
+            Self::Dynamic(f) => f(origin, req, depot),
+            Self::DynamicAsync(f) => f(origin, req, depot).await,
+        }
+    }
+}
+
+impl Debug for HeaderValueInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::None => f.debug_tuple("None").finish(),
+            Self::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
+            Self::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum HeaderValueListInner {
+    Exact(HeaderValue),
+    List(Vec<HeaderValue>),
+    Dynamic(Arc<DynFnOptHeaderValue>),
+    DynamicAsync(Arc<DynFnOptHeaderValueAsync>),
+}
+
+impl Default for HeaderValueListInner {
+    fn default() -> Self {
+        Self::List(Vec::new())
+    }
+}
+
+impl Debug for HeaderValueListInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
+            Self::List(inner) => f.debug_tuple("List").field(inner).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
+            Self::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
+        }
+    }
+}

--- a/crates/cors/src/lib.rs
+++ b/crates/cors/src/lib.rs
@@ -47,6 +47,7 @@ mod allow_methods;
 mod allow_origin;
 mod allow_private_network;
 mod expose_headers;
+pub(crate) mod inner;
 mod max_age;
 mod vary;
 

--- a/crates/cors/src/lib.rs
+++ b/crates/cors/src/lib.rs
@@ -47,7 +47,7 @@ mod allow_methods;
 mod allow_origin;
 mod allow_private_network;
 mod expose_headers;
-pub(crate) mod inner;
+mod inner;
 mod max_age;
 mod vary;
 

--- a/crates/cors/src/max_age.rs
+++ b/crates/cors/src/max_age.rs
@@ -1,33 +1,34 @@
-use std::fmt::{self, Debug, Formatter};
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
 use salvo_core::http::header::{self, HeaderName, HeaderValue};
 use salvo_core::{Depot, Request};
 
+use super::inner::HeaderValueInner;
+
 /// Holds configuration for how to set the [`Access-Control-Max-Age`][mdn] header.
 ///
 /// See [`Cors::max_age`][super::Cors::max_age] for more details.
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct MaxAge(MaxAgeInner);
+pub struct MaxAge(HeaderValueInner);
 
 impl MaxAge {
     /// Set a static max-age value
     ///
     /// See [`Cors::max_age`][super::Cors::max_age] for more details.
     pub fn exact(max_age: Duration) -> Self {
-        Self(MaxAgeInner::Exact(max_age.as_secs().into()))
+        Self(HeaderValueInner::Exact(max_age.as_secs().into()))
     }
 
     /// Set a static max-age value
     ///
     /// See [`Cors::max_age`][super::Cors::max_age] for more details.
     pub fn seconds(seconds: u64) -> Self {
-        Self(MaxAgeInner::Exact(seconds.into()))
+        Self(HeaderValueInner::Exact(seconds.into()))
     }
 
     /// Set the max-age by an async closure.
@@ -40,7 +41,7 @@ impl MaxAge {
             + Sync
             + 'static,
     {
-        Self(MaxAgeInner::Dynamic(Arc::new(c)))
+        Self(HeaderValueInner::Dynamic(Arc::new(c)))
     }
 
     /// Set the max-age by an async closure.
@@ -51,7 +52,7 @@ impl MaxAge {
         C: Fn(Option<&HeaderValue>, &Request, &Depot) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Option<HeaderValue>> + Send + 'static,
     {
-        Self(MaxAgeInner::DynamicAsync(Arc::new(
+        Self(HeaderValueInner::DynamicAsync(Arc::new(
             move |header, req, depot| Box::pin(c(header, req, depot)),
         )))
     }
@@ -62,25 +63,8 @@ impl MaxAge {
         req: &Request,
         depot: &Depot,
     ) -> Option<(HeaderName, HeaderValue)> {
-        let max_age = match &self.0 {
-            MaxAgeInner::None => return None,
-            MaxAgeInner::Exact(v) => v.clone(),
-            MaxAgeInner::Dynamic(f) => f(origin, req, depot)?,
-            MaxAgeInner::DynamicAsync(f) => f(origin, req, depot).await?,
-        };
-
-        Some((header::ACCESS_CONTROL_MAX_AGE, max_age))
-    }
-}
-
-impl Debug for MaxAge {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            MaxAgeInner::None => f.debug_tuple("None").finish(),
-            MaxAgeInner::Exact(inner) => f.debug_tuple("Exact").field(inner).finish(),
-            MaxAgeInner::Dynamic(_) => f.debug_tuple("Dynamic").finish(),
-            MaxAgeInner::DynamicAsync(_) => f.debug_tuple("DynamicAsync").finish(),
-        }
+        let value = self.0.resolve(origin, req, depot).await?;
+        Some((header::ACCESS_CONTROL_MAX_AGE, value))
     }
 }
 
@@ -92,59 +76,38 @@ impl From<Duration> for MaxAge {
 
 impl From<u64> for MaxAge {
     fn from(max_age: u64) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
 }
 
 impl From<u32> for MaxAge {
     fn from(max_age: u32) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
 }
 
 impl From<usize> for MaxAge {
     fn from(max_age: usize) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
 }
 
 impl From<i64> for MaxAge {
     fn from(max_age: i64) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
 }
 
 impl From<i32> for MaxAge {
     fn from(max_age: i32) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
 }
 
 impl From<isize> for MaxAge {
     fn from(max_age: isize) -> Self {
-        Self(MaxAgeInner::Exact(max_age.into()))
+        Self(HeaderValueInner::Exact(max_age.into()))
     }
-}
-
-#[derive(Clone, Default)]
-enum MaxAgeInner {
-    #[default]
-    None,
-    Exact(HeaderValue),
-    Dynamic(
-        Arc<dyn Fn(Option<&HeaderValue>, &Request, &Depot) -> Option<HeaderValue> + Send + Sync>,
-    ),
-    DynamicAsync(
-        Arc<
-            dyn Fn(
-                    Option<&HeaderValue>,
-                    &Request,
-                    &Depot,
-                ) -> Pin<Box<dyn Future<Output = Option<HeaderValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
 }
 
 #[cfg(test)]
@@ -154,18 +117,18 @@ mod tests {
     use salvo_core::http::header::{self, HeaderValue};
     use salvo_core::{Depot, Request};
 
-    use super::{MaxAge, MaxAgeInner};
+    use super::{MaxAge, super::inner::HeaderValueInner};
 
     #[test]
     fn test_from_duration() {
         let max_age: MaxAge = Duration::from_secs(3600).into();
-        assert!(matches!(max_age.0, MaxAgeInner::Exact(ref v) if v == "3600"));
+        assert!(matches!(max_age.0, HeaderValueInner::Exact(ref v) if v == "3600"));
     }
 
     #[test]
     fn test_from_u64() {
         let max_age: MaxAge = 3600u64.into();
-        assert!(matches!(max_age.0, MaxAgeInner::Exact(ref v) if v == "3600"));
+        assert!(matches!(max_age.0, HeaderValueInner::Exact(ref v) if v == "3600"));
     }
 
     #[tokio::test]

--- a/crates/cors/src/max_age.rs
+++ b/crates/cors/src/max_age.rs
@@ -117,7 +117,8 @@ mod tests {
     use salvo_core::http::header::{self, HeaderValue};
     use salvo_core::{Depot, Request};
 
-    use super::{MaxAge, super::inner::HeaderValueInner};
+    use super::super::inner::HeaderValueInner;
+    use super::MaxAge;
 
     #[test]
     fn test_from_duration() {


### PR DESCRIPTION
This PR introduces several **breaking changes** aimed at refining the code structure of `salvo-cors`.

In anticipation of the upcoming Salvo v1 stable release, these changes improve maintainability and ensure a more consistent API design across different CORS rules.

### Breaking Changes

* **Updated `AllowCredentials` Signature**
Changed `AllowCredentials` to accept `Option<&HeaderValue>` instead of `&HeaderValue`. This aligns its API design with other CORS rules, improving overall consistency.
* **Simplified `AllowPrivateNetwork` Dynamic Callbacks**
Modified the return type of `dynamic` and `dynamic_async` functions within `AllowPrivateNetwork` from `Option<HeaderValue>` to `bool`. Since both functions ultimately determine a binary decision (whether to add the header or not), returning a boolean simplifies the logic and keeps it consistent with `AllowCredentials`.
* **Decoupled and Consolidated `Inner` Types**
Extracted and consolidated all rule-specific `Inner` types into generic, reusable variants like `BoolInner` and `HeaderInner`. For example, both `AllowCredentials` and `AllowPrivateNetwork` have been refactored to share a unified `BoolInner` structure.
This elimination of duplicate structures offers two major benefits:
1. Removes the need to implement identical structs and repeat `Debug` trait implementations manually.
2. Significantly simplifies the final header processing function (`to_header`) for each individual rule.