### PR TITLE
Document WebSocket subprotocol negotiation

### DIFF
--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -4,6 +4,12 @@
 
 //! WebSocket implementation.
 //!
+//! Browser clients that pass the second `protocols` argument to `new WebSocket(url, protocols)`
+//! send a `Sec-WebSocket-Protocol` header. Configure [`WebSocketUpgrade::protocols`] with the
+//! server-supported subprotocols, or use [`WebSocketUpgrade::accept_any_protocol`] when the
+//! server intentionally accepts any offered subprotocol. Otherwise the upgrade response will not
+//! include `Sec-WebSocket-Protocol`.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -20,6 +26,7 @@
 //! async fn connect(req: &mut Request, res: &mut Response) -> Result<(), StatusError> {
 //!     let user = req.parse_queries::<User>();
 //!     WebSocketUpgrade::new()
+//!         .protocols(&["echo.v1"])
 //!         .upgrade(req, res, |mut ws| async move {
 //!             println!("{user:#?} ");
 //!             while let Some(msg) = ws.recv().await {
@@ -66,7 +73,7 @@
 //!             const status = document.getElementById('status');
 //!             const msg = document.getElementById('msg');
 //!             const submit = document.getElementById('submit');
-//!             const ws = new WebSocket(`ws://${location.host}/ws?id=123&name=chris`);
+//!             const ws = new WebSocket(`ws://${location.host}/ws?id=123&name=chris`, 'echo.v1');
 //!
 //!             ws.onopen = function() {
 //!                 status.innerHTML = '<p><em>Connected!</em></p>';

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -11,6 +11,7 @@ struct User {
 async fn connect(req: &mut Request, res: &mut Response) -> Result<(), StatusError> {
     let user = req.parse_queries::<User>();
     WebSocketUpgrade::new()
+        .protocols(&["echo.v1"])
         .upgrade(req, res, |mut ws| async move {
             println!("{user:#?} ");
             while let Some(msg) = ws.recv().await {
@@ -60,7 +61,7 @@ static INDEX_HTML: &str = r#"<!DOCTYPE html>
             const status = document.getElementById('status');
             const msg = document.getElementById('msg');
             const submit = document.getElementById('submit');
-            const ws = new WebSocket(`ws://${location.host}/ws?id=123&name=chris`);
+            const ws = new WebSocket(`ws://${location.host}/ws?id=123&name=chris`, 'echo.v1');
 
             ws.onopen = function() {
                 status.innerHTML = '<p><em>Connected!</em></p>';


### PR DESCRIPTION
Refs #1516.

## Summary
- Document that browser clients passing the second `protocols` argument to `new WebSocket(url, protocols)` send `Sec-WebSocket-Protocol` and need explicit server-side negotiation.
- Update the WebSocket module example and runnable `examples/websocket` sample to negotiate `echo.v1`, so the upgrade response includes `Sec-WebSocket-Protocol` when the browser requests it.
- Keep the default behavior unchanged, so Salvo does not silently accept and echo arbitrary subprotocol values.

## Validation
- `cargo test -p salvo_extra --no-default-features --features websocket,salvo_core/aws-lc-rs websocket -- --nocapture`
- `cargo check --manifest-path examples/websocket/Cargo.toml`
- `git diff --check`