### PR TITLE
Fix request body docs formatting

### DIFF
--- a/crates/oapi-macros/src/operation/request_body.rs
+++ b/crates/oapi-macros/src/operation/request_body.rs
@@ -38,14 +38,14 @@ use crate::{AnyValue, Array, DiagResult, Required, TryToTokens, parse_utils};
 ///    request_body = Foo,
 /// )]
 /// ```
-/// 
+///
 /// Or the request body content can also be an array as well by surrounding it with brackets `[..]`.
 /// ```text
 /// #[salvo_oapi::endpoint(
 ///    request_body = [Foo],
 /// )]
 /// ```
-/// 
+///
 /// To define optional request body just wrap the type in `Option<type>`.
 /// ```text
 /// #[salvo_oapi::endpoint(


### PR DESCRIPTION
## Summary

- Remove trailing spaces from two blank doc-comment lines in `request_body.rs`.
- Make `cargo fmt --all -- --check` pass on stable rustfmt for this file.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`

Note: stable rustfmt still prints warnings for existing nightly-only options in `rustfmt.toml`, but the formatting check exits successfully.