### PR TITLE
Expose Quinn connection for WebTransport requests

### DIFF
--- a/crates/core/src/conn/quinn.rs
+++ b/crates/core/src/conn/quinn.rs
@@ -25,16 +25,27 @@ pub use listener::{QuinnAcceptor, QuinnListener};
 #[allow(dead_code)]
 pub struct QuinnConnection {
     inner: http3_quinn::Connection,
+    raw: quinn::Connection,
     fusewire: Option<ArcFusewire>,
 }
 impl QuinnConnection {
-    pub(crate) fn new(inner: http3_quinn::Connection, fusewire: Option<ArcFusewire>) -> Self {
-        Self { inner, fusewire }
+    pub(crate) fn new(raw: quinn::Connection, fusewire: Option<ArcFusewire>) -> Self {
+        Self {
+            inner: http3_quinn::Connection::new(raw.clone()),
+            raw,
+            fusewire,
+        }
     }
     /// Get inner quinn connection.
     #[must_use]
     pub fn into_inner(self) -> http3_quinn::Connection {
         self.inner
+    }
+
+    /// Get the underlying Quinn connection.
+    #[must_use]
+    pub fn quinn(&self) -> &quinn::Connection {
+        &self.raw
     }
 }
 impl Debug for QuinnConnection {

--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -67,6 +67,7 @@ impl Builder {
         graceful_stop_token: Option<CancellationToken>,
     ) -> IoResult<()> {
         let fusewire = hyper_handler.fusewire.clone();
+        let raw_conn = conn.quinn().clone();
         let mut conn = self
             .0
             .build::<salvo_http3::quinn::Connection, bytes::Bytes>(conn.into_inner())
@@ -96,6 +97,7 @@ impl Builder {
                                 stream,
                                 hyper_handler,
                                 fusewire.clone(),
+                                raw_conn.clone(),
                             )
                             .await?
                             {
@@ -145,11 +147,13 @@ async fn process_web_transport(
     stream: RequestStream<salvo_http3::quinn::BidiStream<Bytes>, Bytes>,
     hyper_handler: crate::service::HyperHandler,
     _fusewire: Option<ArcFusewire>,
+    raw_conn: crate::proto::quinn::Connection,
 ) -> IoResult<Option<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>> {
     let (parts, _body) = request.into_parts();
     let mut request = hyper::Request::from_parts(parts, ReqBody::None);
     request.extensions_mut().insert(Arc::new(Mutex::new(conn)));
     request.extensions_mut().insert(Arc::new(stream));
+    request.extensions_mut().insert(raw_conn);
 
     let mut response = hyper::service::Service::call(&hyper_handler, request)
         .await

--- a/crates/core/src/conn/quinn/listener.rs
+++ b/crates/core/src/conn/quinn/listener.rs
@@ -9,7 +9,7 @@ use std::vec;
 
 use futures_util::stream::{BoxStream, StreamExt};
 use http::uri::Scheme;
-use salvo_http3::quinn::{self, Endpoint};
+use salvo_http3::quinn::Endpoint;
 use tokio_util::sync::CancellationToken;
 
 use super::{QuinnConnection, QuinnCoupler};
@@ -188,7 +188,7 @@ impl Acceptor for QuinnAcceptor {
                     });
                     return Ok(Accepted {
                         coupler: QuinnCoupler,
-                        stream: QuinnConnection::new(quinn::Connection::new(conn), fusewire.clone()),
+                        stream: QuinnConnection::new(conn, fusewire.clone()),
                         fusewire,
                         local_addr: self.holdings[0].local_addr.clone(),
                         remote_addr: remote_addr.into(),

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -664,6 +664,16 @@ impl Request {
             matches!((self.method(), protocol), (&Method::CONNECT, Some(p)) if p == &salvo_http3::ext::Protocol::WEB_TRANSPORT)
         }
 
+        /// Get the underlying Quinn connection for a WebTransport request.
+        ///
+        /// Returns a cheap clone of the connection handle while handling a
+        /// WebTransport `CONNECT` request. It can be used to inspect QUIC-level
+        /// state, such as [`quinn::Connection::stats`](crate::proto::quinn::Connection::stats).
+        #[inline]
+        pub fn quinn_connection(&self) -> Option<crate::proto::quinn::Connection> {
+            self.extensions.get::<crate::proto::quinn::Connection>().cloned()
+        }
+
         /// Try to get a WebTransport session from the request.
         pub async fn web_transport_mut(&mut self) -> Result<&mut crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>, crate::Error> {
             if self.is_wt_connect() {

--- a/crates/core/src/proto.rs
+++ b/crates/core/src/proto.rs
@@ -3,5 +3,6 @@ cfg_feature! {
     #![feature = "quinn"]
 
     pub use salvo_http3::{quic, webtransport};
+    pub use salvo_http3::quinn::quinn;
     pub use salvo_http3::webtransport::server::WebTransportSession;
 }


### PR DESCRIPTION
## Summary

- Keep a cheap clone of the underlying `quinn::Connection` alongside `QuinnConnection`.
- Insert that raw connection handle into WebTransport request extensions.
- Add `Request::quinn_connection()` so handlers can inspect QUIC-level state such as `stats()`.
- Re-export raw `quinn` under `proto::quinn` for users of the new API.

This implements the raw Quinn connection access proposed in #1480 without changing the HTTP/3 listener transport defaults.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p salvo_core --features quinn --all-targets`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p salvo_core --features quinn --all-targets`

Note: stable rustfmt still prints warnings for existing nightly-only options in `rustfmt.toml`, but the formatting check exits successfully.