### PR TITLE
Document ACME ECDSA key default

### DIFF
--- a/crates/acme/src/config.rs
+++ b/crates/acme/src/config.rs
@@ -204,7 +204,9 @@ impl AcmeConfigBuilder {
 
     /// Sets the key type for certificate private keys.
     ///
-    /// Defaults to [`KeyType::EcdsaP256`].
+    /// Defaults to [`KeyType::EcdsaP256`], which is the recommended key type
+    /// for newly generated certificates. RSA variants are available for
+    /// compatibility, but must be selected explicitly.
     /// Available types: `EcdsaP256`, `EcdsaP384`, `EcdsaP521`, `Rsa2048`,
     /// `Rsa4096`, `Rsa8192`, `Ed25519`.
     #[inline]
@@ -315,6 +317,7 @@ mod tests {
         assert!(builder.cache_path.is_none());
         assert!(builder.keys_for_http01.is_none());
         assert_eq!(builder.before_expired, Duration::from_secs(12 * 60 * 60));
+        assert_eq!(builder.key_type, KeyType::EcdsaP256);
     }
 
     #[test]

--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -15,6 +15,13 @@
 //! - **Persistent storage**: pluggable storage backend via [`Storage`].
 //! - **Background renewal**: automatic certificate renewal and OCSP refresh.
 //!
+//! ## Certificate key type
+//!
+//! Salvo ACME defaults to [`KeyType::EcdsaP256`] for newly generated
+//! certificate private keys. RSA key types remain available for compatibility,
+//! but they are explicit opt-in via [`AcmeConfigBuilder::key_type`] or
+//! [`AcmeListenerBuilder::key_type`].
+//!
 //! ## Quick Start - HTTP-01
 //!
 //! ```ignore

--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -174,6 +174,10 @@ impl<T> AcmeListenerBuilder<T> {
 
     /// Sets the key type for certificate private keys.
     ///
+    /// `EcdsaP256` is the default and recommended key type for newly generated
+    /// certificates. RSA variants are available for compatibility, but must be
+    /// selected explicitly.
+    ///
     /// Available types: `EcdsaP256` (default), `EcdsaP384`, `EcdsaP521`,
     /// `Rsa2048`, `Rsa4096`, `Rsa8192`, `Ed25519`.
     #[inline]


### PR DESCRIPTION
## Summary
- Document that `salvo-acme` defaults to ECDSA P-256 certificate keys.
- Clarify that RSA key types are compatibility options and must be selected explicitly.
- Add a unit assertion locking `AcmeConfigBuilder`'s default key type to `KeyType::EcdsaP256`.

This addresses the `_improve.md` RSA advisory follow-up by ensuring the default ACME certificate key path avoids RSA. It does not remove the transitive `rsa` dependency from `certon`; `cargo audit` still reports `RUSTSEC-2023-0071` until upstream provides a fixed dependency path or the advisory is explicitly accepted.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p salvo-acme`
- `cargo check -p salvo-acme --all-targets`
- `cargo clippy -p salvo-acme --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p salvo-acme --no-deps`
- `cargo audit` (known failure: `RUSTSEC-2023-0071` via `certon`/`rsa`)
- `cargo audit --ignore RUSTSEC-2023-0071`