### PR TITLE
Fix OIDC revalidation races

### DIFF
--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -311,13 +311,12 @@ impl OidcDecoder {
     /// Will only ever spawn one task at a single time.
     /// If called while an update task is currently running, will do nothing.
     fn revalidate_cache(&self) {
-        if !self.cache_state.is_revalidating() {
-            self.cache_state.set_is_revalidating(true);
+        if self.cache_state.begin_revalidation() {
             tracing::info!("Spawning Task to re-validate JWKS");
             let decoder = self.clone();
             tokio::task::spawn(async move {
                 let _ = decoder.update_cache().await;
-                decoder.cache_state.set_is_revalidating(false);
+                decoder.cache_state.finish_revalidation();
                 decoder.notifier.notify_waiters();
             });
         }
@@ -326,8 +325,12 @@ impl OidcDecoder {
     /// If the JWKS is currently updating in the background, this function resolves when the update is complete.
     /// If we are not currently updating the JWKS in the background, this function will resolve immediately.
     async fn wait_update(&self) {
-        if self.cache_state.is_revalidating() {
-            self.notifier.notified().await;
+        loop {
+            let notified = self.notifier.notified();
+            if !self.cache_state.is_revalidating() {
+                break;
+            }
+            notified.await;
         }
     }
 

--- a/crates/jwt-auth/src/oidc/cache.rs
+++ b/crates/jwt-auth/src/oidc/cache.rs
@@ -137,11 +137,17 @@ impl CacheState {
 
     /// Check if the cache is revalidating
     pub fn is_revalidating(&self) -> bool {
-        self.is_revalidating.load(Ordering::SeqCst)
+        self.is_revalidating.load(Ordering::Acquire)
     }
-    /// Set the cache is revalidating
-    pub fn set_is_revalidating(&self, value: bool) {
-        self.is_revalidating.store(value, Ordering::SeqCst);
+    /// Try to mark the cache as revalidating.
+    pub fn begin_revalidation(&self) -> bool {
+        self.is_revalidating
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+    /// Mark the cache as no longer revalidating.
+    pub fn finish_revalidation(&self) {
+        self.is_revalidating.store(false, Ordering::Release);
     }
 }
 
@@ -309,5 +315,18 @@ mod tests {
         let header_value = HeaderValue::from_static("invalid-directive");
         let policy = CachePolicy::from_header_val(Some(&header_value));
         assert_eq!(policy, CachePolicy::default());
+    }
+
+    #[test]
+    fn test_cache_state_revalidation_claim_is_atomic() {
+        let state = CacheState::new();
+
+        assert!(state.begin_revalidation());
+        assert!(state.is_revalidating());
+        assert!(!state.begin_revalidation());
+
+        state.finish_revalidation();
+        assert!(!state.is_revalidating());
+        assert!(state.begin_revalidation());
     }
 }


### PR DESCRIPTION
## Summary
- Use an atomic compare-and-exchange to claim the OIDC JWKS revalidation task.
- Mark revalidation completion with release ordering and notify waiters after the state transition.
- Register `Notify` futures before rechecking the revalidation flag so waiters cannot miss a fast completion notification.
- Add a unit test covering the single-claimer revalidation state transition.

## Why
`revalidate_cache` previously loaded and then stored `is_revalidating` as two separate operations. Concurrent requests could all observe `false` and spawn duplicate JWKS refresh tasks. `wait_update` also checked the flag before registering for notification, which allowed a fast refresh to notify before a waiter had actually subscribed.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo-jwt-auth --all-targets --all-features`
- `cargo clippy -p salvo-jwt-auth --all-targets --all-features -- -D warnings`
- `cargo test -p salvo-jwt-auth --all-features`