### PR TITLE
Normalize rate limiter quotas

### DIFF
--- a/crates/rate-limiter/src/fixed_guard.rs
+++ b/crates/rate-limiter/src/fixed_guard.rs
@@ -32,15 +32,11 @@ impl FixedGuard {
 impl RateGuard for FixedGuard {
     type Quota = BasicQuota;
     async fn verify(&mut self, quota: &Self::Quota) -> bool {
-        if self.quota.is_none() || OffsetDateTime::now_utc() > self.reset || self.quota.as_ref() != Some(quota) {
-            if self.quota.as_ref() != Some(quota) {
-                let mut quota = quota.clone();
-                if quota.limit == 0 {
-                    quota.limit = 1;
-                }
-                self.quota = Some(quota);
-            }
-            self.reset = OffsetDateTime::now_utc() + quota.period;
+        let now = OffsetDateTime::now_utc();
+        let quota = quota.normalized();
+        if self.quota.as_ref() != Some(&quota) || now > self.reset {
+            self.quota = Some(quota.clone());
+            self.reset = now + quota.period;
             self.count = 1;
             true
         } else if self.count < quota.limit {
@@ -52,6 +48,7 @@ impl RateGuard for FixedGuard {
     }
 
     async fn remaining(&self, quota: &Self::Quota) -> usize {
+        let quota = quota.normalized();
         quota.limit.saturating_sub(self.count)
     }
 
@@ -60,6 +57,7 @@ impl RateGuard for FixedGuard {
     }
 
     async fn limit(&self, quota: &Self::Quota) -> usize {
+        let quota = quota.normalized();
         quota.limit
     }
 }
@@ -165,7 +163,20 @@ mod tests {
         let quota = BasicQuota::per_second(0);
 
         assert!(guard.verify(&quota).await);
+        assert!(!guard.verify(&quota).await);
         assert_eq!(guard.remaining(&quota).await, 0);
+        assert_eq!(guard.limit(&quota).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_fixed_guard_normalizes_non_positive_period() {
+        let mut guard = FixedGuard::new();
+        let quota = BasicQuota::set_seconds(2, 0);
+
+        assert!(guard.verify(&quota).await);
+        assert!(guard.verify(&quota).await);
+        assert!(!guard.verify(&quota).await);
+        assert_eq!(guard.quota.as_ref().unwrap().period, Duration::seconds(1));
     }
 
     #[tokio::test]

--- a/crates/rate-limiter/src/quota.rs
+++ b/crates/rate-limiter/src/quota.rs
@@ -68,6 +68,15 @@ impl BasicQuota {
     pub const fn set_hours(limit: usize, hours: i64) -> Self {
         Self::new(limit, Duration::seconds(3600 * hours))
     }
+
+    pub(crate) fn normalized(&self) -> Self {
+        let mut quota = self.clone();
+        quota.limit = quota.limit.max(1);
+        if quota.period <= Duration::ZERO {
+            quota.period = Duration::seconds(1);
+        }
+        quota
+    }
 }
 
 /// A quota split into cells for sliding-window accounting.
@@ -124,6 +133,21 @@ impl CelledQuota {
     pub const fn set_hours(limit: usize, cells: usize, hours: i64) -> Self {
         Self::new(limit, cells, Duration::seconds(3600 * hours))
     }
+
+    pub(crate) fn normalized(&self) -> Self {
+        let mut quota = self.clone();
+        quota.limit = quota.limit.max(1);
+        if quota.period <= Duration::ZERO {
+            quota.period = Duration::seconds(1);
+        }
+        quota.cells = quota.cells.max(1).min(quota.limit).min(u32::MAX as usize);
+
+        let max_nonzero_cells = usize::try_from(quota.period.whole_nanoseconds())
+            .unwrap_or(usize::MAX)
+            .max(1);
+        quota.cells = quota.cells.min(max_nonzero_cells);
+        quota
+    }
 }
 
 impl<Key, T> QuotaGetter<Key> for T
@@ -175,6 +199,14 @@ mod tests {
     }
 
     #[test]
+    fn test_basic_quota_normalized() {
+        let quota = BasicQuota::set_seconds(0, 0).normalized();
+
+        assert_eq!(quota.limit, 1);
+        assert_eq!(quota.period, Duration::seconds(1));
+    }
+
+    #[test]
     fn test_celled_quota() {
         let quota = CelledQuota::per_second(10, 3);
         assert_eq!(quota.limit, 10);
@@ -205,5 +237,17 @@ mod tests {
         assert_eq!(quota.limit, 15);
         assert_eq!(quota.cells, 6);
         assert_eq!(quota.period, Duration::seconds(7200));
+    }
+
+    #[test]
+    fn test_celled_quota_normalized() {
+        let quota = CelledQuota::new(0, 0, Duration::seconds(0)).normalized();
+
+        assert_eq!(quota.limit, 1);
+        assert_eq!(quota.cells, 1);
+        assert_eq!(quota.period, Duration::seconds(1));
+
+        let quota = CelledQuota::new(10, 10, Duration::nanoseconds(1)).normalized();
+        assert_eq!(quota.cells, 1);
     }
 }

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -33,20 +33,6 @@ impl SlidingGuard {
         }
     }
 
-    fn normalize_quota(quota: &CelledQuota) -> CelledQuota {
-        let mut quota = quota.clone();
-        if quota.limit == 0 {
-            quota.limit = 1;
-        }
-        if quota.cells == 0 {
-            quota.cells = 1;
-        }
-        if quota.cells > quota.limit {
-            quota.cells = quota.limit;
-        }
-        quota
-    }
-
     fn reset_window(&mut self, quota: &CelledQuota, now: OffsetDateTime) {
         self.cell_start = now;
         self.cell_span = quota.period / (quota.cells as u32);
@@ -61,7 +47,7 @@ impl RateGuard for SlidingGuard {
     type Quota = CelledQuota;
     async fn verify(&mut self, quota: &Self::Quota) -> bool {
         let now = OffsetDateTime::now_utc();
-        let quota = Self::normalize_quota(quota);
+        let quota = quota.normalized();
         if self.quota.as_ref() != Some(&quota) {
             self.reset_window(&quota, now);
             self.quota = Some(quota);
@@ -86,14 +72,17 @@ impl RateGuard for SlidingGuard {
     }
 
     async fn remaining(&self, quota: &Self::Quota) -> usize {
+        let quota = quota.normalized();
         quota.limit.saturating_sub(self.total)
     }
 
     async fn reset(&self, quota: &Self::Quota) -> i64 {
+        let quota = quota.normalized();
         (self.cell_start + quota.period).unix_timestamp()
     }
 
     async fn limit(&self, quota: &Self::Quota) -> usize {
+        let quota = quota.normalized();
         quota.limit
     }
 }
@@ -178,6 +167,27 @@ mod tests {
         // Zero cells should be treated as 1
         assert!(guard.verify(&quota).await);
         assert_eq!(guard.counts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_sliding_guard_verify_zero_limit() {
+        let mut guard = SlidingGuard::new();
+        let quota = CelledQuota::per_second(0, 2);
+
+        assert!(guard.verify(&quota).await);
+        assert!(!guard.verify(&quota).await);
+        assert_eq!(guard.limit(&quota).await, 1);
+        assert_eq!(guard.remaining(&quota).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_sliding_guard_normalizes_tiny_cell_span() {
+        let mut guard = SlidingGuard::new();
+        let quota = CelledQuota::new(10, 10, Duration::nanoseconds(1));
+
+        assert!(guard.verify(&quota).await);
+        assert_eq!(guard.counts.len(), 1);
+        assert!(guard.cell_span > Duration::ZERO);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Normalize `BasicQuota` and `CelledQuota` before guard accounting.
- Make fixed-window checks use the normalized quota for comparison, reset timing, remaining count, and limit headers.
- Make sliding-window checks normalize non-positive periods and clamp cells so `cell_span` cannot become zero.
- Add regression tests for zero limit, non-positive period, and tiny-period sliding windows.

## Why
Fixed-window rate limiting previously stored a partially normalized quota but still compared and reset using the original value. A zero limit or non-positive period could keep resetting the window and effectively bypass limits. Sliding-window accounting already normalized part of the quota, but a tiny period with too many cells could produce a zero cell span and leave the rotation loop unable to make progress.

This keeps the public constructors compatible while normalizing invalid runtime values inside the guard path.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo-rate-limiter --all-targets --all-features`
- `cargo clippy -p salvo-rate-limiter --all-targets --all-features -- -D warnings`
- `cargo test -p salvo-rate-limiter --all-features`