### PR TITLE
Respect Accept-Encoding order for precompressed files

### DIFF
--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -94,10 +94,7 @@ pub fn parse_accept_encoding(header: &str) -> Vec<(String, u8)> {
         })
         .collect::<Vec<(String, u8)>>();
 
-    vec.sort_by(|(_, a), (_, b)| match b.cmp(a) {
-        std::cmp::Ordering::Equal => std::cmp::Ordering::Greater,
-        other => other,
-    });
+    vec.sort_by(|(_, a), (_, b)| b.cmp(a));
 
     vec
 }

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -1,6 +1,6 @@
 //! Serve static directories with directory listing support
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::fs::Metadata;
@@ -10,8 +10,10 @@ use std::time::SystemTime;
 
 use salvo_core::fs::NamedFile;
 use salvo_core::handler::Handler;
-use salvo_core::http::header::ACCEPT_ENCODING;
-use salvo_core::http::{self, HeaderValue, Request, Response, StatusCode, StatusError, mime};
+use salvo_core::http::header::{ACCEPT_ENCODING, VARY};
+use salvo_core::http::{
+    self, HeaderMap, HeaderValue, Request, Response, StatusCode, StatusError, mime,
+};
 use salvo_core::routing::{
     decode_url_path, encode_url_path, normalize_url_path, redirect_to_dir_url,
 };
@@ -71,6 +73,21 @@ impl From<CompressionAlgo> for HeaderValue {
             CompressionAlgo::Gzip => Self::from_static("gzip"),
             CompressionAlgo::Zstd => Self::from_static("zstd"),
         }
+    }
+}
+
+fn append_vary_accept_encoding(headers: &mut HeaderMap) {
+    let already_varies = headers
+        .get_all(VARY)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|value| {
+            let value = value.trim();
+            value == "*" || value.eq_ignore_ascii_case("accept-encoding")
+        });
+    if !already_varies {
+        headers.append(VARY, HeaderValue::from_static("Accept-Encoding"));
     }
 }
 
@@ -490,6 +507,7 @@ impl Handler for StaticDir {
                 .map(|ext| self.is_compressed_ext(ext))
                 .unwrap_or(false);
             let mut content_encoding = None;
+            let mut varies_on_accept_encoding = false;
             let content_type = mime_infer::from_path(&abs_path).first();
 
             let named_path = if !is_compressed_ext {
@@ -502,26 +520,34 @@ impl Handler for StaticDir {
                         .unwrap_or_default();
                     // Skip compressed variant lookup when client only accepts identity
                     if !header.is_empty() && header != "identity" {
-                        let accept_algos = http::parse_accept_encoding(header)
-                            .into_iter()
-                            .filter_map(|(algo, _level)| algo.parse::<CompressionAlgo>().ok())
-                            .collect::<HashSet<_>>();
-                        for (algo, exts) in &self.compressed_variations {
-                            if accept_algos.contains(algo) {
-                                for zip_ext in exts {
-                                    let mut path = abs_path.clone();
-                                    path.as_mut_os_string().push(".");
-                                    path.as_mut_os_string().push(zip_ext.as_str());
-                                    if self
-                                        .resolve_child_path(&canonical_root, path.clone())
-                                        .await
-                                        .map(|path| path.metadata.is_file())
-                                        .unwrap_or(false)
-                                    {
-                                        new_abs_path = Some(path);
-                                        content_encoding = Some(algo.to_string());
-                                        break;
-                                    }
+                        varies_on_accept_encoding = true;
+                        'accepted_encoding: for (algo, level) in http::parse_accept_encoding(header)
+                        {
+                            if level == 0 {
+                                continue;
+                            }
+                            if algo.eq_ignore_ascii_case("identity") {
+                                break;
+                            }
+                            let Ok(algo) = algo.parse::<CompressionAlgo>() else {
+                                continue;
+                            };
+                            let Some(exts) = self.compressed_variations.get(&algo) else {
+                                continue;
+                            };
+                            for zip_ext in exts {
+                                let mut path = abs_path.clone();
+                                path.as_mut_os_string().push(".");
+                                path.as_mut_os_string().push(zip_ext.as_str());
+                                if self
+                                    .resolve_child_path(&canonical_root, path.clone())
+                                    .await
+                                    .map(|path| path.metadata.is_file())
+                                    .unwrap_or(false)
+                                {
+                                    new_abs_path = Some(path);
+                                    content_encoding = Some(algo.to_string());
+                                    break 'accepted_encoding;
                                 }
                             }
                         }
@@ -534,7 +560,7 @@ impl Handler for StaticDir {
                 abs_path
             };
 
-            let builder = {
+            let (builder, varies_on_accept_encoding) = {
                 let mut builder = NamedFile::builder(named_path);
                 if let Some(content_encoding) = content_encoding {
                     builder = builder.content_encoding(content_encoding);
@@ -545,11 +571,14 @@ impl Handler for StaticDir {
                 if let Some(content_type) = content_type {
                     builder = builder.content_type(content_type);
                 }
-                builder
+                (builder, varies_on_accept_encoding)
             };
             if let Ok(named_file) = builder.build().await {
                 let headers = req.headers();
                 named_file.send(headers, res).await;
+                if varies_on_accept_encoding {
+                    append_vary_accept_encoding(res.headers_mut());
+                }
             } else {
                 res.render(StatusError::internal_server_error().brief("read file failed"));
             }

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -43,6 +43,8 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    use salvo_core::http::HeaderValue;
+    use salvo_core::http::header::{CONTENT_ENCODING, VARY};
     use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
@@ -202,6 +204,56 @@ mod tests {
             .send(&service)
             .await;
         assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_serve_static_dir_respects_accept_encoding_q_order() {
+        let router = Router::with_path("{*path}").get(StaticDir::new(vec!["test/static"]));
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:5801/test1.txt")
+            .add_header("accept-encoding", "br;q=0.1, gzip;q=1", true)
+            .send(&service)
+            .await;
+        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_ENCODING),
+            Some(&HeaderValue::from_static("gzip"))
+        );
+        let varies_on_accept_encoding = response
+            .headers()
+            .get_all(VARY)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|value| value.trim().eq_ignore_ascii_case("accept-encoding"));
+        assert!(varies_on_accept_encoding);
+
+        let response = TestClient::get("http://127.0.0.1:5801/test1.txt")
+            .add_header("accept-encoding", "br;q=1, gzip;q=0.1", true)
+            .send(&service)
+            .await;
+        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_ENCODING),
+            Some(&HeaderValue::from_static("br"))
+        );
+
+        let mut response = TestClient::get("http://127.0.0.1:5801/test1.txt")
+            .add_header("accept-encoding", "identity;q=1, gzip;q=0.5", true)
+            .send(&service)
+            .await;
+        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.headers().get(CONTENT_ENCODING), None);
+        let varies_on_accept_encoding = response
+            .headers()
+            .get_all(VARY)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|value| value.trim().eq_ignore_ascii_case("accept-encoding"));
+        assert!(varies_on_accept_encoding);
+        assert_eq!(response.take_string().await.unwrap(), "copy1");
     }
 
     #[cfg(feature = "embed")]

--- a/crates/serve-static/test/static/test1.txt.br
+++ b/crates/serve-static/test/static/test1.txt.br
@@ -1,0 +1,1 @@
+brotli variant

--- a/crates/serve-static/test/static/test1.txt.gz
+++ b/crates/serve-static/test/static/test1.txt.gz
@@ -1,0 +1,1 @@
+gzip variant


### PR DESCRIPTION
## Summary
- preserve `Accept-Encoding` q-value ordering when selecting precompressed static file variants
- treat higher-priority `identity` as a reason to keep serving the original file
- add `Vary: Accept-Encoding` when a precompressed variant is selected
- add fixture coverage for gzip/br preference order and identity preference

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo_core -p salvo-serve-static --all-targets --all-features`
- `cargo clippy -p salvo_core -p salvo-serve-static --all-targets --all-features -- -D warnings`
- `cargo test -p salvo_core http:: --all-features`
- `cargo test -p salvo-serve-static --all-features`