### PR TITLE
Add body cache-clearing replacement

### DIFF
--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -92,6 +92,9 @@ impl Handler for SecureMaxSize {
 ///   internally. Subsequent calls return the cached bytes.
 /// - [`form_data()`](Request::form_data) parses form data and caches the result. If the body has
 ///   already been consumed by `payload()`, it will use the cached bytes to parse the form.
+/// - [`replace_body()`](Request::replace_body) preserves those cached values for compatibility.
+///   Use [`replace_body_and_clear_cache()`](Request::replace_body_and_clear_cache) when replacing
+///   the body should also invalidate cached payload and form data.
 ///
 /// # Size Limits
 ///
@@ -572,6 +575,24 @@ impl Request {
     #[inline]
     pub fn replace_body(&mut self, body: ReqBody) -> ReqBody {
         std::mem::replace(&mut self.body, body)
+    }
+
+    /// Replaces the body with a new value, clears cached payload and form data, and returns the
+    /// old body.
+    ///
+    /// This is useful for middleware that transforms the request body and wants subsequent calls to
+    /// [`payload()`](Request::payload) or [`form_data()`](Request::form_data) to read the new body.
+    #[inline]
+    pub fn replace_body_and_clear_cache(&mut self, body: ReqBody) -> ReqBody {
+        let old_body = self.replace_body(body);
+        self.clear_body_cache();
+        old_body
+    }
+
+    #[inline]
+    fn clear_body_cache(&mut self) {
+        self.payload = tokio::sync::OnceCell::new();
+        self.form_data = tokio::sync::OnceCell::new();
     }
 
     /// Takes the body from the request, leaving [`ReqBody::None`] in its place.
@@ -1684,6 +1705,54 @@ Hello World\r\n\
         let file = form_data.files.get("file").unwrap();
         assert_eq!(file.name().unwrap(), "test.txt");
         assert_eq!(file.content_type().unwrap(), "text/plain");
+    }
+
+    #[tokio::test]
+    async fn test_replace_body_preserves_cached_payload() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/form")
+            .add_header("content-type", "application/x-www-form-urlencoded", true)
+            .raw_form("username=first")
+            .build();
+
+        let payload = req.payload().await.unwrap().clone();
+        assert_eq!(payload.as_ref(), b"username=first");
+
+        req.replace_body(ReqBody::from("username=second"));
+
+        let payload = req.payload().await.unwrap();
+        assert_eq!(payload.as_ref(), b"username=first");
+    }
+
+    #[tokio::test]
+    async fn test_replace_body_and_clear_cache_refreshes_payload() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/form")
+            .add_header("content-type", "application/x-www-form-urlencoded", true)
+            .raw_form("username=first")
+            .build();
+
+        let payload = req.payload().await.unwrap().clone();
+        assert_eq!(payload.as_ref(), b"username=first");
+
+        req.replace_body_and_clear_cache(ReqBody::from("username=second"));
+
+        let payload = req.payload().await.unwrap();
+        assert_eq!(payload.as_ref(), b"username=second");
+    }
+
+    #[tokio::test]
+    async fn test_replace_body_and_clear_cache_refreshes_form_data() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/form")
+            .add_header("content-type", "application/x-www-form-urlencoded", true)
+            .raw_form("username=first")
+            .build();
+
+        let form_data = req.form_data().await.unwrap();
+        assert_eq!(form_data.fields.get("username").unwrap(), "first");
+
+        req.replace_body_and_clear_cache(ReqBody::from("username=second"));
+
+        let form_data = req.form_data().await.unwrap();
+        assert_eq!(form_data.fields.get("username").unwrap(), "second");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `Request::replace_body_and_clear_cache` for body-transforming middleware
- keep `replace_body` cache-preserving behavior for compatibility
- document the cache semantics and cover payload/form-data refresh behavior

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo_core --all-targets --all-features`
- `cargo clippy -p salvo_core --all-targets --all-features -- -D warnings`
- `cargo test -p salvo_core http::request --all-features`
- `cargo test -p salvo_core http::request::tests::test_replace_body --all-features`