### PR TITLE
Add secure cookie policy

### DIFF
--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -57,6 +57,8 @@ pub mod mime;
 mod range;
 pub mod request;
 pub mod response;
+/// Cookie security policy helpers.
+pub mod secure_cookie;
 cfg_feature! {
     #![feature = "cookie"]
     pub use cookie;
@@ -68,6 +70,7 @@ pub use http::method::Method;
 pub use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header, method, uri};
 pub use range::HttpRange;
 pub use request::Request;
+pub use secure_cookie::SecureCookiePolicy;
 pub mod body;
 pub use body::{Body, ReqBody, ResBody};
 pub use http::version::Version;

--- a/crates/core/src/http/secure_cookie.rs
+++ b/crates/core/src/http/secure_cookie.rs
@@ -1,0 +1,63 @@
+use http::uri::Scheme;
+
+use crate::Request;
+
+/// Policy for deciding whether response cookies should include the `Secure` attribute.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SecureCookiePolicy {
+    /// Always include the `Secure` attribute.
+    Always,
+    /// Never include the `Secure` attribute.
+    Never,
+    /// Include the `Secure` attribute when the request URI scheme is HTTPS.
+    #[default]
+    AutoFromScheme,
+}
+
+impl SecureCookiePolicy {
+    /// Create a fixed secure-cookie policy from a boolean.
+    #[inline]
+    #[must_use]
+    pub fn from_bool(secure: bool) -> Self {
+        if secure { Self::Always } else { Self::Never }
+    }
+
+    /// Resolve this policy for a request.
+    #[inline]
+    #[must_use]
+    pub fn is_secure(self, req: &Request) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::AutoFromScheme => req.uri().scheme() == Some(&Scheme::HTTPS),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::TestClient;
+
+    #[test]
+    fn secure_cookie_policy_from_bool_uses_fixed_policy() {
+        assert_eq!(
+            SecureCookiePolicy::from_bool(true),
+            SecureCookiePolicy::Always
+        );
+        assert_eq!(
+            SecureCookiePolicy::from_bool(false),
+            SecureCookiePolicy::Never
+        );
+    }
+
+    #[test]
+    fn secure_cookie_policy_resolves_from_scheme() {
+        let http_req = TestClient::get("http://example.com/").build();
+        let https_req = TestClient::get("https://example.com/").build();
+
+        assert!(!SecureCookiePolicy::AutoFromScheme.is_secure(&http_req));
+        assert!(SecureCookiePolicy::AutoFromScheme.is_secure(&https_req));
+    }
+}

--- a/crates/core/src/http/secure_cookie.rs
+++ b/crates/core/src/http/secure_cookie.rs
@@ -10,7 +10,7 @@ pub enum SecureCookiePolicy {
     Always,
     /// Never include the `Secure` attribute.
     Never,
-    /// Include the `Secure` attribute when the request URI scheme is HTTPS.
+    /// Include the `Secure` attribute when the request scheme is HTTPS.
     #[default]
     AutoFromScheme,
 }
@@ -30,7 +30,7 @@ impl SecureCookiePolicy {
         match self {
             Self::Always => true,
             Self::Never => false,
-            Self::AutoFromScheme => req.uri().scheme() == Some(&Scheme::HTTPS),
+            Self::AutoFromScheme => req.scheme() == &Scheme::HTTPS,
         }
     }
 }
@@ -59,5 +59,17 @@ mod tests {
 
         assert!(!SecureCookiePolicy::AutoFromScheme.is_secure(&http_req));
         assert!(SecureCookiePolicy::AutoFromScheme.is_secure(&https_req));
+    }
+
+    #[test]
+    fn secure_cookie_policy_uses_recorded_scheme_when_uri_has_no_scheme() {
+        let hyper_req = http::Request::builder()
+            .uri("/")
+            .body(crate::http::ReqBody::None)
+            .expect("build request");
+        let req = Request::from_hyper(hyper_req, Scheme::HTTPS);
+
+        assert_eq!(req.uri().scheme(), None);
+        assert!(SecureCookiePolicy::AutoFromScheme.is_secure(&req));
     }
 }

--- a/crates/csrf/src/cookie_store.rs
+++ b/crates/csrf/src/cookie_store.rs
@@ -1,6 +1,6 @@
 use cookie::time::Duration;
 use cookie::{Cookie, Expiration, SameSite};
-use salvo_core::http::uri::Scheme;
+use salvo_core::http::SecureCookiePolicy;
 use salvo_core::{Depot, Error, Request, Response};
 
 use crate::CsrfCipher;
@@ -21,6 +21,8 @@ pub struct CookieStore {
     pub domain: Option<String>,
     /// Forced secure cookie attribute. If None, infer from request URI scheme.
     pub secure: Option<bool>,
+    /// Policy used when `secure` is not explicitly set.
+    pub secure_cookie_policy: SecureCookiePolicy,
 }
 impl Default for CookieStore {
     #[inline]
@@ -39,6 +41,7 @@ impl CookieStore {
             path: "/".into(),
             domain: None,
             secure: None,
+            secure_cookie_policy: SecureCookiePolicy::AutoFromScheme,
         }
     }
     /// Sets cookie name.
@@ -76,6 +79,17 @@ impl CookieStore {
     #[must_use]
     pub fn secure(mut self, secure: bool) -> Self {
         self.secure = Some(secure);
+        self.secure_cookie_policy = SecureCookiePolicy::from_bool(secure);
+        self
+    }
+
+    /// Sets the policy used to decide whether CSRF cookies include `Secure`.
+    ///
+    /// This clears the legacy fixed `secure` override so the policy controls future saves.
+    #[must_use]
+    pub fn secure_cookie_policy(mut self, policy: SecureCookiePolicy) -> Self {
+        self.secure = None;
+        self.secure_cookie_policy = policy;
         self
     }
 }
@@ -107,7 +121,9 @@ impl CsrfStore for CookieStore {
     ) -> Result<(), Self::Error> {
         let secure = self
             .secure
-            .unwrap_or_else(|| req.uri().scheme() == Some(&Scheme::HTTPS));
+            .map(SecureCookiePolicy::from_bool)
+            .unwrap_or(self.secure_cookie_policy)
+            .is_secure(req);
         let expires = cookie::time::OffsetDateTime::now_utc() + self.ttl;
         let cookie_builder = Cookie::build((self.name.clone(), format!("{token}.{proof}")))
             .http_only(true)
@@ -146,6 +162,7 @@ mod tests {
         assert_eq!(cookie_store.path, "/test");
         assert_eq!(cookie_store.domain.as_deref(), Some("example.com"));
         assert_eq!(cookie_store.secure, Some(true));
+        assert_eq!(cookie_store.secure_cookie_policy, SecureCookiePolicy::Always);
 
         let mut req = TestClient::get("http://example.com/test").build();
         let mut depot = Depot::new();
@@ -187,5 +204,45 @@ mod tests {
 
         let cookie = res.cookies().get("test_cookie").unwrap();
         assert_eq!(cookie.secure(), Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_cookie_store_secure_policy_can_force_secure() {
+        let cipher = BcryptCipher::new();
+        let cookie_store = CookieStore::new()
+            .name("test_cookie")
+            .secure_cookie_policy(SecureCookiePolicy::Always);
+        let mut req = TestClient::get("http://example.com/test").build();
+        let mut depot = Depot::new();
+        let mut res = Response::new();
+
+        let (token, proof) = cipher.generate();
+        cookie_store
+            .save(&mut req, &mut depot, &mut res, &token, &proof)
+            .await
+            .unwrap();
+
+        let cookie = res.cookies().get("test_cookie").unwrap();
+        assert_eq!(cookie.secure(), Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_cookie_store_secure_policy_can_disable_https_secure() {
+        let cipher = BcryptCipher::new();
+        let cookie_store = CookieStore::new()
+            .name("test_cookie")
+            .secure_cookie_policy(SecureCookiePolicy::Never);
+        let mut req = TestClient::get("https://example.com/test").build();
+        let mut depot = Depot::new();
+        let mut res = Response::new();
+
+        let (token, proof) = cipher.generate();
+        cookie_store
+            .save(&mut req, &mut depot, &mut res, &token, &proof)
+            .await
+            .unwrap();
+
+        let cookie = res.cookies().get("test_cookie").unwrap();
+        assert_eq!(cookie.secure(), Some(false));
     }
 }

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -67,7 +67,7 @@ use std::fmt::{self, Formatter};
 use std::time::Duration;
 
 use cookie::{Cookie, Key, KeyError, SameSite};
-use salvo_core::http::uri::Scheme;
+use salvo_core::http::SecureCookiePolicy;
 use salvo_core::{Depot, Error, FlowCtrl, Handler, Request, Response, async_trait};
 use saysion::base64::Engine as _;
 use saysion::base64::engine::general_purpose;
@@ -122,7 +122,7 @@ pub struct HandlerBuilder<S> {
     session_ttl: Option<Duration>,
     save_unchanged: bool,
     same_site_policy: SameSite,
-    secure_cookie: Option<bool>,
+    secure_cookie_policy: SecureCookiePolicy,
     key: Key,
     fallback_keys: Vec<Key>,
 }
@@ -138,7 +138,7 @@ where
             .field("cookie_domain", &self.cookie_domain)
             .field("session_ttl", &self.session_ttl)
             .field("same_site_policy", &self.same_site_policy)
-            .field("secure_cookie", &self.secure_cookie)
+            .field("secure_cookie_policy", &self.secure_cookie_policy)
             .field("key", &"..")
             .field("fallback_keys", &"..")
             .field("save_unchanged", &self.save_unchanged)
@@ -191,7 +191,7 @@ where
             cookie_name: "salvo.session.id".into(),
             cookie_domain: None,
             same_site_policy: SameSite::Lax,
-            secure_cookie: None,
+            secure_cookie_policy: SecureCookiePolicy::AutoFromScheme,
             session_ttl: Some(Duration::from_secs(24 * 60 * 60)),
             key,
             fallback_keys: vec![],
@@ -266,7 +266,18 @@ where
     #[inline]
     #[must_use]
     pub fn secure_cookie(mut self, secure: bool) -> Self {
-        self.secure_cookie = Some(secure);
+        self.secure_cookie_policy = SecureCookiePolicy::from_bool(secure);
+        self
+    }
+
+    /// Sets the policy used to decide whether session cookies include `Secure`.
+    ///
+    /// The default policy is [`SecureCookiePolicy::AutoFromScheme`]. `SameSite::None`
+    /// session cookies are always sent with `Secure`.
+    #[inline]
+    #[must_use]
+    pub fn secure_cookie_policy(mut self, policy: SecureCookiePolicy) -> Self {
+        self.secure_cookie_policy = policy;
         self
     }
 
@@ -303,7 +314,7 @@ where
             cookie_domain,
             session_ttl,
             same_site_policy,
-            secure_cookie,
+            secure_cookie_policy,
             key,
             fallback_keys,
         } = self;
@@ -322,7 +333,7 @@ where
             cookie_domain,
             session_ttl,
             same_site_policy,
-            secure_cookie,
+            secure_cookie_policy,
             hmac,
             fallback_hmacs,
         })
@@ -338,7 +349,7 @@ pub struct SessionHandler<S> {
     session_ttl: Option<Duration>,
     save_unchanged: bool,
     same_site_policy: SameSite,
-    secure_cookie: Option<bool>,
+    secure_cookie_policy: SecureCookiePolicy,
     hmac: Hmac<Sha256>,
     fallback_hmacs: Vec<Hmac<Sha256>>,
 }
@@ -355,7 +366,7 @@ where
             .field("cookie_domain", &self.cookie_domain)
             .field("session_ttl", &self.session_ttl)
             .field("same_site_policy", &self.same_site_policy)
-            .field("secure_cookie", &self.secure_cookie)
+            .field("secure_cookie_policy", &self.secure_cookie_policy)
             .field("key", &"..")
             .field("fallback_keys", &"..")
             .field("save_unchanged", &self.save_unchanged)
@@ -400,9 +411,8 @@ where
             match self.store.store_session(session).await {
                 Ok(cookie_value) => {
                     if let Some(cookie_value) = cookie_value {
-                        let secure_cookie = self
-                            .secure_cookie
-                            .unwrap_or_else(|| req.uri().scheme() == Some(&Scheme::HTTPS));
+                        let secure_cookie = self.same_site_policy == SameSite::None
+                            || self.secure_cookie_policy.is_secure(req);
                         let cookie = self.build_cookie(secure_cookie, cookie_value);
                         res.add_cookie(cookie);
                     }
@@ -649,6 +659,10 @@ mod tests {
         assert!(builder.cookie_domain.is_none());
         assert!(builder.save_unchanged);
         assert_eq!(builder.same_site_policy, SameSite::Lax);
+        assert_eq!(
+            builder.secure_cookie_policy,
+            SecureCookiePolicy::AutoFromScheme
+        );
         assert_eq!(builder.session_ttl, Some(Duration::from_secs(24 * 60 * 60)));
     }
 
@@ -795,7 +809,18 @@ mod tests {
         assert_eq!(handler.session_ttl, Some(Duration::from_secs(7200)));
         assert!(!handler.save_unchanged);
         assert_eq!(handler.same_site_policy, SameSite::Strict);
-        assert_eq!(handler.secure_cookie, Some(true));
+        assert_eq!(handler.secure_cookie_policy, SecureCookiePolicy::Always);
+    }
+
+    #[test]
+    fn test_handler_builder_secure_cookie_policy() {
+        let builder = HandlerBuilder::new(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .secure_cookie_policy(SecureCookiePolicy::Never);
+
+        assert_eq!(builder.secure_cookie_policy, SecureCookiePolicy::Never);
     }
 
     // Tests for SessionHandler
@@ -921,6 +946,38 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
+        assert!(cookie.contains("Secure"));
+    }
+
+    #[tokio::test]
+    async fn test_session_same_site_none_forces_secure_cookie() {
+        #[handler]
+        pub async fn index() -> &'static str {
+            "ok"
+        }
+
+        let session_handler = SessionHandler::builder(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .same_site_policy(SameSite::None)
+        .secure_cookie(false)
+        .build()
+        .unwrap();
+
+        let router = Router::new().hoop(session_handler).get(index);
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:8698/")
+            .send(&service)
+            .await;
+        let cookie = response
+            .headers()
+            .get(SET_COOKIE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cookie.contains("SameSite=None"));
         assert!(cookie.contains("Secure"));
     }
 


### PR DESCRIPTION
## Summary
- add a shared `SecureCookiePolicy` for resolving cookie `Secure` attributes
- keep existing session/csrf `secure_cookie(bool)` and `secure(bool)` APIs while adding explicit policy builders
- force session cookies with `SameSite=None` to include `Secure`

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo_core -p salvo-session -p salvo-csrf --all-targets --all-features`
- `cargo clippy -p salvo_core -p salvo-session -p salvo-csrf --all-targets --all-features -- -D warnings`
- `cargo test -p salvo_core http::secure_cookie --all-features`
- `cargo test -p salvo-session --all-features`
- `cargo test -p salvo-csrf --all-features`