### PR TITLE
Clean up names and docs

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -577,7 +577,7 @@ impl NamedFile {
         }
     }
 
-    /// GEt last_modified value.
+    /// Get last modified value.
     #[inline]
     pub fn last_modified(&self) -> Option<SystemTime> {
         self.modified

--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -48,12 +48,12 @@ impl FormData {
         O: Into<Bytes> + 'static,
         E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
-        let ctype: Option<Mime> = headers
+        let content_type: Option<Mime> = headers
             .get(CONTENT_TYPE)
             .and_then(|h| h.to_str().ok())
             .and_then(|v| v.parse().ok());
-        match ctype {
-            Some(ctype) if ctype.subtype() == mime::WWW_FORM_URLENCODED => {
+        match content_type {
+            Some(content_type) if content_type.subtype() == mime::WWW_FORM_URLENCODED => {
                 futures_util::pin_mut!(body);
                 let mut data = BytesMut::new();
                 while let Some(chunk) = body.try_next().await.map_err(|e| {
@@ -70,7 +70,7 @@ impl FormData {
                 form_data.fields = form_urlencoded::parse(&data).into_owned().collect();
                 Ok(form_data)
             }
-            Some(ctype) if ctype.type_() == mime::MULTIPART => {
+            Some(content_type) if content_type.type_() == mime::MULTIPART => {
                 let mut form_data = Self::new();
                 let Some(boundary) = headers
                     .get(CONTENT_TYPE)

--- a/crates/csrf/src/bcrypt_cipher.rs
+++ b/crates/csrf/src/bcrypt_cipher.rs
@@ -18,7 +18,8 @@ impl Default for BcryptCipher {
 impl BcryptCipher {
     /// Create a new `BcryptCipher`.
     #[inline]
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
             cost: 8,
             token_size: 32,
@@ -27,7 +28,8 @@ impl BcryptCipher {
 
     /// Sets the length of the token.
     #[inline]
-    #[must_use] pub fn token_size(mut self, token_size: usize) -> Self {
+    #[must_use]
+    pub fn token_size(mut self, token_size: usize) -> Self {
         assert!((8..=72).contains(&token_size), "length must be between 8 and 72");
         self.token_size = token_size;
         self
@@ -35,7 +37,8 @@ impl BcryptCipher {
 
     /// Sets the cost for bcrypt.
     #[inline]
-    #[must_use] pub fn cost(mut self, cost: u32) -> Self {
+    #[must_use]
+    pub fn cost(mut self, cost: u32) -> Self {
         assert!((4..=31).contains(&cost), "cost must be between 4 and 31");
         self.cost = cost;
         self

--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -100,7 +100,8 @@ fn request_limit(max_size: u64) -> usize {
 
 /// Create a new `MaxSize`.
 #[inline]
-#[must_use] pub fn max_size(size: u64) -> MaxSize {
+#[must_use]
+pub fn max_size(size: u64) -> MaxSize {
     MaxSize(size)
 }
 

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -314,11 +314,11 @@ impl OidcDecoder {
         if !self.cache_state.is_revalidating() {
             self.cache_state.set_is_revalidating(true);
             tracing::info!("Spawning Task to re-validate JWKS");
-            let a = self.clone();
+            let decoder = self.clone();
             tokio::task::spawn(async move {
-                let _ = a.update_cache().await;
-                a.cache_state.set_is_revalidating(false);
-                a.notifier.notify_waiters();
+                let _ = decoder.update_cache().await;
+                decoder.cache_state.set_is_revalidating(false);
+                decoder.notifier.notify_waiters();
             });
         }
     }
@@ -362,10 +362,10 @@ impl OidcDecoder {
 
         let max_age = fetched + max_age_secs;
         let now = current_time();
-        let val = read_cache.get_key(kid);
+        let cached_key = read_cache.get_key(kid);
 
         if now <= max_age {
-            return Ok(val);
+            return Ok(cached_key);
         }
 
         // If the stale while revalidate setting is present
@@ -373,14 +373,14 @@ impl OidcDecoder {
             // if we're within the SWR allowed window
             if now <= swr.as_secs() + max_age {
                 self.revalidate_cache();
-                return Ok(val);
+                return Ok(cached_key);
             }
         }
         if let Some(swr_err) = read_cache.cache_policy.stale_if_error {
             // if the last update failed and the stale-if-error is present
             if now <= swr_err.as_secs() + max_age && self.cache_state.is_error() {
                 self.revalidate_cache();
-                return Ok(val);
+                return Ok(cached_key);
             }
         }
         drop(read_cache);

--- a/crates/jwt-auth/src/oidc/cache.rs
+++ b/crates/jwt-auth/src/oidc/cache.rs
@@ -22,7 +22,7 @@ pub struct CachePolicy {
     /// Time in Seconds to refresh the JWKS from the OIDC Provider
     /// Default/Minimum value: 1 Second
     pub max_age: Duration,
-    /// The amount of time a s
+    /// The amount of time the stale JWKS data can be used while it is being revalidated.
     pub stale_while_revalidate: Option<Duration>,
     /// The amount of time the stale JWKS data should be valid for if we are unable to re-validate it from the URL.
     /// Minimum Value: 60 Seconds
@@ -31,7 +31,8 @@ pub struct CachePolicy {
 
 impl CachePolicy {
     /// Create a new cache policy from the header value of the Cache-Control header
-    #[must_use] pub fn from_header_val(value: Option<&HeaderValue>) -> Self {
+    #[must_use]
+    pub fn from_header_val(value: Option<&HeaderValue>) -> Self {
         // Initialize the default config of polling every second
         let mut config = Self::default();
 
@@ -46,25 +47,25 @@ impl CachePolicy {
         // Iterate over every token in the header value
         for token in value.split(',') {
             // split them into whitespace trimmed pairs
-            let (key, val) = {
+            let (key, directive_value) = {
                 let mut split = token.split('=').map(str::trim);
                 (split.next(), split.next())
             };
-            //Modify the default config based on the values that matter
-            //Any values here would be more permissive than the default behavior
-            match (key, val) {
-                (Some("max-age"), Some(val)) => {
-                    if let Ok(secs) = val.parse::<u64>() {
+            // Modify the default config based on the values that matter.
+            // Any values here would be more permissive than the default behavior.
+            match (key, directive_value) {
+                (Some("max-age"), Some(directive_value)) => {
+                    if let Ok(secs) = directive_value.parse::<u64>() {
                         self.max_age = Duration::from_secs(secs);
                     }
                 }
-                (Some("stale-while-revalidate"), Some(val)) => {
-                    if let Ok(secs) = val.parse::<u64>() {
+                (Some("stale-while-revalidate"), Some(directive_value)) => {
+                    if let Ok(secs) = directive_value.parse::<u64>() {
                         self.stale_while_revalidate = Some(Duration::from_secs(secs));
                     }
                 }
-                (Some("stale-if-error"), Some(val)) => {
-                    if let Ok(secs) = val.parse::<u64>() {
+                (Some("stale-if-error"), Some(directive_value)) => {
+                    if let Ok(secs) = directive_value.parse::<u64>() {
                         self.stale_if_error = Some(Duration::from_secs(secs));
                     }
                 }
@@ -108,7 +109,8 @@ pub struct CacheState {
 
 impl CacheState {
     /// Create a new `CacheState`
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
             last_update: AtomicU64::new(current_time()),
             is_revalidating: AtomicBool::new(false),
@@ -163,7 +165,8 @@ pub struct JwkSetStore {
 
 impl JwkSetStore {
     /// Create a new `JwkSetStore`
-    #[must_use] pub fn new(jwks: JwkSet, cache_policy: CachePolicy, validation: Validation) -> Self {
+    #[must_use]
+    pub fn new(jwks: JwkSet, cache_policy: CachePolicy, validation: Validation) -> Self {
         Self {
             jwks,
             decoding_map: HashMap::new(),
@@ -204,7 +207,8 @@ impl JwkSetStore {
     }
 
     /// Get the DecodingInfo for a given kid
-    #[must_use] pub fn get_key(&self, kid: &str) -> Option<Arc<DecodingInfo>> {
+    #[must_use]
+    pub fn get_key(&self, kid: &str) -> Option<Arc<DecodingInfo>> {
         self.decoding_map.get(kid).cloned()
     }
 

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -460,7 +460,7 @@ where
         &mut self.client
     }
 
-    /// Enable x-forwarded-for header prepending.
+    /// Enable x-forwarded-for header forwarding.
     #[inline]
     #[must_use]
     pub fn client_ip_forwarding(mut self, enable: bool) -> Self {
@@ -506,7 +506,7 @@ where
         }
         let path = encode_url_path(&normalize_url_path(&path));
         let query = (self.url_query_getter)(req, depot);
-        let rest = if let Some(query) = query {
+        let path_and_query = if let Some(query) = query {
             if let Some(stripped) = query.strip_prefix('?') {
                 format!("{path}?{}", utf8_percent_encode(stripped, QUERY_ENCODE_SET))
             } else {
@@ -515,17 +515,17 @@ where
         } else {
             path
         };
-        let forward_url = if upstream.ends_with('/') && rest.starts_with('/') {
-            format!("{}{}", upstream.trim_end_matches('/'), rest)
-        } else if upstream.ends_with('/') || rest.starts_with('/') {
-            format!("{upstream}{rest}")
-        } else if rest.is_empty() {
+        let forward_url = if upstream.ends_with('/') && path_and_query.starts_with('/') {
+            format!("{}{}", upstream.trim_end_matches('/'), path_and_query)
+        } else if upstream.ends_with('/') || path_and_query.starts_with('/') {
+            format!("{upstream}{path_and_query}")
+        } else if path_and_query.is_empty() {
             upstream.to_owned()
         } else {
-            format!("{upstream}/{rest}")
+            format!("{upstream}/{path_and_query}")
         };
         let forward_url: Uri = TryFrom::try_from(forward_url).map_err(Error::other)?;
-        let mut build = hyper::Request::builder()
+        let mut request_builder = hyper::Request::builder()
             .method(req.method())
             .uri(&forward_url);
         let connection_headers = connection_header_names(req.headers());
@@ -537,13 +537,14 @@ where
             if self.strip_authorization_header_enabled && key == AUTHORIZATION {
                 continue;
             }
-            build = build.header(key, value);
+            request_builder = request_builder.header(key, value);
         }
         if let Some(upgrade_type) = upgrade_type {
-            build = build.header(CONNECTION, HeaderValue::from_static("upgrade"));
+            request_builder =
+                request_builder.header(CONNECTION, HeaderValue::from_static("upgrade"));
             match HeaderValue::from_str(&upgrade_type) {
                 Ok(upgrade_type) => {
-                    build = build.header(UPGRADE, upgrade_type);
+                    request_builder = request_builder.header(UPGRADE, upgrade_type);
                 }
                 Err(e) => {
                     tracing::error!(error = ?e, "invalid upgrade header value");
@@ -553,7 +554,7 @@ where
         if let Some(host_value) = (self.host_header_getter)(&forward_url, req, depot) {
             match HeaderValue::from_str(&host_value) {
                 Ok(host_value) => {
-                    build = build.header(HOST, host_value);
+                    request_builder = request_builder.header(HOST, host_value);
                 }
                 Err(e) => {
                     tracing::error!(error = ?e, "invalid host header value");
@@ -566,7 +567,7 @@ where
             if let Some(client_ip) = req.remote_addr().ip() {
                 match HeaderValue::from_str(&client_ip.to_string()) {
                     Ok(xff) => {
-                        if let Some(headers) = build.headers_mut() {
+                        if let Some(headers) = request_builder.headers_mut() {
                             headers.insert(&xff_header_name, xff);
                         }
                     }
@@ -577,7 +578,7 @@ where
             }
         }
 
-        build.body(req.take_body()).map_err(Error::other)
+        request_builder.body(req.take_body()).map_err(Error::other)
     }
 }
 

--- a/crates/rate-limiter/src/fixed_guard.rs
+++ b/crates/rate-limiter/src/fixed_guard.rs
@@ -19,7 +19,8 @@ impl Default for FixedGuard {
 
 impl FixedGuard {
     /// Create a new `FixedGuard`.
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
             reset: OffsetDateTime::now_utc(),
             count: 0,

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -5,7 +5,7 @@ use super::{CelledQuota, RateGuard};
 /// Sliding window implement.
 #[derive(Clone, Debug)]
 pub struct SlidingGuard {
-    cell_inst: OffsetDateTime,
+    cell_start: OffsetDateTime,
     cell_span: Duration,
     counts: Vec<usize>,
     head: usize,
@@ -21,9 +21,10 @@ impl Default for SlidingGuard {
 
 impl SlidingGuard {
     /// Create a new `SlidingGuard`.
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
-            cell_inst: OffsetDateTime::now_utc(),
+            cell_start: OffsetDateTime::now_utc(),
             cell_span: Duration::default(),
             counts: vec![],
             head: 0,
@@ -47,7 +48,7 @@ impl SlidingGuard {
     }
 
     fn reset_window(&mut self, quota: &CelledQuota, now: OffsetDateTime) {
-        self.cell_inst = now;
+        self.cell_start = now;
         self.cell_span = quota.period / (quota.cells as u32);
         self.counts = vec![0; quota.cells];
         self.head = 0;
@@ -66,7 +67,7 @@ impl RateGuard for SlidingGuard {
             self.quota = Some(quota);
             return true;
         }
-        let mut delta = now - self.cell_inst;
+        let mut delta = now - self.cell_start;
         if delta > quota.period {
             self.reset_window(&quota, now);
             return true;
@@ -79,7 +80,7 @@ impl RateGuard for SlidingGuard {
             }
             self.counts[self.head] += 1;
             self.total += 1;
-            self.cell_inst = now;
+            self.cell_start = now;
         }
         self.total <= quota.limit
     }
@@ -89,7 +90,7 @@ impl RateGuard for SlidingGuard {
     }
 
     async fn reset(&self, quota: &Self::Quota) -> i64 {
-        (self.cell_inst + quota.period).unix_timestamp()
+        (self.cell_start + quota.period).unix_timestamp()
     }
 
     async fn limit(&self, quota: &Self::Quota) -> usize {
@@ -124,7 +125,7 @@ mod tests {
         let guard = SlidingGuard::new();
         let debug_str = format!("{guard:?}");
         assert!(debug_str.contains("SlidingGuard"));
-        assert!(debug_str.contains("cell_inst"));
+        assert!(debug_str.contains("cell_start"));
         assert!(debug_str.contains("counts"));
     }
 
@@ -304,7 +305,7 @@ mod tests {
         assert!(guard.verify(&quota).await);
 
         for request_index in 2..=12 {
-            guard.cell_inst = OffsetDateTime::now_utc() - Duration::seconds(3);
+            guard.cell_start = OffsetDateTime::now_utc() - Duration::seconds(3);
             assert!(
                 guard.verify(&quota).await,
                 "request {request_index} rejected, head={}, counts={:?}",

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -602,14 +602,14 @@ fn list_json(current: &CurrentInfo) -> String {
     json!(current).to_string()
 }
 fn list_xml(current: &CurrentInfo) -> String {
-    let mut ftxt = "<list>".to_owned();
+    let mut xml = "<list>".to_owned();
     if current.dirs.is_empty() && current.files.is_empty() {
-        ftxt.push_str("No files");
+        xml.push_str("No files");
     } else {
         let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
         for dir in &current.dirs {
             let _ = write!(
-                ftxt,
+                xml,
                 "<dir><name>{}</name><modified>{}</modified><link>{}</link></dir>",
                 xml_escape(&dir.name),
                 dir.modified.format(&format).expect("format time failed"),
@@ -618,7 +618,7 @@ fn list_xml(current: &CurrentInfo) -> String {
         }
         for file in &current.files {
             let _ = write!(
-                ftxt,
+                xml,
                 "<file><name>{}</name><modified>{}</modified><size>{}</size><link>{}</link></file>",
                 xml_escape(&file.name),
                 file.modified.format(&format).expect("format time failed"),
@@ -627,8 +627,8 @@ fn list_xml(current: &CurrentInfo) -> String {
             );
         }
     }
-    ftxt.push_str("</list>");
-    ftxt
+    xml.push_str("</list>");
+    xml
 }
 
 fn is_safe_relative_path(path: &str) -> bool {
@@ -686,7 +686,7 @@ fn list_html(current: &CurrentInfo) -> String {
             let _ = write!(out, r#"/<a href="{link}">{encoded}</a>"#);
         }
     }
-    let mut ftxt = format!(
+    let mut html = format!(
         r#"<!DOCTYPE html><html><head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width">
@@ -695,24 +695,24 @@ fn list_html(current: &CurrentInfo) -> String {
         encode_url_path(&current.path),
         HTML_STYLE,
     );
-    header_link(&mut ftxt, &current.path);
-    let _ = write!(ftxt, "</h3></header><hr/>");
+    header_link(&mut html, &current.path);
+    let _ = write!(html, "</h3></header><hr/>");
     if current.dirs.is_empty() && current.files.is_empty() {
-        let _ = write!(ftxt, "<p>No files</p>");
+        let _ = write!(html, "<p>No files</p>");
     } else {
-        let _ = write!(ftxt, "<table><tr><th>");
+        let _ = write!(html, "<table><tr><th>");
         if !(current.path.is_empty() || current.path == "/") {
-            let _ = write!(ftxt, "<a href=\"../\">[..]</a>");
+            let _ = write!(html, "<a href=\"../\">[..]</a>");
         }
         let _ = write!(
-            ftxt,
+            html,
             "</th><th>Name</th><th>Last modified</th><th>Size</th></tr>"
         );
         let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
         for dir in &current.dirs {
             let encoded = encode_url_path(&dir.name);
             let _ = write!(
-                ftxt,
+                html,
                 r#"<tr><td>{}</td><td><a href="./{}/">{}</a></td><td>{}</td><td></td></tr>"#,
                 DIR_ICON,
                 encoded,
@@ -723,7 +723,7 @@ fn list_html(current: &CurrentInfo) -> String {
         for file in &current.files {
             let encoded = encode_url_path(&file.name);
             let _ = write!(
-                ftxt,
+                html,
                 r#"<tr><td>{}</td><td><a href="./{}">{}</a></td><td>{}</td><td>{}</td></tr>"#,
                 FILE_ICON,
                 encoded,
@@ -732,13 +732,13 @@ fn list_html(current: &CurrentInfo) -> String {
                 human_size(file.size)
             );
         }
-        let _ = write!(ftxt, "</table>");
+        let _ = write!(html, "</table>");
     }
     let _ = write!(
-        ftxt,
+        html,
         r#"<hr/><footer><a href="https://salvo.rs" target="_blank">salvo</a></footer></body>"#
     );
-    ftxt
+    html
 }
 fn list_text(current: &CurrentInfo) -> String {
     use std::fmt::Write;

--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -396,8 +396,8 @@ impl DataStore for DiskStore {
         self.ensure_root().await?;
 
         let data_path = self.data_path(&file.id);
-        let mut file = file;
-        file.storage = Some(StoreInfo {
+        let mut upload = file;
+        upload.storage = Some(StoreInfo {
             type_name: "file".to_owned(),
             path: data_path.to_string_lossy().into_owned(),
             bucket: None,
@@ -410,14 +410,14 @@ impl DataStore for DiskStore {
             .await
             .map_err(|e| TusError::Internal(e.to_string()))?;
 
-        let mut meta = MetaUpload::from(file.clone());
+        let mut meta = MetaUpload::from(upload.clone());
         self.try_finalize_if_complete(&mut meta).await;
         if let Err(err) = self.write_meta_atomic(&meta).await {
             let _ = fs::remove_file(&data_path).await;
             return Err(err);
         }
 
-        Ok(file)
+        Ok(upload)
     }
 
     async fn remove(&self, id: &str) -> TusResult<()> {


### PR DESCRIPTION
## Summary
- rename short local variables and fields called out in `_improve.md`
- split single-line `#[must_use] pub fn` attributes into the standard two-line style
- fix small doc/comment typos and clarify proxy X-Forwarded-For wording

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p salvo_core -p salvo-serve-static -p salvo-jwt-auth -p salvo-rate-limiter -p salvo-csrf -p salvo_extra -p salvo-proxy -p salvo-tus --all-targets --all-features`
- `cargo clippy -p salvo_core -p salvo-serve-static -p salvo-jwt-auth -p salvo-rate-limiter -p salvo-csrf -p salvo_extra -p salvo-proxy -p salvo-tus --all-targets --all-features -- -D warnings`
- `cargo test -p salvo_core -p salvo-serve-static -p salvo-jwt-auth -p salvo-rate-limiter -p salvo-csrf -p salvo_extra -p salvo-proxy -p salvo-tus --all-features`