### PR TITLE
Code quality: cleaned up some RustRover warnings

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -130,7 +130,7 @@ where
 {
     type Key = K;
     async fn issue(&self, req: &mut Request, depot: &Depot) -> Option<Self::Key> {
-        (self)(req, depot)
+        self(req, depot)
     }
 }
 

--- a/crates/core/src/conn/quinn/client.rs
+++ b/crates/core/src/conn/quinn/client.rs
@@ -410,12 +410,12 @@ where
                 Err(e) => {
                     let connection_error = self.inner.shared.read("poll_close error read").error.as_ref().cloned();
 
-                    match connection_error {
-                        Some(e) if e.is_closed() => return Poll::Ready(Ok(())),
-                        Some(e) => return Poll::Ready(Err(e)),
+                    return match connection_error {
+                        Some(e) if e.is_closed() => Poll::Ready(Ok(())),
+                        Some(e) => Poll::Ready(Err(e)),
                         None => {
                             self.inner.shared.write("poll_close error").error = e.clone().into();
-                            return Poll::Ready(Err(e));
+                            Poll::Ready(Err(e))
                         }
                     }
                 }

--- a/crates/core/src/conn/quinn/listener.rs
+++ b/crates/core/src/conn/quinn/listener.rs
@@ -177,7 +177,7 @@ impl Acceptor for QuinnAcceptor {
         if let Some(new_conn) = self.endpoint.accept().await {
             let remote_addr = new_conn.remote_address();
             let local_addr = self.holdings[0].local_addr.clone();
-            match new_conn.await {
+            return match new_conn.await {
                 Ok(conn) => {
                     let fusewire = fuse_factory.map(|f| {
                         f.create(FuseInfo {
@@ -186,16 +186,16 @@ impl Acceptor for QuinnAcceptor {
                             local_addr: local_addr.clone(),
                         })
                     });
-                    return Ok(Accepted {
+                    Ok(Accepted {
                         coupler: QuinnCoupler,
                         stream: QuinnConnection::new(conn, fusewire.clone()),
                         fusewire,
                         local_addr: self.holdings[0].local_addr.clone(),
                         remote_addr: remote_addr.into(),
                         http_scheme: self.holdings[0].http_scheme.clone(),
-                    });
+                    })
                 }
-                Err(e) => return Err(IoError::other(e.to_string())),
+                Err(e) => Err(IoError::other(e.to_string())),
             }
         }
         Err(IoError::other("quinn accept error"))

--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -75,7 +75,7 @@ impl Depot {
     /// Get reference to the depot's inner map of string-keyed values.
     ///
     /// **Note**: this exposes only values inserted with an explicit string key; values stored by
-    /// type (via [`Depot::inject`]) are kept in separate storage and are not included.
+    /// type (via [`Depot::insert_typed`]) are kept in separate storage and are not included.
     #[inline]
     #[must_use]
     pub fn inner(&self) -> &HashMap<String, Box<dyn Any + Send + Sync>> {

--- a/crates/core/src/fuse/flex.rs
+++ b/crates/core/src/fuse/flex.rs
@@ -300,9 +300,7 @@ impl FlexFusewire {
         Self::lock_timeout_state(state).armed
     }
 
-    fn lock_timeout_state(
-        state: &TimeoutWatchStateRef,
-    ) -> MutexGuard<'_, TimeoutWatchState> {
+    fn lock_timeout_state(state: &TimeoutWatchStateRef) -> MutexGuard<'_, TimeoutWatchState> {
         state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/core/src/fuse/flex.rs
+++ b/crates/core/src/fuse/flex.rs
@@ -300,9 +300,9 @@ impl FlexFusewire {
         Self::lock_timeout_state(state).armed
     }
 
-    fn lock_timeout_state<'a>(
-        state: &'a TimeoutWatchStateRef,
-    ) -> MutexGuard<'a, TimeoutWatchState> {
+    fn lock_timeout_state(
+        state: &TimeoutWatchStateRef,
+    ) -> MutexGuard<'_, TimeoutWatchState> {
         state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -312,7 +312,7 @@ where
     F: Fn(&mut Request, &Depot) -> bool + Send + Sync + 'static,
 {
     fn skipped(&self, req: &mut Request, depot: &Depot) -> bool {
-        (self)(req, depot)
+        self(req, depot)
     }
 }
 

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -92,9 +92,9 @@ impl Handler for SecureMaxSize {
 ///   internally. Subsequent calls return the cached bytes.
 /// - [`form_data()`](Request::form_data) parses form data and caches the result. If the body has
 ///   already been consumed by `payload()`, it will use the cached bytes to parse the form.
-/// - [`replace_body()`](Request::replace_body) preserves those cached values for compatibility.
-///   Use [`replace_body_and_clear_cache()`](Request::replace_body_and_clear_cache) when replacing
-///   the body should also invalidate cached payload and form data.
+/// - [`replace_body()`](Request::replace_body) preserves those cached values for compatibility. Use
+///   [`replace_body_and_clear_cache()`](Request::replace_body_and_clear_cache) when replacing the
+///   body should also invalidate cached payload and form data.
 ///
 /// # Size Limits
 ///

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -235,13 +235,13 @@ mod tests {
 
     #[test]
     fn test_methods() {
-        assert!(get() == MethodFilter(Method::GET));
-        assert!(head() == MethodFilter(Method::HEAD));
-        assert!(options() == MethodFilter(Method::OPTIONS));
-        assert!(post() == MethodFilter(Method::POST));
-        assert!(patch() == MethodFilter(Method::PATCH));
-        assert!(put() == MethodFilter(Method::PUT));
-        assert!(delete() == MethodFilter(Method::DELETE));
+        assert_eq!(get(), MethodFilter(Method::GET));
+        assert_eq!(head(), MethodFilter(Method::HEAD));
+        assert_eq!(options(), MethodFilter(Method::OPTIONS));
+        assert_eq!(post(), MethodFilter(Method::POST));
+        assert_eq!(patch(), MethodFilter(Method::PATCH));
+        assert_eq!(put(), MethodFilter(Method::PUT));
+        assert_eq!(delete(), MethodFilter(Method::DELETE));
     }
 
     #[tokio::test]

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -385,7 +385,7 @@ impl<'de> RequestDeserializer<'de> {
                     let parser = self.real_parser(source);
                     match parser {
                         SourceParser::Json => {
-                            if let Some(payload) = &self.payload {
+                            return if let Some(payload) = &self.payload {
                                 match payload {
                                     Payload::FormData(form_data) => {
                                         let mut value = form_data.fields.get(field_name);
@@ -402,7 +402,7 @@ impl<'de> RequestDeserializer<'de> {
                                             self.field_source = Some(source);
                                             return true;
                                         }
-                                        return false;
+                                        false
                                     }
                                     Payload::JsonMap(map) => {
                                         let mut value = map.get(field_name);
@@ -419,16 +419,16 @@ impl<'de> RequestDeserializer<'de> {
                                             self.field_source = Some(source);
                                             return true;
                                         }
-                                        return false;
+                                        false
                                     }
                                     Payload::JsonStr(value) => {
                                         self.field_str_value = Some(Cow::Borrowed(*value));
                                         self.field_source = Some(source);
-                                        return true;
+                                        true
                                     }
                                 }
                             } else {
-                                return false;
+                                false
                             }
                         }
                         SourceParser::MultiMap => {

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -429,7 +429,7 @@ impl<'de> RequestDeserializer<'de> {
                                 }
                             } else {
                                 false
-                            }
+                            };
                         }
                         SourceParser::MultiMap => {
                             if let Some(Payload::FormData(form_data)) = self.payload {

--- a/crates/core/src/test/request/builder.rs
+++ b/crates/core/src/test/request/builder.rs
@@ -238,7 +238,7 @@ impl RequestBuilder {
             body,
         } = self;
         let mut req = hyper::Request::builder().method(method).uri(url.to_string());
-        (*req.headers_mut().expect("`headers_mut` returns `None`")) = headers;
+        *req.headers_mut().expect("`headers_mut` returns `None`") = headers;
         req.body(body).expect("invalid request body")
     }
 

--- a/crates/extra/src/basic_auth.rs
+++ b/crates/extra/src/basic_auth.rs
@@ -152,8 +152,8 @@ pub fn ask_credentials(res: &mut Response, realm: impl AsRef<str>) {
     // that case so the request resolves with a 401 instead of panicking the
     // request task.
     let challenge = format!("Basic realm={:?}", realm.as_ref());
-    let value = HeaderValue::try_from(challenge)
-        .unwrap_or_else(|_| HeaderValue::from_static("Basic"));
+    let value =
+        HeaderValue::try_from(challenge).unwrap_or_else(|_| HeaderValue::from_static("Basic"));
     res.headers_mut().insert("WWW-Authenticate", value);
     res.status_code(StatusCode::UNAUTHORIZED);
 }
@@ -185,11 +185,11 @@ pub fn parse_credentials(
             .map_err(Error::other)?;
         let auth = String::from_utf8(auth_bytes)
             .map_err(|_| Error::other("credentials contain invalid UTF-8"))?;
-        if let Some((username, password)) = auth.split_once(':') {
-            return Ok((username.to_owned(), password.to_owned()));
+        return if let Some((username, password)) = auth.split_once(':') {
+            Ok((username.to_owned(), password.to_owned()))
         } else {
-            return Err(Error::other("`authorization` has bad format"));
-        }
+            Err(Error::other("`authorization` has bad format"))
+        };
     }
     Err(Error::other("parse http header failed"))
 }
@@ -307,10 +307,8 @@ mod tests {
     #[test]
     fn test_parse_credentials_rejects_prefixed_scheme() {
         let mut req = Request::new();
-        req.headers_mut().insert(
-            AUTHORIZATION,
-            "BasicX cm9vdDpwd2Q=".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert(AUTHORIZATION, "BasicX cm9vdDpwd2Q=".parse().unwrap());
 
         assert!(parse_credentials(&req, &[AUTHORIZATION]).is_err());
     }

--- a/crates/oapi-macros/src/component.rs
+++ b/crates/oapi-macros/src/component.rs
@@ -491,7 +491,7 @@ impl ComponentSchema {
                     }
                 });
 
-                let format: SchemaFormat = (type_path).into();
+                let format: SchemaFormat = type_path.into();
                 if format.is_known_format() {
                     let format = format.try_to_token_stream()?;
                     tokens.extend(quote! {

--- a/crates/oapi-macros/src/operation.rs
+++ b/crates/oapi-macros/src/operation.rs
@@ -323,7 +323,7 @@ impl Parse for PathType<'_> {
         // Check for `ref(...)` syntax. The `ref` keyword may appear as either
         // a Rust keyword token (`Token![ref]`) or an identifier depending on
         // the tokenization context (e.g., inside proc_macro attributes).
-        let is_ref = if (fork.parse::<Option<Token![ref]>>()?).is_some()
+        let is_ref = if fork.parse::<Option<Token![ref]>>()?.is_some()
             || fork
                 .parse::<Option<Ident>>()?
                 .is_some_and(|ident| ident == "ref")

--- a/crates/oapi-macros/src/operation/request_body.rs
+++ b/crates/oapi-macros/src/operation/request_body.rs
@@ -31,8 +31,9 @@ use crate::{AnyValue, Array, DiagResult, Required, TryToTokens, parse_utils};
 /// #[salvo_oapi::endpoint(
 ///    request_body = (content = String, description = "foobar", content_type = "text/xml"),
 /// )]
+/// ```
 ///
-/// It is also possible to provide the request body type simply by providing only the content object type.
+/// The request body type can also be provided directly.
 /// ```text
 /// #[salvo_oapi::endpoint(
 ///    request_body = Foo,

--- a/crates/oapi-macros/src/schema/enum_schemas.rs
+++ b/crates/oapi-macros/src/schema/enum_schemas.rs
@@ -435,7 +435,7 @@ impl TryToTokens for SimpleEnum<'_> {
     }
 }
 
-fn regular_enum_to_tokens<T: self::enum_variant::Variant>(
+fn regular_enum_to_tokens<T: enum_variant::Variant>(
     tokens: &mut TokenStream,
     container_rules: Option<&SerdeContainer>,
     enum_variant_features: &Vec<Feature>,
@@ -528,33 +528,31 @@ impl ComplexEnum<'_> {
 
                 let example = pop_feature!(named_struct_features => Feature::Example(_));
 
-                Ok(Some(self::enum_variant::Variant::to_tokens(
-                    &ObjectVariant {
-                        name: variant_name.unwrap_or(Cow::Borrowed(name)),
-                        title: title_features
-                            .first()
-                            .map(TryToTokens::try_to_token_stream)
-                            .transpose()?,
-                        example: example
-                            .as_ref()
-                            .map(TryToTokens::try_to_token_stream)
-                            .transpose()?,
-                        item: NamedStructSchema {
-                            struct_name: Cow::Borrowed(&*self.enum_name),
-                            attributes: &variant.attrs,
-                            description: None,
-                            rename_all: named_struct_features.pop_rename_all_feature(),
-                            features: Some(named_struct_features),
-                            fields: &named_fields.named,
-                            generics: None,
-                            name: None,
-                            aliases: None,
-                            inline: None,
-                            compose_context: None,
-                        }
-                        .try_to_token_stream()?,
-                    },
-                )))
+                Ok(Some(enum_variant::Variant::to_tokens(&ObjectVariant {
+                    name: variant_name.unwrap_or(Cow::Borrowed(name)),
+                    title: title_features
+                        .first()
+                        .map(TryToTokens::try_to_token_stream)
+                        .transpose()?,
+                    example: example
+                        .as_ref()
+                        .map(TryToTokens::try_to_token_stream)
+                        .transpose()?,
+                    item: NamedStructSchema {
+                        struct_name: Cow::Borrowed(&*self.enum_name),
+                        attributes: &variant.attrs,
+                        description: None,
+                        rename_all: named_struct_features.pop_rename_all_feature(),
+                        features: Some(named_struct_features),
+                        fields: &named_fields.named,
+                        generics: None,
+                        name: None,
+                        aliases: None,
+                        inline: None,
+                        compose_context: None,
+                    }
+                    .try_to_token_stream()?,
+                })))
             }
             Fields::Unnamed(unnamed_fields) => {
                 let (title_features, mut unnamed_struct_features) = variant
@@ -578,31 +576,29 @@ impl ComplexEnum<'_> {
 
                 let example = pop_feature!(unnamed_struct_features => Feature::Example(_));
 
-                Ok(Some(self::enum_variant::Variant::to_tokens(
-                    &ObjectVariant {
-                        name: variant_name.unwrap_or(Cow::Borrowed(name)),
-                        title: title_features
-                            .first()
-                            .map(TryToTokens::try_to_token_stream)
-                            .transpose()?,
-                        example: example
-                            .as_ref()
-                            .map(TryToTokens::try_to_token_stream)
-                            .transpose()?,
-                        item: UnnamedStructSchema {
-                            struct_name: Cow::Borrowed(&*self.enum_name),
-                            attributes: &variant.attrs,
-                            description: None,
-                            features: Some(unnamed_struct_features),
-                            fields: &unnamed_fields.unnamed,
-                            name: None,
-                            aliases: None,
-                            inline: None,
-                            compose_context: None,
-                        }
-                        .try_to_token_stream()?,
-                    },
-                )))
+                Ok(Some(enum_variant::Variant::to_tokens(&ObjectVariant {
+                    name: variant_name.unwrap_or(Cow::Borrowed(name)),
+                    title: title_features
+                        .first()
+                        .map(TryToTokens::try_to_token_stream)
+                        .transpose()?,
+                    example: example
+                        .as_ref()
+                        .map(TryToTokens::try_to_token_stream)
+                        .transpose()?,
+                    item: UnnamedStructSchema {
+                        struct_name: Cow::Borrowed(&*self.enum_name),
+                        attributes: &variant.attrs,
+                        description: None,
+                        features: Some(unnamed_struct_features),
+                        fields: &unnamed_fields.unnamed,
+                        name: None,
+                        aliases: None,
+                        inline: None,
+                        compose_context: None,
+                    }
+                    .try_to_token_stream()?,
+                })))
             }
             Fields::Unit => {
                 let mut unit_features =

--- a/crates/oapi-macros/src/schema/enum_schemas.rs
+++ b/crates/oapi-macros/src/schema/enum_schemas.rs
@@ -7,9 +7,8 @@ use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{Attribute, Fields, Generics, Token, Variant};
 
-use super::enum_variant::{
-    self, AdjacentlyTaggedEnum, CustomEnum, Enum, ObjectVariant, SimpleEnumVariant, TaggedEnum,
-    UntaggedEnum,
+use super::enum_variant::{AdjacentlyTaggedEnum, CustomEnum, Enum, ObjectVariant, SimpleEnumVariant, TaggedEnum,
+                          UntaggedEnum,
 };
 use super::feature::{
     self, ComplexEnumFeatures, EnumFeatures, EnumNamedFieldVariantFeatures,

--- a/crates/oapi-macros/src/schema/enum_schemas.rs
+++ b/crates/oapi-macros/src/schema/enum_schemas.rs
@@ -7,8 +7,9 @@ use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{Attribute, Fields, Generics, Token, Variant};
 
-use super::enum_variant::{AdjacentlyTaggedEnum, CustomEnum, Enum, ObjectVariant, SimpleEnumVariant, TaggedEnum,
-                          UntaggedEnum,
+use super::enum_variant::{
+    self, AdjacentlyTaggedEnum, CustomEnum, Enum, ObjectVariant, SimpleEnumVariant, TaggedEnum,
+    UntaggedEnum,
 };
 use super::feature::{
     self, ComplexEnumFeatures, EnumFeatures, EnumNamedFieldVariantFeatures,

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -591,7 +591,7 @@ impl OpenApi {
                 let Endpoint {
                     mut operation,
                     mut components,
-                } = (creator)();
+                } = creator();
                 operation.tags.extend(node.metadata.tags.iter().cloned());
                 operation
                     .securities

--- a/crates/oapi/src/openapi/example.rs
+++ b/crates/oapi/src/openapi/example.rs
@@ -105,6 +105,9 @@ mod tests {
 
         let example = example.value(serde_json::Value::String("value".to_owned()));
         assert!(example.value.is_some());
-        assert_eq!(example.value.unwrap(), serde_json::Value::String("value".to_owned()));
+        assert_eq!(
+            example.value.unwrap(),
+            serde_json::Value::String("value".to_owned())
+        );
     }
 }

--- a/crates/oapi/src/openapi/example.rs
+++ b/crates/oapi/src/openapi/example.rs
@@ -95,16 +95,16 @@ mod tests {
         assert!(example.external_value.is_empty());
 
         let example = example.summary("summary");
-        assert!(example.summary == "summary");
+        assert_eq!(example.summary, "summary");
 
         let example = example.description("description");
-        assert!(example.description == "description");
+        assert_eq!(example.description, "description");
 
         let example = example.external_value("external_value");
-        assert!(example.external_value == "external_value");
+        assert_eq!(example.external_value, "external_value");
 
         let example = example.value(serde_json::Value::String("value".to_owned()));
         assert!(example.value.is_some());
-        assert!(example.value.unwrap() == serde_json::Value::String("value".to_owned()));
+        assert_eq!(example.value.unwrap(), serde_json::Value::String("value".to_owned()));
     }
 }

--- a/crates/oapi/src/openapi/server.rs
+++ b/crates/oapi/src/openapi/server.rs
@@ -450,7 +450,7 @@ mod tests {
         let servers = Servers::new();
         let server = Server::new("/api/v1").description("api v1");
         let servers = servers.server(server);
-        assert!(servers.len() == 1);
+        assert_eq!(servers.len(), 1);
     }
 
     #[test]
@@ -458,7 +458,7 @@ mod tests {
         let mut servers = Servers::new();
         let server = Server::new("/api/v1").description("api v1");
         servers.insert(server);
-        assert!(servers.len() == 1);
+        assert_eq!(servers.len(), 1);
     }
 
     #[test]
@@ -474,7 +474,7 @@ mod tests {
             .add_variable("key2", ServerVariable::new());
         servers.insert(server2);
 
-        assert!(servers.len() == 1);
+        assert_eq!(servers.len(), 1);
         assert_json_eq!(
             servers,
             json!([
@@ -527,8 +527,8 @@ mod tests {
         let mut servers = Servers::new();
         let server = Server::new("/api/v1").description("api v1");
         servers.insert(server);
-        assert!(servers.len() == 1);
-        assert!(servers.deref().len() == 1);
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers.deref().len(), 1);
 
         servers.deref_mut().clear();
         assert!(servers.is_empty());
@@ -570,11 +570,11 @@ mod tests {
         let mut server_variables = ServerVariables::new();
         let variable = ServerVariable::new();
         server_variables.insert("key", variable);
-        assert!(server_variables.len() == 1);
+        assert_eq!(server_variables.len(), 1);
 
         let new_variable = ServerVariable::new().description("description");
         server_variables.insert("key", new_variable);
-        assert!(server_variables.len() == 1);
+        assert_eq!(server_variables.len(), 1);
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
         other_server_variables.insert("key", variable);
 
         server_variables.append(&mut other_server_variables);
-        assert!(server_variables.len() == 1);
+        assert_eq!(server_variables.len(), 1);
     }
 
     #[test]
@@ -598,7 +598,7 @@ mod tests {
         other_server_variables.insert("key", variable);
 
         server_variables.extend(other_server_variables.0);
-        assert!(server_variables.len() == 1);
+        assert_eq!(server_variables.len(), 1);
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod tests {
         server_variables.insert("key", variable);
 
         assert!(!server_variables.is_empty());
-        assert!(server_variables.deref().len() == 1);
+        assert_eq!(server_variables.deref().len(), 1);
 
         server_variables.deref_mut().clear();
         assert!(server_variables.is_empty());

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -119,6 +119,6 @@ mod tests {
             .take_string()
             .await
             .unwrap();
-        assert!(content == "Hello");
+        assert_eq!(content, "Hello");
     }
 }

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -149,7 +149,7 @@ where
 {
     type Key = K;
     async fn issue(&self, req: &mut Request, depot: &Depot) -> Option<Self::Key> {
-        (self)(req, depot)
+        self(req, depot)
     }
 }
 

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -136,21 +136,21 @@ mod tests {
             "http://127.0.0.1:5801/dir1/dir2/test3.txt",
         )
         .await;
-        assert!(content == "dir2 test3");
+        assert_eq!(content, "dir2 test3");
         let content = access(
             &service,
             "text/plain",
             "http://127.0.0.1:5801/dir1/../dir1/test3.txt",
         )
         .await;
-        assert!(content == "copy3");
+        assert_eq!(content, "copy3");
         let content = access(
             &service,
             "text/plain",
             "http://127.0.0.1:5801/dir1\\..\\dir1\\test3.txt",
         )
         .await;
-        assert!(content == "copy3");
+        assert_eq!(content, "copy3");
     }
 
     #[tokio::test]

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -822,7 +822,7 @@ mod tests {
 
         assert!(tus.options.on_incoming_request.is_some());
         let req = Request::default();
-        (tus.options.on_incoming_request.unwrap())(&req, "test-id".to_owned()).await;
+        tus.options.on_incoming_request.unwrap()(&req, "test-id".to_owned()).await;
         assert!(called.load(Ordering::SeqCst));
     }
 

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -270,7 +270,7 @@ impl TusOptions {
             Self::extract_host_and_proto(req.headers(), self.respect_forwarded_headers);
 
         if let Some(callback) = &self.generate_url_function {
-            match callback(
+            return match callback(
                 req,
                 GenerateUrlCtx {
                     proto,
@@ -279,8 +279,8 @@ impl TusOptions {
                     id: upload_id,
                 },
             ) {
-                Ok(url) => return Ok(url),
-                Err(e) => return Err(e),
+                Ok(url) => Ok(url),
+                Err(e) => Err(e),
             };
         }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,6 @@ Salvo is a powerful web framework that can make your work easier.
 homepage = "https://salvo.rs"
 repository = "https://github.com/salvo-rs/salvo"
 documentation = "https://docs.rs/salvo/"
-readme = "./README.md"
 keywords = ["http", "async", "web", "framework", "server"]
 license = "Apache-2.0"
 categories = [

--- a/examples/custom-error-page/src/main.rs
+++ b/examples/custom-error-page/src/main.rs
@@ -38,7 +38,7 @@ fn create_service() -> Service {
 
 // Custom handler for 404 Not Found errors
 #[handler]
-async fn handle404(&self, _req: &Request, _depot: &Depot, res: &mut Response, ctrl: &mut FlowCtrl) {
+async fn handle404(_req: &Request, _depot: &Depot, res: &mut Response, ctrl: &mut FlowCtrl) {
     // Check if the error is a 404 Not Found
     if StatusCode::NOT_FOUND == res.status_code.unwrap_or(StatusCode::NOT_FOUND) {
         // Return custom error page

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -49,7 +49,7 @@ async fn listen_shutdown_signal(handle: ServerHandle) {
     tokio::select! {
         _ = ctrl_c => println!("ctrl_c signal received"),
         _ = terminate => println!("terminate signal received"),
-    };
+    }
 
     // Graceful Shutdown Server
     handle.stop_graceful(None);


### PR DESCRIPTION
Cleaned up RustRover warnings:
- Update doc that includes a link to deprecated code
- Remove useless parentness
- Remove useless imports
- Lift returns
- Elide explicit lifetimes
- Use `assert_eq!` instead of `assert!(a == b)`
