### PR TITLE
Clean up P3 naming and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ cargo test --all --all-features --no-fail-fast
 cargo test --workspace --doc
 ```
 
+Formatting uses nightly because `rustfmt.toml` contains nightly-only options.
+
 Nightly-only checks used in CI:
 
 ```bash

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -176,7 +176,7 @@ impl Debug for Catcher {
     }
 }
 impl Catcher {
-    /// Create new `Catcher`.
+    /// Creates a new `Catcher`.
     pub fn new<H: Handler>(goal: H) -> Self {
         Self {
             goal: Arc::new(goal),
@@ -238,12 +238,12 @@ pub struct DefaultGoal {
     footer: Option<Cow<'static, str>>,
 }
 impl DefaultGoal {
-    /// Create new `DefaultGoal`.
+    /// Creates a new `DefaultGoal`.
     #[must_use]
     pub fn new() -> Self {
         Self { footer: None }
     }
-    /// Create new `DefaultGoal` with custom footer.
+    /// Creates a new `DefaultGoal` with a custom footer.
     #[inline]
     #[must_use]
     pub fn with_footer(footer: impl Into<Cow<'static, str>>) -> Self {

--- a/crates/core/src/conn/native_tls/config.rs
+++ b/crates/core/src/conn/native_tls/config.rs
@@ -35,7 +35,7 @@ impl Default for NativeTlsConfig {
     }
 }
 impl NativeTlsConfig {
-    /// Create new `NativeTlsConfig`
+    /// Creates a new `NativeTlsConfig`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/crates/core/src/conn/openssl/config.rs
+++ b/crates/core/src/conn/openssl/config.rs
@@ -123,7 +123,7 @@ impl Debug for OpensslConfig {
 }
 
 impl OpensslConfig {
-    /// Create new `OpensslConfig`
+    /// Creates a new `OpensslConfig`.
     #[inline]
     #[must_use]
     pub fn new(keycert: Keycert) -> Self {

--- a/crates/core/src/conn/openssl/listener.rs
+++ b/crates/core/src/conn/openssl/listener.rs
@@ -40,7 +40,7 @@ where
     T: Listener + Send,
     E: StdError + Send,
 {
-    /// Create new OpensslListener with config stream.
+    /// Creates a new `OpensslListener` with a config stream.
     #[inline]
     pub fn new(config_stream: S, inner: T) -> Self {
         Self {
@@ -134,7 +134,7 @@ where
     T: Acceptor + Send + 'static,
     T::Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    /// Create new OpensslAcceptor.
+    /// Creates a new `OpensslAcceptor`.
     pub fn new(
         inner: T,
         current_acceptor: Arc<ArcSwapOption<SslAcceptor>>,
@@ -234,4 +234,3 @@ where
         })
     }
 }
-

--- a/crates/core/src/conn/rustls/config.rs
+++ b/crates/core/src/conn/rustls/config.rs
@@ -157,7 +157,7 @@ pub struct RustlsConfig {
 }
 
 impl RustlsConfig {
-    /// Create new `RustlsConfig`
+    /// Creates a new `RustlsConfig`.
     #[inline]
     #[must_use]
     pub fn new(fallback: impl Into<Option<Keycert>>) -> Self {

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -469,7 +469,7 @@ fn escape_quoted_filename(filename: &str) -> String {
     escaped
 }
 impl NamedFile {
-    /// Create new [`NamedFileBuilder`].
+    /// Creates a new [`NamedFileBuilder`].
     #[inline]
     pub fn builder(path: impl Into<PathBuf>) -> NamedFileBuilder {
         NamedFileBuilder {

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -342,7 +342,7 @@ impl Debug for HoopedHandler {
 }
 
 impl HoopedHandler {
-    /// Create new `HoopedHandler`.
+    /// Creates a new `HoopedHandler`.
     pub fn new<H: Handler>(inner: H) -> Self {
         Self {
             inner: Arc::new(inner),

--- a/crates/core/src/http/body/req.rs
+++ b/crates/core/src/http/body/req.rs
@@ -48,22 +48,22 @@ impl ReqBody {
             }
         }
     }
-    /// Check is that body is not set.
+    /// Returns true if the body is not set.
     #[inline]
     pub fn is_none(&self) -> bool {
         matches!(*self, Self::None)
     }
-    /// Check is that body is once.
+    /// Returns true if the body contains one byte buffer.
     #[inline]
     pub fn is_once(&self) -> bool {
         matches!(*self, Self::Once(_))
     }
-    /// Check is that body is hyper default body type.
+    /// Returns true if the body is Hyper's default incoming body type.
     #[inline]
     pub fn is_hyper(&self) -> bool {
         matches!(*self, Self::Hyper { .. })
     }
-    /// Check is that body is stream.
+    /// Returns true if the body is boxed.
     #[inline]
     pub fn is_boxed(&self) -> bool {
         matches!(*self, Self::Boxed { .. })
@@ -256,7 +256,7 @@ cfg_feature! {
             S: RecvStream + Send + Unpin + 'static,
             B: Buf + Send + Unpin + 'static,
         {
-            /// Create new `H3ReqBody` instance.
+            /// Creates a new `H3ReqBody` instance.
             pub fn new(inner: salvo_http3::server::RequestStream<S, B>) -> Self {
                 Self { inner }
             }

--- a/crates/core/src/http/body/res.rs
+++ b/crates/core/src/http/body/res.rs
@@ -37,42 +37,42 @@ pub enum ResBody {
     Error(StatusError),
 }
 impl ResBody {
-    /// Check is that body is not set.
+    /// Returns true if the body is not set.
     #[inline]
     pub fn is_none(&self) -> bool {
         matches!(*self, Self::None)
     }
-    /// Check is that body is once.
+    /// Returns true if the body contains one byte buffer.
     #[inline]
     pub fn is_once(&self) -> bool {
         matches!(*self, Self::Once(_))
     }
-    /// Check is that body is chunks.
+    /// Returns true if the body contains queued chunks.
     #[inline]
     pub fn is_chunks(&self) -> bool {
         matches!(*self, Self::Chunks(_))
     }
-    /// Check is that body is hyper default body type.
+    /// Returns true if the body is Hyper's default incoming body type.
     #[inline]
     pub fn is_hyper(&self) -> bool {
         matches!(*self, Self::Hyper(_))
     }
-    /// Check is that body is stream.
+    /// Returns true if the body is boxed.
     #[inline]
     pub fn is_boxed(&self) -> bool {
         matches!(*self, Self::Boxed(_))
     }
-    /// Check is that body is stream.
+    /// Returns true if the body is a stream.
     #[inline]
     pub fn is_stream(&self) -> bool {
         matches!(*self, Self::Stream(_))
     }
-    /// Check is that body is stream.
+    /// Returns true if the body is a channel.
     #[inline]
     pub fn is_channel(&self) -> bool {
         matches!(*self, Self::Channel { .. })
     }
-    /// Check is that body is error will be process in catcher.
+    /// Returns true if the body is an error to process in a catcher.
     pub fn is_error(&self) -> bool {
         matches!(*self, Self::Error(_))
     }

--- a/crates/core/src/http/errors/status_error.rs
+++ b/crates/core/src/http/errors/status_error.rs
@@ -245,7 +245,7 @@ impl Display for StatusError {
 }
 
 impl StatusError {
-    /// Create new `StatusError` with code. If code is not error, it will be `None`.
+    /// Creates a new `StatusError` with a code. If the code is not an error, it will be `None`.
     #[must_use]
     pub fn from_code(code: StatusCode) -> Option<Self> {
         match code {

--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -31,7 +31,7 @@ pub struct FormData {
 }
 
 impl FormData {
-    /// Create new `FormData`.
+    /// Creates a new `FormData`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -166,7 +166,7 @@ impl From<CombWisp> for WispKind {
 #[derive(Debug)]
 pub struct RegexWispBuilder(Regex);
 impl RegexWispBuilder {
-    /// Create new `RegexWispBuilder`.
+    /// Creates a new `RegexWispBuilder`.
     #[inline]
     #[must_use]
     pub fn new(checker: Regex) -> Self {
@@ -186,7 +186,7 @@ impl WispBuilder for RegexWispBuilder {
 /// A [`WispBuilder`] that builds a [`CharsWisp`] from a per-character checker.
 pub struct CharsWispBuilder(Arc<dyn Fn(char) -> bool + Send + Sync + 'static>);
 impl CharsWispBuilder {
-    /// Create new `CharsWispBuilder`.
+    /// Creates a new `CharsWispBuilder`.
     #[inline]
     pub fn new<C>(checker: C) -> Self
     where
@@ -342,7 +342,7 @@ pub struct CombWisp {
     wild_start: Option<String>,
 }
 impl CombWisp {
-    /// Create new `CombWisp`.
+    /// Creates a new `CombWisp`.
     ///
     /// # Panics
     /// If it contains an unsupported `WispKind`.
@@ -1106,7 +1106,7 @@ impl PathFilter {
         }
     }
 
-    /// Create new `PathFilter`.
+    /// Creates a new `PathFilter`.
     ///
     /// Invalid path patterns are logged and converted into a filter that never matches.
     /// Use [`PathFilter::try_new`] to handle malformed patterns explicitly.

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -59,7 +59,7 @@ impl Debug for FlowCtrl {
 }
 
 impl FlowCtrl {
-    /// Create new `FlowCtrl`.
+    /// Creates a new `FlowCtrl`.
     #[inline]
     #[must_use]
     pub fn new(handlers: Vec<Arc<dyn Handler>>) -> Self {

--- a/crates/core/src/routing/path_params.rs
+++ b/crates/core/src/routing/path_params.rs
@@ -18,7 +18,7 @@ impl Deref for PathParams {
     }
 }
 impl PathParams {
-    /// Create new `PathParams`.
+    /// Creates a new `PathParams`.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -133,7 +133,7 @@ impl<A> Debug for Server<A> {
 }
 
 impl<A: Acceptor + Send> Server<A> {
-    /// Create new `Server` with [`Acceptor`].
+    /// Creates a new `Server` with an [`Acceptor`].
     ///
     /// # Example
     ///
@@ -150,7 +150,7 @@ impl<A: Acceptor + Send> Server<A> {
         Self::with_http_builder(acceptor, HttpBuilder::new())
     }
 
-    /// Create new `Server` with [`Acceptor`] and [`HttpBuilder`].
+    /// Creates a new `Server` with an [`Acceptor`] and [`HttpBuilder`].
     pub fn with_http_builder(acceptor: A, builder: HttpBuilder) -> Self {
         #[cfg(feature = "server-handle")]
         let (tx_cmd, rx_cmd) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/cors/src/lib.rs
+++ b/crates/cors/src/lib.rs
@@ -122,7 +122,7 @@ impl Default for Cors {
 }
 
 impl Cors {
-    /// Create new `Cors`.
+    /// Creates a new `Cors`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/crates/csrf/src/finder.rs
+++ b/crates/csrf/src/finder.rs
@@ -16,7 +16,7 @@ pub struct HeaderFinder {
     header_name: String,
 }
 impl HeaderFinder {
-    /// Create new `HeaderFinder`, you can use value like `x-csrf-token`.
+    /// Creates a new `HeaderFinder`; you can use a value like `x-csrf-token`.
     #[inline]
     pub fn new(header_name: impl Into<String>) -> Self {
         Self {
@@ -38,7 +38,7 @@ pub struct FormFinder {
     field_name: String,
 }
 impl FormFinder {
-    /// Create new `FormFinder`.
+    /// Creates a new `FormFinder`.
     #[inline]
     pub fn new(field_name: impl Into<String>) -> Self {
         Self {
@@ -60,7 +60,7 @@ pub struct JsonFinder {
     field_name: String,
 }
 impl JsonFinder {
-    /// Create new `FormFinder`.
+    /// Creates a new `FormFinder`.
     #[inline]
     pub fn new(field_name: impl Into<String>) -> Self {
         Self {

--- a/crates/extra/src/basic_auth.rs
+++ b/crates/extra/src/basic_auth.rs
@@ -86,7 +86,7 @@ impl<V> BasicAuth<V>
 where
     V: BasicAuthValidator,
 {
-    /// Create new `BasicAuthValidator`.
+    /// Creates a new `BasicAuthValidator`.
     #[inline]
     pub fn new(validator: V) -> Self {
         Self {
@@ -124,7 +124,7 @@ where
         &self.header_names
     }
 
-    /// Get mutable reference to the header names.
+    /// Returns a mutable reference to the header names.
     #[inline]
     pub fn header_names_mut(&mut self) -> &mut Vec<HeaderName> {
         &mut self.header_names

--- a/crates/extra/src/catch_panic.rs
+++ b/crates/extra/src/catch_panic.rs
@@ -39,7 +39,7 @@ use salvo_core::{async_trait, Depot, FlowCtrl, Error, Handler};
 #[derive(Default, Debug)]
 pub struct CatchPanic {}
 impl CatchPanic {
-    /// Create new `CatchPanic` middleware.
+    /// Creates a new `CatchPanic` middleware.
     #[inline]
     #[must_use] pub fn new() -> Self {
         Self {}
@@ -89,4 +89,3 @@ mod tests {
         assert!(logs_contain("panic occurred"));
     }
 }
-

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -74,7 +74,7 @@ impl Debug for ForceHttps {
 }
 
 impl ForceHttps {
-    /// Create new `ForceHttps` middleware.
+    /// Creates a new `ForceHttps` middleware.
     #[must_use]
     pub fn new() -> Self {
         Default::default()

--- a/crates/extra/src/logging.rs
+++ b/crates/extra/src/logging.rs
@@ -40,7 +40,7 @@ pub struct Logger {
     pub log_status_error: bool,
 }
 impl Logger {
-    /// Create new `Logger` middleware.
+    /// Creates a new `Logger` middleware.
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/crates/extra/src/sse.rs
+++ b/crates/extra/src/sse.rs
@@ -225,7 +225,7 @@ where
     S: TryStream<Ok = SseEvent> + Send + 'static,
     S::Error: StdError + Send + Sync + 'static,
 {
-    /// Create new `SseKeepAlive`.
+    /// Creates a new `SseKeepAlive`.
     #[inline]
     #[must_use]
     pub fn new(event_stream: S) -> Self {

--- a/crates/extra/src/trailing_slash.rs
+++ b/crates/extra/src/trailing_slash.rs
@@ -100,7 +100,7 @@ impl Debug for TrailingSlash {
 }
 
 impl TrailingSlash {
-    /// Create new `TrailingSlash`.
+    /// Creates a new `TrailingSlash`.
     #[inline]
     pub fn new(action: TrailingSlashAction) -> Self {
         Self {
@@ -112,13 +112,13 @@ impl TrailingSlash {
             redirect_code: StatusCode::MOVED_PERMANENTLY,
         }
     }
-    /// Create new `TrailingSlash` and sets its action as [`TrailingSlashAction::Add`].
+    /// Creates a new `TrailingSlash` and sets its action to [`TrailingSlashAction::Add`].
     #[inline]
     #[must_use]
     pub fn new_add() -> Self {
         Self::new(TrailingSlashAction::Add)
     }
-    /// Create new `TrailingSlash` and sets its action as [`TrailingSlashAction::Remove`].
+    /// Creates a new `TrailingSlash` and sets its action to [`TrailingSlashAction::Remove`].
     #[inline]
     #[must_use]
     pub fn new_remove() -> Self {

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -133,14 +133,14 @@ impl Default for WebSocketUpgrade {
 }
 
 impl WebSocketUpgrade {
-    /// Create new `WebSocketUpgrade`.
+    /// Creates a new `WebSocketUpgrade`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
         Self { config: None, protocols: Vec::new(), accept_any: false }
     }
 
-    /// Create new `WebSocketUpgrade` with config.
+    /// Creates a new `WebSocketUpgrade` with config.
     #[inline]
     #[must_use]
     pub fn with_config(config: WebSocketConfig) -> Self {

--- a/crates/flash/src/cookie_store.rs
+++ b/crates/flash/src/cookie_store.rs
@@ -98,7 +98,7 @@ impl CookieStore {
         self
     }
 
-    /// Into `FlashHandler`.
+    /// Converts this store into a `FlashHandler`.
     #[must_use]
     pub fn into_handler(self) -> FlashHandler<Self> {
         FlashHandler::new(self)

--- a/crates/jwt-auth/src/finder.rs
+++ b/crates/jwt-auth/src/finder.rs
@@ -38,12 +38,12 @@ pub trait JwtTokenFinder: Send + Sync {
 /// let finder = HeaderFinder::new();
 ///
 /// // Custom configuration for specific methods
-/// let get_only = HeaderFinder::new().cared_methods(vec![Method::GET]);
+/// let get_only = HeaderFinder::new().allowed_methods(vec![Method::GET]);
 /// ```
 #[derive(Eq, PartialEq, Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct HeaderFinder {
-    /// List of HTTP methods for which this finder should extract tokens.
+    /// Allowed HTTP methods for which this finder should extract tokens.
     /// If the request's method is not in this list, the finder will not attempt extraction.
     pub cared_methods: Vec<Method>,
 
@@ -51,7 +51,7 @@ pub struct HeaderFinder {
     pub header_names: Vec<HeaderName>,
 }
 impl HeaderFinder {
-    /// Create new `HeaderFinder`.
+    /// Creates a new `HeaderFinder`.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -75,17 +75,28 @@ impl HeaderFinder {
         self
     }
 
-    /// Get cared methods list mutable reference.
+    /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
-    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+    pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
         &mut self.cared_methods
     }
-    /// Sets cared methods list and returns `Self`.
+    /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
-    pub fn cared_methods(mut self, methods: Vec<Method>) -> Self {
+    pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
         self.cared_methods = methods;
         self
+    }
+    /// Returns a mutable reference to the allowed HTTP methods.
+    #[inline]
+    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+        self.allowed_methods_mut()
+    }
+    /// Sets the allowed HTTP methods and returns `Self`.
+    #[inline]
+    #[must_use]
+    pub fn cared_methods(self, methods: Vec<Method>) -> Self {
+        self.allowed_methods(methods)
     }
 }
 #[async_trait]
@@ -150,19 +161,19 @@ mod tests {
 /// let finder = FormFinder::new("access_token");
 ///
 /// // Limit to POST requests only
-/// let post_only = FormFinder::new("access_token").cared_methods(vec![Method::POST]);
+/// let post_only = FormFinder::new("access_token").allowed_methods(vec![Method::POST]);
 /// ```
 #[derive(Eq, PartialEq, Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct FormFinder {
-    /// List of HTTP methods for which this finder should extract tokens.
+    /// Allowed HTTP methods for which this finder should extract tokens.
     pub cared_methods: Vec<Method>,
 
     /// Name of the form field containing the token.
     pub field_name: Cow<'static, str>,
 }
 impl FormFinder {
-    /// Create new `FormFinder`.
+    /// Creates a new `FormFinder`.
     #[inline]
     pub fn new<T: Into<Cow<'static, str>>>(field_name: T) -> Self {
         Self {
@@ -170,17 +181,28 @@ impl FormFinder {
             cared_methods: ALL_METHODS.to_vec(),
         }
     }
-    /// Get cared methods list mutable reference.
+    /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
-    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+    pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
         &mut self.cared_methods
     }
-    /// Sets cared methods list and returns Self.
+    /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
-    pub fn cared_methods(mut self, methods: Vec<Method>) -> Self {
+    pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
         self.cared_methods = methods;
         self
+    }
+    /// Returns a mutable reference to the allowed HTTP methods.
+    #[inline]
+    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+        self.allowed_methods_mut()
+    }
+    /// Sets the allowed HTTP methods and returns `Self`.
+    #[inline]
+    #[must_use]
+    pub fn cared_methods(self, methods: Vec<Method>) -> Self {
+        self.allowed_methods(methods)
     }
 }
 #[async_trait]
@@ -209,19 +231,19 @@ impl JwtTokenFinder for FormFinder {
 /// let finder = QueryFinder::new("token");
 ///
 /// // Limit to GET requests only
-/// let get_only = QueryFinder::new("token").cared_methods(vec![Method::GET]);
+/// let get_only = QueryFinder::new("token").allowed_methods(vec![Method::GET]);
 /// ```
 #[derive(Eq, PartialEq, Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct QueryFinder {
-    /// List of HTTP methods for which this finder should extract tokens.
+    /// Allowed HTTP methods for which this finder should extract tokens.
     pub cared_methods: Vec<Method>,
 
     /// Name of the query parameter containing the token.
     pub query_name: Cow<'static, str>,
 }
 impl QueryFinder {
-    /// Create new `QueryFinder`.
+    /// Creates a new `QueryFinder`.
     #[inline]
     pub fn new<T: Into<Cow<'static, str>>>(query_name: T) -> Self {
         Self {
@@ -229,17 +251,28 @@ impl QueryFinder {
             cared_methods: ALL_METHODS.to_vec(),
         }
     }
-    /// Get cared methods list mutable reference.
+    /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
-    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+    pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
         &mut self.cared_methods
     }
-    /// Sets cared methods list and returns Self.
+    /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
-    pub fn cared_methods(mut self, methods: Vec<Method>) -> Self {
+    pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
         self.cared_methods = methods;
         self
+    }
+    /// Returns a mutable reference to the allowed HTTP methods.
+    #[inline]
+    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+        self.allowed_methods_mut()
+    }
+    /// Sets the allowed HTTP methods and returns `Self`.
+    #[inline]
+    #[must_use]
+    pub fn cared_methods(self, methods: Vec<Method>) -> Self {
+        self.allowed_methods(methods)
     }
 }
 
@@ -269,19 +302,19 @@ impl JwtTokenFinder for QueryFinder {
 /// let finder = CookieFinder::new("jwt");
 ///
 /// // Limit to specific methods
-/// let restricted = CookieFinder::new("jwt").cared_methods(vec![Method::GET, Method::POST]);
+/// let restricted = CookieFinder::new("jwt").allowed_methods(vec![Method::GET, Method::POST]);
 /// ```
 #[derive(Eq, PartialEq, Clone, Default, Debug)]
 #[non_exhaustive]
 pub struct CookieFinder {
-    /// List of HTTP methods for which this finder should extract tokens.
+    /// Allowed HTTP methods for which this finder should extract tokens.
     pub cared_methods: Vec<Method>,
 
     /// Name of the cookie containing the token.
     pub cookie_name: Cow<'static, str>,
 }
 impl CookieFinder {
-    /// Create new `CookieFinder`.
+    /// Creates a new `CookieFinder`.
     #[inline]
     pub fn new<T: Into<Cow<'static, str>>>(cookie_name: T) -> Self {
         Self {
@@ -289,17 +322,28 @@ impl CookieFinder {
             cared_methods: ALL_METHODS.to_vec(),
         }
     }
-    /// Get cared methods list mutable reference.
+    /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
-    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+    pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
         &mut self.cared_methods
     }
-    /// Sets cared methods list and returns Self.
+    /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
-    pub fn cared_methods(mut self, methods: Vec<Method>) -> Self {
+    pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
         self.cared_methods = methods;
         self
+    }
+    /// Returns a mutable reference to the allowed HTTP methods.
+    #[inline]
+    pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
+        self.allowed_methods_mut()
+    }
+    /// Sets the allowed HTTP methods and returns `Self`.
+    #[inline]
+    #[must_use]
+    pub fn cared_methods(self, methods: Vec<Method>) -> Self {
+        self.allowed_methods(methods)
     }
 }
 #[async_trait]

--- a/crates/jwt-auth/src/finder.rs
+++ b/crates/jwt-auth/src/finder.rs
@@ -87,12 +87,14 @@ impl HeaderFinder {
         self.cared_methods = methods;
         self
     }
-    /// Returns a mutable reference to the allowed HTTP methods.
+    /// Deprecated alias for [`Self::allowed_methods_mut`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods_mut` instead")]
     #[inline]
     pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
         self.allowed_methods_mut()
     }
-    /// Sets the allowed HTTP methods and returns `Self`.
+    /// Deprecated alias for [`Self::allowed_methods`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods` instead")]
     #[inline]
     #[must_use]
     pub fn cared_methods(self, methods: Vec<Method>) -> Self {
@@ -193,12 +195,14 @@ impl FormFinder {
         self.cared_methods = methods;
         self
     }
-    /// Returns a mutable reference to the allowed HTTP methods.
+    /// Deprecated alias for [`Self::allowed_methods_mut`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods_mut` instead")]
     #[inline]
     pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
         self.allowed_methods_mut()
     }
-    /// Sets the allowed HTTP methods and returns `Self`.
+    /// Deprecated alias for [`Self::allowed_methods`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods` instead")]
     #[inline]
     #[must_use]
     pub fn cared_methods(self, methods: Vec<Method>) -> Self {
@@ -263,12 +267,14 @@ impl QueryFinder {
         self.cared_methods = methods;
         self
     }
-    /// Returns a mutable reference to the allowed HTTP methods.
+    /// Deprecated alias for [`Self::allowed_methods_mut`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods_mut` instead")]
     #[inline]
     pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
         self.allowed_methods_mut()
     }
-    /// Sets the allowed HTTP methods and returns `Self`.
+    /// Deprecated alias for [`Self::allowed_methods`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods` instead")]
     #[inline]
     #[must_use]
     pub fn cared_methods(self, methods: Vec<Method>) -> Self {
@@ -334,12 +340,14 @@ impl CookieFinder {
         self.cared_methods = methods;
         self
     }
-    /// Returns a mutable reference to the allowed HTTP methods.
+    /// Deprecated alias for [`Self::allowed_methods_mut`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods_mut` instead")]
     #[inline]
     pub fn cared_methods_mut(&mut self) -> &mut Vec<Method> {
         self.allowed_methods_mut()
     }
-    /// Sets the allowed HTTP methods and returns `Self`.
+    /// Deprecated alias for [`Self::allowed_methods`].
+    #[deprecated(since = "0.93.0", note = "use `allowed_methods` instead")]
     #[inline]
     #[must_use]
     pub fn cared_methods(self, methods: Vec<Method>) -> Self {

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -368,7 +368,7 @@ where
     C: DeserializeOwned + Send + Sync + 'static,
     D: JwtAuthDecoder + Send + Sync + 'static,
 {
-    /// Create new `JwtAuth`.
+    /// Creates a new `JwtAuth`.
     #[inline]
     #[must_use]
     pub fn new(decoder: D) -> Self {
@@ -566,8 +566,8 @@ mod tests {
     }
 
     #[test]
-    fn test_header_finder_cared_methods() {
-        let finder = HeaderFinder::new().cared_methods(vec![Method::GET, Method::POST]);
+    fn test_header_finder_allowed_methods() {
+        let finder = HeaderFinder::new().allowed_methods(vec![Method::GET, Method::POST]);
         assert_eq!(finder.cared_methods.len(), 2);
         assert!(finder.cared_methods.contains(&Method::GET));
         assert!(finder.cared_methods.contains(&Method::POST));
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn test_header_finder_mut_methods() {
         let mut finder = HeaderFinder::new();
-        finder.cared_methods_mut().push(Method::CONNECT);
+        finder.allowed_methods_mut().push(Method::CONNECT);
         finder.header_names_mut().clear();
         assert!(finder.header_names.is_empty());
     }
@@ -612,8 +612,8 @@ mod tests {
     }
 
     #[test]
-    fn test_query_finder_cared_methods() {
-        let finder = QueryFinder::new("token").cared_methods(vec![Method::GET]);
+    fn test_query_finder_allowed_methods() {
+        let finder = QueryFinder::new("token").allowed_methods(vec![Method::GET]);
         assert_eq!(finder.cared_methods.len(), 1);
         assert!(finder.cared_methods.contains(&Method::GET));
     }
@@ -628,15 +628,15 @@ mod tests {
     }
 
     #[test]
-    fn test_cookie_finder_cared_methods() {
-        let finder = CookieFinder::new("jwt").cared_methods(vec![Method::GET, Method::POST]);
+    fn test_cookie_finder_allowed_methods() {
+        let finder = CookieFinder::new("jwt").allowed_methods(vec![Method::GET, Method::POST]);
         assert_eq!(finder.cared_methods.len(), 2);
     }
 
     #[test]
     fn test_cookie_finder_mut_methods() {
         let mut finder = CookieFinder::new("token");
-        finder.cared_methods_mut().clear();
+        finder.allowed_methods_mut().clear();
         assert!(finder.cared_methods.is_empty());
     }
 
@@ -650,8 +650,8 @@ mod tests {
     }
 
     #[test]
-    fn test_form_finder_cared_methods() {
-        let finder = FormFinder::new("access_token").cared_methods(vec![Method::POST]);
+    fn test_form_finder_allowed_methods() {
+        let finder = FormFinder::new("access_token").allowed_methods(vec![Method::POST]);
         assert_eq!(finder.cared_methods.len(), 1);
         assert!(finder.cared_methods.contains(&Method::POST));
     }
@@ -1040,7 +1040,7 @@ mod tests {
     async fn test_header_finder_method_filtering() {
         let auth_handler: JwtAuth<JwtClaims, ConstDecoder> =
             JwtAuth::new(ConstDecoder::from_secret(b"SECRET")).finders(vec![Box::new(
-                HeaderFinder::new().cared_methods(vec![Method::POST]),
+                HeaderFinder::new().allowed_methods(vec![Method::POST]),
             )]);
 
         #[handler]
@@ -1064,7 +1064,7 @@ mod tests {
         )
         .unwrap();
 
-        // GET should not find token (method not cared)
+        // GET should not find token because the method is not allowed.
         let content = TestClient::get("http://127.0.0.1:5801/hello")
             .add_header("Authorization", format!("Bearer {token}"), true)
             .send(&service)

--- a/crates/oapi-macros/src/endpoint/server.rs
+++ b/crates/oapi-macros/src/endpoint/server.rs
@@ -13,7 +13,7 @@
 //!
 //! # Examples
 //!
-//! Create new server with relative path.
+//! Creates a new server with a relative path.
 //! ```rust
 //! # use salvo_oapi::server::Server;
 //! Server::new("/api/v1");
@@ -171,13 +171,13 @@ impl Server {
     ///
     /// # Examples
     ///
-    /// Create new server with url path.
+    /// Creates a new server with a URL path.
     /// ```
     /// # use salvo_oapi::server::Server;
     ///  Server::new("/api/v1");
     /// ```
     ///
-    /// Create new server with alternative server.
+    /// Creates a new server with an alternative server.
     /// ```
     /// # use salvo_oapi::server::Server;
     ///  Server::new("https://alternative.pet-api.test/api/v1");

--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -328,7 +328,7 @@ impl TryToTokens for SchemaFormat<'_> {
 pub(crate) struct Type<'a>(&'a syn::Path);
 
 impl Type<'_> {
-    /// Check is the format know format. Known formats can be used within `quote!{...}` statements.
+    /// Returns true if the format is known. Known formats can be used within `quote!{...}` statements.
     pub(crate) fn is_known_format(&self) -> bool {
         let Some(last_segment) = self.0.segments.last() else {
             return false;

--- a/crates/oapi/src/endpoint.rs
+++ b/crates/oapi/src/endpoint.rs
@@ -19,7 +19,7 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Create new `Endpoint` with given operation and components.
+    /// Creates a new `Endpoint` with the given operation and components.
     #[must_use]
     pub fn new(operation: Operation, components: Components) -> Self {
         Self {

--- a/crates/oapi/src/extract/parameter/cookie.rs
+++ b/crates/oapi/src/extract/parameter/cookie.rs
@@ -225,14 +225,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_cookie_prarm_extract() {
+    async fn test_required_cookie_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = CookieParam::<String, true>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_required_cookie_prarm_extract_with_value() {
+    async fn test_required_cookie_param_extract_with_value() {
         let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         req.headers_mut()
             .append("cookie", HeaderValue::from_static("param=param"));
@@ -246,7 +246,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_cookie_prarm_extract_with_value_panic() {
+    async fn test_required_cookie_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -264,14 +264,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_cookie_prarm_extract() {
+    async fn test_cookie_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = CookieParam::<String, false>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_cookie_prarm_extract_with_value() {
+    async fn test_cookie_param_extract_with_value() {
         let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         req.headers_mut()
             .append("cookie", HeaderValue::from_static("param=param"));
@@ -285,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_cookie_prarm_extract_with_value_panic() {
+    async fn test_cookie_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);

--- a/crates/oapi/src/extract/parameter/header.rs
+++ b/crates/oapi/src/extract/parameter/header.rs
@@ -31,7 +31,7 @@ impl<T> Deref for HeaderParam<T, true> {
     fn deref(&self) -> &Self::Target {
         self.0
             .as_ref()
-            .expect("`HeaderParam<T, true>` defref get `None`")
+            .expect("`HeaderParam<T, true>` deref returned `None`")
     }
 }
 impl<T> Deref for HeaderParam<T, false> {
@@ -46,7 +46,7 @@ impl<T> DerefMut for HeaderParam<T, true> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
             .as_mut()
-            .expect("`HeaderParam<T, true>` defref_mut get `None`")
+            .expect("`HeaderParam<T, true>` deref_mut returned `None`")
     }
 }
 impl<T> DerefMut for HeaderParam<T, false> {
@@ -229,14 +229,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_header_prarm_extract() {
+    async fn test_required_header_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = HeaderParam::<String, true>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_required_header_prarm_extract_with_value() {
+    async fn test_required_header_param_extract_with_value() {
         let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         req.headers_mut()
             .append("param", HeaderValue::from_static("param"));
@@ -250,7 +250,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_header_prarm_extract_with_value_panic() {
+    async fn test_required_header_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -268,14 +268,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_header_prarm_extract() {
+    async fn test_header_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = HeaderParam::<String, false>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_header_prarm_extract_with_value() {
+    async fn test_header_param_extract_with_value() {
         let mut req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         req.headers_mut()
             .append("param", HeaderValue::from_static("param"));
@@ -289,7 +289,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_header_prarm_extract_with_value_panic() {
+    async fn test_header_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);

--- a/crates/oapi/src/extract/parameter/path.rs
+++ b/crates/oapi/src/extract/parameter/path.rs
@@ -155,14 +155,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_path_prarm_extract() {
+    async fn test_path_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = PathParam::<String>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_path_prarm_extract_with_value() {
+    async fn test_path_param_extract_with_value() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -174,7 +174,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_path_prarm_extract_with_value_panic() {
+    async fn test_path_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);

--- a/crates/oapi/src/extract/parameter/query.rs
+++ b/crates/oapi/src/extract/parameter/query.rs
@@ -30,7 +30,7 @@ impl<T> Deref for QueryParam<T, true> {
     fn deref(&self) -> &Self::Target {
         self.0
             .as_ref()
-            .expect("`QueryParam<T, true>` defref get `None`")
+            .expect("`QueryParam<T, true>` deref returned `None`")
     }
 }
 impl<T> Deref for QueryParam<T, false> {
@@ -45,7 +45,7 @@ impl<T> DerefMut for QueryParam<T, true> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
             .as_mut()
-            .expect("`QueryParam<T, true>` defref_mut get `None`")
+            .expect("`QueryParam<T, true>` deref_mut returned `None`")
     }
 }
 impl<T> DerefMut for QueryParam<T, false> {
@@ -213,14 +213,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_query_prarm_extract() {
+    async fn test_required_query_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = QueryParam::<String, true>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_required_query_prarm_extract_with_value() {
+    async fn test_required_query_param_extract_with_value() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -234,7 +234,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_required_query_prarm_extract_with_value_panic() {
+    async fn test_required_query_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -252,14 +252,14 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_query_prarm_extract() {
+    async fn test_query_param_extract() {
         let mut req = Request::new();
         let mut depot = Depot::new();
         let _ = QueryParam::<String, false>::extract(&mut req, &mut depot).await;
     }
 
     #[tokio::test]
-    async fn test_query_prarm_extract_with_value() {
+    async fn test_query_param_extract_with_value() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn test_query_prarm_extract_with_value_panic() {
+    async fn test_query_param_extract_with_value_panic() {
         let req = TestClient::get("http://127.0.0.1:5801").build_hyper();
         let schema = req.uri().scheme().cloned().unwrap();
         let mut req = Request::from_hyper(req, schema);

--- a/crates/oapi/src/openapi/header.rs
+++ b/crates/oapi/src/openapi/header.rs
@@ -26,7 +26,7 @@ impl Header {
     ///
     /// # Examples
     ///
-    /// Create new [`Header`] with integer type.
+    /// Creates a new [`Header`] with an integer type.
     /// ```
     /// # use salvo_oapi::{Header, Object, BasicType};
     /// let header = Header::new(Object::with_type(BasicType::Integer));

--- a/crates/oapi/src/openapi/security.rs
+++ b/crates/oapi/src/openapi/security.rs
@@ -40,7 +40,7 @@ impl SecurityRequirement {
     ///
     /// # Examples
     ///
-    /// Create new security requirement with scopes.
+    /// Creates a new security requirement with scopes.
     /// ```
     /// # use salvo_oapi::security::SecurityRequirement;
     /// SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
@@ -193,7 +193,7 @@ impl ApiKeyValue {
     ///
     /// # Examples
     ///
-    /// Create new api key security schema with name `api_key`.
+    /// Creates a new API key security schema named `api_key`.
     /// ```
     /// # use salvo_oapi::security::ApiKeyValue;
     /// let api_key = ApiKeyValue::new("api_key");
@@ -210,7 +210,7 @@ impl ApiKeyValue {
     ///
     /// # Examples
     ///
-    /// Create new api key security schema with name `api_key` with description.
+    /// Creates a new API key security schema named `api_key` with a description.
     /// ```
     /// # use salvo_oapi::security::ApiKeyValue;
     /// let api_key = ApiKeyValue::with_description("api_key", "my api_key token");
@@ -256,7 +256,7 @@ pub struct Http {
 }
 
 impl Http {
-    /// Create new http authentication security schema.
+    /// Creates a new HTTP authentication security schema.
     ///
     /// Accepts one argument which defines the scheme of the http authentication.
     ///
@@ -433,7 +433,7 @@ impl OAuth2 {
     ///
     /// # Examples
     ///
-    /// Create new OAuth2 flow with multiple authentication flows.
+    /// Creates a new OAuth2 flow with multiple authentication flows.
     /// ```
     /// # use salvo_oapi::security::{OAuth2, Flow, Password, AuthorizationCode, Scopes};
     /// OAuth2::new([
@@ -471,7 +471,7 @@ impl OAuth2 {
     ///
     /// # Examples
     ///
-    /// Create new OAuth2 flow with multiple authentication flows with description.
+    /// Creates a new OAuth2 flow with multiple authentication flows and a description.
     /// ```
     /// # use salvo_oapi::security::{OAuth2, Flow, Password, AuthorizationCode, Scopes};
     /// OAuth2::with_description(
@@ -571,7 +571,7 @@ impl Implicit {
     ///
     /// # Examples
     ///
-    /// Create new implicit flow with scopes.
+    /// Creates a new implicit flow with scopes.
     /// ```
     /// # use salvo_oapi::security::{Implicit, Scopes};
     /// Implicit::new(
@@ -583,7 +583,7 @@ impl Implicit {
     /// );
     /// ```
     ///
-    /// Create new implicit flow without any scopes.
+    /// Creates a new implicit flow without any scopes.
     /// ```
     /// # use salvo_oapi::security::{Implicit, Scopes};
     /// Implicit::new("https://localhost/auth/dialog", Scopes::new());
@@ -665,7 +665,7 @@ impl AuthorizationCode {
     ///
     /// # Examples
     ///
-    /// Create new authorization code flow with scopes.
+    /// Creates a new authorization code flow with scopes.
     /// ```
     /// # use salvo_oapi::security::{AuthorizationCode, Scopes};
     /// AuthorizationCode::new(
@@ -678,7 +678,7 @@ impl AuthorizationCode {
     /// );
     /// ```
     ///
-    /// Create new authorization code flow without any scopes.
+    /// Creates a new authorization code flow without any scopes.
     /// ```
     /// # use salvo_oapi::security::{AuthorizationCode, Scopes};
     /// AuthorizationCode::new(
@@ -770,7 +770,7 @@ impl Password {
     ///
     /// # Examples
     ///
-    /// Create new password flow with scopes.
+    /// Creates a new password flow with scopes.
     /// ```
     /// # use salvo_oapi::security::{Password, Scopes};
     /// Password::new(
@@ -782,7 +782,7 @@ impl Password {
     /// );
     /// ```
     ///
-    /// Create new password flow without any scopes.
+    /// Creates a new password flow without any scopes.
     /// ```
     /// # use salvo_oapi::security::{Password, Scopes};
     /// Password::new("https://localhost/token", Scopes::new());
@@ -803,7 +803,7 @@ impl Password {
     ///
     /// # Examples
     ///
-    /// Create new password flow with refresh url.
+    /// Creates a new password flow with a refresh URL.
     /// ```
     /// # use salvo_oapi::security::{Password, Scopes};
     /// Password::with_refresh_url(
@@ -861,7 +861,7 @@ impl ClientCredentials {
     ///
     /// # Examples
     ///
-    /// Create new client credentials flow with scopes.
+    /// Creates a new client credentials flow with scopes.
     /// ```
     /// # use salvo_oapi::security::{ClientCredentials, Scopes};
     /// ClientCredentials::new(
@@ -873,7 +873,7 @@ impl ClientCredentials {
     /// );
     /// ```
     ///
-    /// Create new client credentials flow without any scopes.
+    /// Creates a new client credentials flow without any scopes.
     /// ```
     /// # use salvo_oapi::security::{ClientCredentials, Scopes};
     /// ClientCredentials::new("https://localhost/token", Scopes::new());
@@ -894,7 +894,7 @@ impl ClientCredentials {
     ///
     /// # Examples
     ///
-    /// Create new client credentials for with refresh url.
+    /// Creates a new client credentials flow with a refresh URL.
     /// ```
     /// # use salvo_oapi::security::{ClientCredentials, Scopes};
     /// ClientCredentials::with_refresh_url(

--- a/crates/oapi/src/openapi/server.rs
+++ b/crates/oapi/src/openapi/server.rs
@@ -13,7 +13,7 @@
 //!
 //! # Examples
 //!
-//! Create new server with relative path.
+//! Creates a new server with a relative path.
 //! ```rust
 //! # use salvo_oapi::server::Server;
 //! Server::new("/api/v1");
@@ -188,13 +188,13 @@ impl Server {
     ///
     /// # Examples
     ///
-    /// Create new server with url path.
+    /// Creates a new server with a URL path.
     /// ```
     /// # use salvo_oapi::server::Server;
     /// Server::new("/api/v1");
     /// ```
     ///
-    /// Create new server with alternative server.
+    /// Creates a new server with an alternative server.
     /// ```
     /// # use salvo_oapi::server::Server;
     /// Server::new("https://alternative.pet-api.test/api/v1");

--- a/crates/oapi/src/swagger_ui.rs
+++ b/crates/oapi/src/swagger_ui.rs
@@ -263,7 +263,7 @@ pub struct Url<'a> {
 }
 
 impl<'a> Url<'a> {
-    /// Create new [`Url`].
+    /// Creates a new [`Url`].
     ///
     /// Name is shown in the select dropdown when there are multiple docs in Swagger UI.
     ///
@@ -284,7 +284,7 @@ impl<'a> Url<'a> {
         }
     }
 
-    /// Create new [`Url`] with primary flag.
+    /// Creates a new [`Url`] with the primary flag.
     ///
     /// Primary flag allows users to override the default behavior of the Swagger UI for selecting the primary
     /// doc to display. By default when there are multiple docs in Swagger UI the first one in the list

--- a/crates/oapi/src/swagger_ui/config.rs
+++ b/crates/oapi/src/swagger_ui/config.rs
@@ -227,7 +227,7 @@ impl<'a> Config<'a> {
     /// fetch the API document.
     ///
     /// # Examples
-    /// Create new config with 2 api doc urls.
+    /// Creates a new config with two API doc URLs.
     /// ```rust
     /// # use salvo_oapi::swagger_ui::Config;
     /// let config = Config::new(["/api-docs/openapi1.json", "/api-docs/openapi2.json"]);
@@ -239,7 +239,7 @@ impl<'a> Config<'a> {
     /// Constructs a new [`Config`] from [`Iterator`] of [`Url`]s.
     ///
     /// # Examples
-    /// Create new config with OAuth config.
+    /// Creates a new config with OAuth config.
     /// ```rust
     /// # use salvo_oapi::swagger_ui::{Config, oauth};
     /// let config = Config::with_oauth_config(

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -371,7 +371,7 @@ where
     U::Error: Into<BoxedError>,
     C: Client,
 {
-    /// Create new `Proxy` with upstreams list.
+    /// Creates a new `Proxy` with an upstream list.
     ///
     /// The default host header getter forwards only the upstream host name. To include
     /// non-default upstream ports, configure [`standard_host_header_getter`] with
@@ -390,7 +390,7 @@ where
         }
     }
 
-    /// Create new `Proxy` with upstreams list and enable x-forwarded-for header.
+    /// Creates a new `Proxy` with an upstream list and enables the x-forwarded-for header.
     ///
     /// Client IP forwarding overwrites any inbound `X-Forwarded-For` value with the direct
     /// client IP from the connection.

--- a/crates/rate-limiter/src/fixed_guard.rs
+++ b/crates/rate-limiter/src/fixed_guard.rs
@@ -3,7 +3,7 @@ use time::OffsetDateTime;
 
 use super::{BasicQuota, RateGuard};
 
-/// Fixed window implement.
+/// Fixed-window rate limiter implementation.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FixedGuard {
     reset: OffsetDateTime,

--- a/crates/rate-limiter/src/quota.rs
+++ b/crates/rate-limiter/src/quota.rs
@@ -30,7 +30,7 @@ pub struct BasicQuota {
     pub period: Duration,
 }
 impl BasicQuota {
-    /// Create new `BasicQuota`.
+    /// Creates a new `BasicQuota`.
     #[must_use]
     pub const fn new(limit: usize, period: Duration) -> Self {
         Self { limit, period }
@@ -91,7 +91,7 @@ pub struct CelledQuota {
     pub cells: usize,
 }
 impl CelledQuota {
-    /// Create new `CelledQuota`.
+    /// Creates a new `CelledQuota`.
     #[must_use]
     pub const fn new(limit: usize, cells: usize, period: Duration) -> Self {
         Self {

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -2,7 +2,7 @@ use time::{Duration, OffsetDateTime};
 
 use super::{CelledQuota, RateGuard};
 
-/// Sliding window implement.
+/// Sliding-window rate limiter implementation.
 #[derive(Clone, Debug)]
 pub struct SlidingGuard {
     cell_start: OffsetDateTime,

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -195,7 +195,7 @@ impl Debug for StaticDir {
     }
 }
 impl StaticDir {
-    /// Create new `StaticDir`.
+    /// Creates a new `StaticDir`.
     #[inline]
     pub fn new<T: StaticRoots + Sized>(roots: T) -> Self {
         let mut compressed_variations = HashMap::new();

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -150,7 +150,7 @@ impl<S> HandlerBuilder<S>
 where
     S: SessionStore,
 {
-    /// Create new `HandlerBuilder`
+    /// Creates a new `HandlerBuilder`.
     ///
     /// # Security Note
     ///
@@ -429,7 +429,7 @@ impl<S> SessionHandler<S>
 where
     S: SessionStore + Send + Sync + 'static,
 {
-    /// Create new `HandlerBuilder`
+    /// Creates a new `HandlerBuilder`.
     pub fn builder(store: S, secret: &[u8]) -> HandlerBuilder<S> {
         HandlerBuilder::new(store, secret)
     }

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -15,7 +15,13 @@ use crate::stores::UploadInfo;
 use crate::utils::is_safe_upload_id;
 
 /// Optional tus upload ID passed to size and URL callbacks.
-pub type UploadId = Option<String>;
+pub type MaybeUploadId = Option<String>;
+
+/// Optional tus upload ID passed to size and URL callbacks.
+///
+/// This alias is kept for compatibility. New internal code should prefer
+/// [`MaybeUploadId`] when the optional nature matters at the call site.
+pub type UploadId = MaybeUploadId;
 
 static RE_FILE_ID: OnceLock<Regex> = OnceLock::new();
 /// Returns the regex used to extract an upload ID from a request path.
@@ -27,6 +33,8 @@ pub fn file_id_regex() -> &'static Regex {
 #[derive(Clone)]
 pub enum MaxSize {
     /// Fixed maximum number of bytes accepted for an upload.
+    ///
+    /// A value of `0` means no configured size limit.
     Fixed(u64),
     /// Callback that computes the maximum number of bytes for each request.
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
## Summary

- Rename misspelled OAPI parameter test names and deref assertion messages.
- Standardize public doc comments from fragment-style wording to clearer Rustdoc phrasing.
- Add `allowed_methods` / `allowed_methods_mut` aliases for JWT token finders while keeping the existing `cared_methods` API for compatibility.
- Clarify TUS optional upload ID naming with `MaybeUploadId`, document `MaxSize::Fixed(0)`, and note nightly rustfmt usage in CONTRIBUTING.

## Validation

- `cargo fmt --all -- --check` passes locally, with expected stable rustfmt warnings for nightly-only options.
- `cargo check --workspace --all-targets --all-features` passes.
- `cargo test --workspace --doc` passes.
- `cargo test -p salvo-jwt-auth --all-targets` passes.
- `cargo test -p salvo-tus --all-targets` passes.
- `cargo test -p salvo-oapi extract::parameter` passes.
- `cargo clippy -p salvo-jwt-auth --all-targets -- -D warnings` passes.

## Note

`cargo test -p salvo-oapi --all-targets` still fails in two existing OpenAPI snapshot tests unrelated to this PR. The failure is a schema format mismatch where current output uses unsigned formats (`uint16` / `uint64`) while the snapshots expect signed formats (`int32` / `int64`). This PR does not touch the schema generation logic.