### PR TITLE
Fix session cookie removal attributes

### DIFF
--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -363,7 +363,19 @@ impl Response {
             self
         }
 
-        /// Removes a cookie from the response.
+        /// Removes a cookie from the response by name.
+        ///
+        /// Use [`Self::remove_cookie_with`] when the removal cookie must include
+        /// the same path or domain as the cookie that was initially set.
+        #[inline]
+        pub fn remove_cookie(&mut self, name: &str) -> &mut Self {
+            if let Some(cookie) = self.cookies.get(name).cloned() {
+                self.cookies.remove(cookie);
+            }
+            self
+        }
+
+        /// Removes a cookie from the response using the supplied cookie attributes.
         ///
         /// Removes `cookie` from this [`CookieJar`]. If an _original_ cookie with the same
         /// name as `cookie` is present in the jar, a _removal_ cookie will be
@@ -377,11 +389,11 @@ impl Response {
         ///
         /// Read more about [removal cookies](https://docs.rs/cookie/0.18.0/cookie/struct.CookieJar.html#method.remove).
         #[inline]
-        pub fn remove_cookie(&mut self, name: &str) -> &mut Self
+        pub fn remove_cookie_with<C>(&mut self, cookie: C) -> &mut Self
+        where
+            C: Into<Cookie<'static>>,
         {
-            if let Some(cookie) = self.cookies.get(name).cloned() {
-                self.cookies.remove(cookie);
-            }
+            self.cookies.remove(cookie);
             self
         }
     }
@@ -708,5 +720,35 @@ mod test {
         );
         assert!(cookie_headers.iter().any(|v| v.starts_with("sid=abc")));
         assert!(cookie_headers.iter().any(|v| v.starts_with("theme=dark")));
+    }
+
+    #[cfg(feature = "cookie")]
+    #[test]
+    fn test_remove_cookie_with_emits_path_and_domain() {
+        use cookie::{Cookie, CookieJar};
+
+        let mut jar = CookieJar::new();
+        jar.add_original(Cookie::new("sid", "abc"));
+
+        let mut res = Response::with_cookies(jar);
+        res.remove_cookie_with(
+            Cookie::build("sid")
+                .path("/app")
+                .domain("example.com")
+                .build(),
+        );
+
+        let hyper_res = res.strip_to_hyper();
+        let cookie = hyper_res
+            .headers()
+            .get(http::header::SET_COOKIE)
+            .expect("set-cookie header")
+            .to_str()
+            .expect("set-cookie should be valid");
+
+        assert!(cookie.starts_with("sid="));
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("Path=/app"));
+        assert!(cookie.contains("Domain=example.com"));
     }
 }

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -370,30 +370,33 @@ impl Response {
         #[inline]
         pub fn remove_cookie(&mut self, name: &str) -> &mut Self {
             if let Some(cookie) = self.cookies.get(name).cloned() {
-                self.cookies.remove(cookie);
+                self.remove_cookie_with(cookie);
+            } else {
+                self.remove_cookie_with(Cookie::new(name.to_owned(), ""));
             }
             self
         }
 
         /// Removes a cookie from the response using the supplied cookie attributes.
         ///
-        /// Removes `cookie` from this [`CookieJar`]. If an _original_ cookie with the same
-        /// name as `cookie` is present in the jar, a _removal_ cookie will be
-        /// present in the `delta` computation. **To properly generate the removal
-        /// cookie, `cookie` must contain the same `path` and `domain` as the cookie
-        /// that was initially set.**
+        /// The supplied cookie is converted to a _removal_ cookie and added to
+        /// the response. **To properly remove the cookie in a browser, `cookie`
+        /// must contain the same `path` and `domain` as the cookie that was
+        /// initially set.**
         ///
         /// A "removal" cookie is a cookie that has the same name as the original
         /// cookie but has an empty value, a max-age of 0, and an expiration date
         /// far in the past.
         ///
-        /// Read more about [removal cookies](https://docs.rs/cookie/0.18.0/cookie/struct.CookieJar.html#method.remove).
+        /// Read more about [removal cookies](https://docs.rs/cookie/0.18.0/cookie/struct.Cookie.html#method.make_removal).
         #[inline]
         pub fn remove_cookie_with<C>(&mut self, cookie: C) -> &mut Self
         where
             C: Into<Cookie<'static>>,
         {
-            self.cookies.remove(cookie);
+            let mut cookie = cookie.into();
+            cookie.make_removal();
+            self.cookies.add(cookie);
             self
         }
     }
@@ -724,13 +727,28 @@ mod test {
 
     #[cfg(feature = "cookie")]
     #[test]
-    fn test_remove_cookie_with_emits_path_and_domain() {
-        use cookie::{Cookie, CookieJar};
+    fn test_remove_cookie_emits_removal_without_original_cookie() {
+        let mut res = Response::new();
+        res.remove_cookie("sid");
 
-        let mut jar = CookieJar::new();
-        jar.add_original(Cookie::new("sid", "abc"));
+        let hyper_res = res.strip_to_hyper();
+        let cookie = hyper_res
+            .headers()
+            .get(http::header::SET_COOKIE)
+            .expect("set-cookie header")
+            .to_str()
+            .expect("set-cookie should be valid");
 
-        let mut res = Response::with_cookies(jar);
+        assert!(cookie.starts_with("sid="));
+        assert!(cookie.contains("Max-Age=0"));
+    }
+
+    #[cfg(feature = "cookie")]
+    #[test]
+    fn test_remove_cookie_with_emits_path_and_domain_without_original_cookie() {
+        use cookie::Cookie;
+
+        let mut res = Response::new();
         res.remove_cookie_with(
             Cookie::build("sid")
                 .path("/app")

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -406,7 +406,9 @@ where
             if let Err(e) = self.store.destroy_session(session).await {
                 tracing::error!(error = ?e, "unable to destroy session");
             }
-            res.remove_cookie(&self.cookie_name);
+            let secure_cookie =
+                self.same_site_policy == SameSite::None || self.secure_cookie_policy.is_secure(req);
+            res.remove_cookie_with(self.build_removal_cookie(secure_cookie));
         } else if self.save_unchanged || session.data_changed() {
             match self.store.store_session(session).await {
                 Ok(cookie_value) => {
@@ -496,6 +498,20 @@ where
         }
 
         self.sign_cookie(&mut cookie);
+
+        cookie
+    }
+    fn build_removal_cookie(&self, secure: bool) -> Cookie<'static> {
+        let mut cookie = Cookie::build((self.cookie_name.clone(), ""))
+            .http_only(true)
+            .same_site(self.same_site_policy)
+            .secure(secure)
+            .path(self.cookie_path.clone())
+            .build();
+
+        if let Some(cookie_domain) = self.cookie_domain.clone() {
+            cookie.set_domain(cookie_domain)
+        }
 
         cookie
     }
@@ -917,6 +933,46 @@ mod tests {
             .send(&service)
             .await;
         assert_eq!(response.status_code, Some(StatusCode::OK));
+    }
+
+    #[tokio::test]
+    async fn test_session_destroy_preserves_cookie_path_and_domain() {
+        #[handler]
+        pub async fn destroy_session(depot: &mut Depot) {
+            if let Some(session) = depot.session_mut() {
+                session.destroy();
+            }
+        }
+
+        let session_handler = SessionHandler::builder(
+            MemoryStore::new(),
+            b"secretabsecretabsecretabsecretabsecretabsecretabsecretabsecretab",
+        )
+        .cookie_domain("example.com")
+        .cookie_path("/app")
+        .build()
+        .unwrap();
+
+        let router = Router::new()
+            .hoop(session_handler)
+            .push(Router::with_path("destroy").get(destroy_session));
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:8698/destroy")
+            .add_header(COOKIE, "salvo.session.id=stale", true)
+            .send(&service)
+            .await;
+
+        let cookie = response
+            .headers()
+            .get(SET_COOKIE)
+            .expect("set-cookie header")
+            .to_str()
+            .expect("set-cookie should be valid");
+        assert!(cookie.starts_with("salvo.session.id="));
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("Path=/app"));
+        assert!(cookie.contains("Domain=example.com"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `Response::remove_cookie_with` so callers can include removal cookie attributes
- preserve configured session cookie path and domain when destroying a session
- cover the core removal API and session destroy behavior with tests

## Validation
- `cargo fmt --all -- --check` (passes; stable rustfmt reports existing nightly-only option warnings)
- `cargo test -p salvo-session --all-targets`
- `cargo test -p salvo_core --features cookie test_remove_cookie_with_emits_path_and_domain`
- `cargo check --workspace --all-targets --all-features`