### PR TITLE
Fix strict rustdoc warnings

### DIFF
--- a/crates/core/src/fs.rs
+++ b/crates/core/src/fs.rs
@@ -42,8 +42,8 @@
 //! Large files are read in chunks to avoid loading the entire file into memory.
 //! `NamedFile::builder(...).preload_threshold(...)` controls the separate
 //! small-file preload limit.
-//! The [`ChunkedFile`] struct implements [`Stream`](futures_util::stream::Stream),
-//! yielding [`Bytes`](bytes::Bytes) chunks as they are read.
+//! The [`ChunkedFile`] struct implements [`Stream`],
+//! yielding [`Bytes`] chunks as they are read.
 mod named_file;
 use std::cmp;
 use std::fmt::{self, Debug, Formatter};
@@ -65,7 +65,7 @@ pub(crate) enum ChunkedState<T> {
 
 /// A streaming file reader that yields data in configurable chunks.
 ///
-/// `ChunkedFile` implements [`Stream`](futures_util::stream::Stream), yielding
+/// `ChunkedFile` implements [`Stream`], yielding
 /// [`Bytes`] chunks as the file is read. This allows large files to be served
 /// without loading the entire content into memory.
 ///

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -50,7 +50,8 @@
 //! - No need to manually add `#[async_trait]`.
 //! - Unused context parameters can be omitted.
 //! - Required parameters can be listed in any supported order.
-//! - Return values that implement [`Writer`] or [`Scribe`] can be returned directly.
+//! - Return values that implement [`Writer`](crate::writing::Writer) or
+//!   [`Scribe`](crate::writing::Scribe) can be returned directly.
 //!
 //! `#[handler]` can also be added to an `impl` block. In that form, the `handle`
 //! method becomes the [`Handler::handle`] implementation for the struct:
@@ -76,7 +77,8 @@
 //! When the `anyhow` feature is enabled, `anyhow::Error` can be returned from a
 //! handler and is rendered as `500 Internal Server Error`.
 //!
-//! Custom error types can implement [`Writer`] to control the generated response:
+//! Custom error types can implement [`Writer`](crate::writing::Writer) to control the generated
+//! response:
 //!
 //! ```ignore
 //! use anyhow::anyhow;

--- a/crates/core/src/routing.rs
+++ b/crates/core/src/routing.rs
@@ -7,7 +7,7 @@
 //! The interior of [`Router`] is actually composed of a series of filters. When a request comes,
 //! the route will test itself and its descendants in order to see if they can match the request in
 //! the order they were added, and then execute the middleware on the entire chain formed by the
-//! route and its descendants in sequence. If the status of [`Response`](crate::http::Response) is
+//! route and its descendants in sequence. If the status of [`Response`] is
 //! set to error (4XX, 5XX) or jump (3XX) during processing, the subsequent middleware and
 //! [`Handler`] will be skipped. You can also manually adjust `ctrl.skip_rest()` to skip subsequent
 //! middleware and [`Handler`].

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -17,7 +17,7 @@ use crate::serde::{CowValue, FlatValue, VecValue};
 use crate::{Depot, Request};
 
 /// Type alias for depot value extractor functions.
-/// Each extractor attempts to extract a specific type from the Depot and convert it to Cow<str>.
+/// Each extractor attempts to extract a specific type from the Depot and convert it to `Cow<str>`.
 type DepotExtractFn = for<'a> fn(&'a Depot, &str) -> Option<Cow<'a, str>>;
 
 /// Registry of depot value extractors.
@@ -54,9 +54,9 @@ static DEPOT_EXTRACTORS: &[DepotExtractFn] = &[
     |d, k| d.get::<bool>(k).ok().map(|v| Cow::Owned(v.to_string())),
 ];
 
-/// Helper function to extract a value from Depot and convert it to a Cow<str>.
-/// Supports String, &str, Arc<String>, Arc<str>, and common primitive types (integers, floats,
-/// bool).
+/// Helper function to extract a value from Depot and convert it to a `Cow<str>`.
+/// Supports `String`, `&str`, `Arc<String>`, `Arc<str>`, and common primitive types (integers,
+/// floats, bool).
 fn get_depot_value<'a>(depot: &'a Depot, key: &str) -> Option<Cow<'a, str>> {
     for extractor in DEPOT_EXTRACTORS {
         if let Some(value) = extractor(depot, key) {

--- a/crates/oapi/docs/lib.md
+++ b/crates/oapi/docs/lib.md
@@ -104,7 +104,7 @@ for comprehensive examples including:
 - [`derive@ToSchema`] - Schema derivation with all attributes
 - [`derive@ToParameters`] - Parameter extraction documentation
 - [`derive@ToResponse`] / [`derive@ToResponses`] - Response documentation
-- [`endpoint`] - Endpoint macro documentation
+- [`macro@endpoint`] - Endpoint macro documentation
 - [Security documentation][security] - API authentication setup
 
 [security]: openapi/security/index.html

--- a/crates/oapi/src/openapi/schema/array.rs
+++ b/crates/oapi/src/openapi/schema/array.rs
@@ -11,7 +11,7 @@ use crate::{Deprecated, PropMap, RefOr, Schema, SchemaType, Xml};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum ArrayItems {
-    /// Defines [`Array::items`] as [`RefOr::T(Schema)`]. This is the default for [`Array`].
+    /// Defines [`Array::items`] as [`RefOr::Type`]. This is the default for [`Array`].
     RefOrSchema(Box<RefOr<Schema>>),
     /// Defines [`Array::items`] as `false` indicating that no extra items are allowed to the
     /// [`Array`]. This can be used together with [`Array::prefix_items`] to disallow [additional


### PR DESCRIPTION
## Summary
- fix broken and ambiguous intra-doc links in core and oapi docs
- remove redundant explicit rustdoc link targets
- mark generic type names as code so rustdoc does not parse them as HTML tags

## Validation
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check` (passes; stable rustfmt reports existing nightly-only option warnings)