### PR TITLE
Fix sliding window rate limiter never sliding

### DIFF
--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -54,20 +54,24 @@ impl RateGuard for SlidingGuard {
             return true;
         }
         let mut delta = now - self.cell_start;
-        if delta > quota.period {
+        if delta >= quota.period {
             self.reset_window(&quota, now);
             return true;
-        } else {
-            while delta > self.cell_span {
-                delta -= self.cell_span;
-                self.head = (self.head + 1) % self.counts.len();
-                self.total = self.total.saturating_sub(self.counts[self.head]);
-                self.counts[self.head] = 0;
-            }
-            self.counts[self.head] += 1;
-            self.total += 1;
-            self.cell_start = now;
         }
+        // Advance the head over every whole cell span that has elapsed since the
+        // current cell started, evicting the counts of the cells that slide out
+        // of the window. Cell boundaries are anchored in absolute time, so
+        // `cell_start` is moved forward by whole cell spans instead of being
+        // reset to `now` on every request (which would freeze the window).
+        while delta >= self.cell_span {
+            delta -= self.cell_span;
+            self.head = (self.head + 1) % self.counts.len();
+            self.total = self.total.saturating_sub(self.counts[self.head]);
+            self.counts[self.head] = 0;
+        }
+        self.counts[self.head] += 1;
+        self.total += 1;
+        self.cell_start = now - delta;
         self.total <= quota.limit
     }
 
@@ -295,6 +299,31 @@ mod tests {
         // Change quota should reset
         assert!(guard.verify(&quota2).await);
         assert_eq!(guard.counts.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_sliding_guard_window_slides_with_small_gaps() {
+        // Regression test: cell boundaries must be anchored in absolute time.
+        // With several requests spaced closer than one cell span, but whose
+        // cumulative elapsed time exceeds a cell span, the head must still
+        // advance. The previous implementation reset `cell_start` to `now` on
+        // every request, so `delta` only ever measured the inter-request gap
+        // and the window never slid (head stayed at 0 forever).
+        let mut guard = SlidingGuard::new();
+        // limit is high so requests are never rejected and cannot interfere.
+        let quota = CelledQuota::new(100, 3, Duration::milliseconds(300)); // cell_span = 100ms
+
+        assert!(guard.verify(&quota).await);
+        for _ in 0..4 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(45)).await;
+            assert!(guard.verify(&quota).await);
+        }
+
+        assert!(
+            guard.head > 0,
+            "sliding window head did not advance over time, head={}",
+            guard.head
+        );
     }
 
     #[tokio::test]

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -35,11 +35,25 @@ impl SlidingGuard {
 
     fn reset_window(&mut self, quota: &CelledQuota, now: OffsetDateTime) {
         self.cell_start = now;
-        self.cell_span = quota.period / (quota.cells as u32);
+        self.cell_span = Self::cell_span(quota);
         self.counts = vec![0; quota.cells];
         self.head = 0;
         self.counts[0] = 1;
         self.total = 1;
+    }
+
+    /// Width of a single cell, rounded **up** so the whole ring spans at least
+    /// `quota.period`. With truncating division `cells * cell_span` can be
+    /// shorter than `period`, which would let the head wrap around and evict a
+    /// still-valid request before `period` elapsed.
+    fn cell_span(quota: &CelledQuota) -> Duration {
+        let cells = quota.cells.max(1) as u32;
+        let span = quota.period / cells;
+        if span * cells < quota.period {
+            span + Duration::nanoseconds(1)
+        } else {
+            span
+        }
     }
 }
 
@@ -299,6 +313,26 @@ mod tests {
         // Change quota should reset
         assert!(guard.verify(&quota2).await);
         assert_eq!(guard.counts.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_sliding_guard_ring_span_covers_period() {
+        // Regression test: `period / cells` truncates, so the ring
+        // (`cells * cell_span`) could span slightly less than `period`. When it
+        // does, advancing over a near-full period wraps the head all the way
+        // around and evicts a request that is still inside the window. The ring
+        // must always cover at least the full period.
+        let mut guard = SlidingGuard::new();
+        let quota = CelledQuota::new(9, 3, Duration::seconds(1)); // 1s / 3 is not exact
+        assert!(guard.verify(&quota).await);
+
+        let normalized = quota.normalized();
+        let ring = guard.cell_span * (normalized.cells as u32);
+        assert!(
+            ring >= normalized.period,
+            "ring span {ring:?} shorter than period {:?}",
+            normalized.period
+        );
     }
 
     #[tokio::test]

--- a/crates/rate-limiter/src/sliding_guard.rs
+++ b/crates/rate-limiter/src/sliding_guard.rs
@@ -3,6 +3,17 @@ use time::{Duration, OffsetDateTime};
 use super::{CelledQuota, RateGuard};
 
 /// Sliding-window rate limiter implementation.
+///
+/// The window is approximated with a ring of `cells` fixed-width buckets
+/// (a "sliding window counter"). Requests are attributed to the bucket covering
+/// the instant they arrive, and a bucket is evicted once a full `period` has
+/// passed since it started. This keeps memory at `O(cells)` regardless of the
+/// request rate, at the cost of sub-cell precision: every request inside a
+/// bucket shares that bucket's start time, so a burst clustered near the end of
+/// a bucket can be forgotten up to one `cell_span` early when the bucket is
+/// reused. The error is bounded by a single bucket's worth of requests and
+/// shrinks as `cells` grows (note `cells` is capped at `limit`). An exact
+/// sliding window would require storing a timestamp per request.
 #[derive(Clone, Debug)]
 pub struct SlidingGuard {
     cell_start: OffsetDateTime,


### PR DESCRIPTION
## Problem

`SlidingGuard::verify` reset `cell_start` to `now` on **every** request (`crates/rate-limiter/src/sliding_guard.rs:69`). The elapsed `delta = now - cell_start` therefore only ever measured the gap since the *previous* request, not the time since the current cell started.

Consequences for steady traffic (gaps smaller than one cell span):
- the `while delta > cell_span` loop never ran, so `head` never advanced;
- old cell counts were never evicted;
- the "sliding" window effectively became a counter that only cleared after a full idle `period`.

The existing tests masked this because `test_sliding_guard_fixed_interval_should_not_reject` manually rewinds `cell_start` before each call, which hides the reset bug.

## Fix

- Anchor cell boundaries in absolute time: advance `cell_start` forward by whole cell spans via `cell_start = now - delta` (the remainder after consuming full spans) instead of resetting to `now`.
- Use `>=` at the `period` and `cell_span` boundaries (off-by-one at exact cell edges).

## Test

Adds `test_sliding_guard_window_slides_with_small_gaps`, which issues requests spaced closer than one cell span but cumulatively exceeding it, and asserts the head advances. This fails on the old code (head stays `0`) and passes now.

All 50 rate-limiter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)