### PR TITLE
Fix three OpenAPI schema generation bugs in oapi-macros

### DIFF
--- a/crates/oapi-macros/src/component.rs
+++ b/crates/oapi-macros/src/component.rs
@@ -347,7 +347,6 @@ impl ComponentSchema {
         let schema = quote! {
             #oapi::oapi::schema::Array::new().items(#component_schema)
             #schema_type
-            .items(#component_schema)
             #unique
         };
 

--- a/crates/oapi-macros/src/feature.rs
+++ b/crates/oapi-macros/src/feature.rs
@@ -269,7 +269,7 @@ impl TryToTokens for Feature {
                 quote! { .max_properties(#max_properties) }
             }
             Self::MinProperties(min_properties) => {
-                quote! { .max_properties(#min_properties) }
+                quote! { .min_properties(#min_properties) }
             }
             Self::SchemaWith(with_schema) => with_schema.to_token_stream(),
             Self::Description(description) => quote! { .description(#description) },

--- a/crates/oapi-macros/src/type_tree.rs
+++ b/crates/oapi-macros/src/type_tree.rs
@@ -20,10 +20,13 @@ enum TypeTreeValue<'t> {
 
 impl PartialEq for TypeTreeValue<'_> {
     fn eq(&self, other: &Self) -> bool {
-        match self {
-            Self::Path(_) | Self::TypePath(_) | Self::UnitType => self == other,
-            Self::Array(array, _) => matches!(other, Self::Array(other, _) if other == array),
-            Self::Tuple(tuple, _) => matches!(other, Self::Tuple(other, _) if other == tuple),
+        match (self, other) {
+            (Self::TypePath(a), Self::TypePath(b)) => a == b,
+            (Self::Path(a), Self::Path(b)) => a == b,
+            (Self::UnitType, Self::UnitType) => true,
+            (Self::Array(a, _), Self::Array(b, _)) => a == b,
+            (Self::Tuple(a, _), Self::Tuple(b, _)) => a == b,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
Three independent code-generation bugs in `oapi-macros`, each producing a wrong OpenAPI spec or breaking compilation.

### 1. `min_properties` emits `maxProperties`
`crates/oapi-macros/src/feature.rs` — the `MinProperties` arm generated `.max_properties(#min_properties)`. The `min_properties` attribute silently set `maxProperties`, and `minProperties` could never be produced.

### 2. `Array` schema duplicates `.items(...)`
`crates/oapi-macros/src/component.rs` — the array schema interpolated `.items(#component_schema)` **twice**. `#component_schema` expands to a `to_schema(components)` call with side effects (component registration), so it was emitted and executed twice, and the `schema_type`/nullable override chaining was applied in the wrong place.

### 3. `TypeTreeValue::PartialEq` infinite recursion
`crates/oapi-macros/src/type_tree.rs` — the `Path | TypePath | UnitType` arm called `self == other`, which re-enters the same `eq` and recurses forever (stack overflow) whenever an `Array`/`Tuple` containing one of those variants is compared. Replaced with an explicit pairwise match.

### Verification
`cargo test -p salvo-oapi --lib --features non-strict-integers` → 279 passed, 0 failed.

(Note: two `openapi::tests::*` tests fail under *default* features on `main` as well — unrelated pre-existing integer-format fixture mismatch; they pass under `non-strict-integers`/`full`, the feature set used by these fixtures.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)