### PR TITLE
Fix ReadSeeker range response streaming the whole reader

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -755,7 +755,7 @@ impl NamedFile {
         if offset != 0 || length != self.metadata.len() || range.is_some() {
             // Range request
             res.status_code(StatusCode::PARTIAL_CONTENT);
-            match ContentRange::bytes(offset..offset + length, self.metadata.len()) {
+            match ContentRange::bytes(offset..offset.saturating_add(length), self.metadata.len()) {
                 Ok(content_range) => {
                     res.headers_mut().typed_insert(content_range);
                 }
@@ -768,7 +768,7 @@ impl NamedFile {
 
             // Fast path: slice from preread bytes if available
             if let Some(preread) = self.preread {
-                let end = cmp::min((offset + length) as usize, preread.len());
+                let end = cmp::min(offset.saturating_add(length) as usize, preread.len());
                 let start = cmp::min(offset as usize, end);
                 res.replace_body(ResBody::Once(preread.slice(start..end)));
             } else {

--- a/crates/core/src/http/range.rs
+++ b/crates/core/src/http/range.rs
@@ -43,6 +43,14 @@ impl HttpRange {
                     // range start relative to the end of the file.
                     let mut length: i64 = end_str.parse().map_err(|_| ())?;
 
+                    // A suffix length of zero (e.g. `bytes=-0`) selects no bytes
+                    // and is unsatisfiable per RFC 7233; treat it like a range
+                    // that does not overlap the representation.
+                    if length <= 0 {
+                        no_overlap = true;
+                        return Ok(None);
+                    }
+
                     if length > size_sig {
                         length = size_sig;
                     }
@@ -114,6 +122,7 @@ mod tests {
             T("bytes=7", 10, vec![]),
             T("bytes= 7 ", 10, vec![]),
             T("bytes=1-", 0, vec![]),
+            T("bytes=-0", 10, vec![]),
             T("bytes=5-4", 10, vec![]),
             T("bytes=0-2,5-4", 10, vec![]),
             T("bytes=2-5,4-3", 10, vec![]),

--- a/crates/core/src/writing/seek.rs
+++ b/crates/core/src/writing/seek.rs
@@ -3,7 +3,7 @@ use std::io::SeekFrom;
 use std::time::SystemTime;
 
 use headers::*;
-use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 
 use crate::http::header::{IF_NONE_MATCH, RANGE};
@@ -131,7 +131,7 @@ where
 
         if offset != 0 || length != self.length || range.is_some() {
             res.status_code(StatusCode::PARTIAL_CONTENT);
-            match ContentRange::bytes(offset..offset + length, self.length) {
+            match ContentRange::bytes(offset..offset.saturating_add(length), self.length) {
                 Ok(content_range) => {
                     res.headers_mut().typed_insert(content_range);
                 }
@@ -144,13 +144,16 @@ where
                 res.render(StatusError::bad_request().brief("seek file failed"));
                 return;
             }
+            // Only stream the requested range, not the rest of the reader. The
+            // declared `Content-Length` must match the number of bytes written.
+            let content_length = cmp::min(length, self.length);
             res.headers_mut()
-                .typed_insert(ContentLength(cmp::min(length, self.length)));
-            res.stream(ReaderStream::new(self.reader));
+                .typed_insert(ContentLength(content_length));
+            res.stream(ReaderStream::new(self.reader.take(content_length)));
         } else {
             res.status_code(StatusCode::OK);
             res.headers_mut().typed_insert(ContentLength(self.length));
-            res.stream(ReaderStream::new(self.reader));
+            res.stream(ReaderStream::new(self.reader.take(self.length)));
         }
     }
 }


### PR DESCRIPTION
## Problem

`ReadSeeker::send` (`crates/core/src/writing/seek.rs`) handled a `Range` request by seeking to `offset` and then streaming **the entire reader**:

```rust
res.headers_mut().typed_insert(ContentLength(cmp::min(length, self.length)));
res.stream(ReaderStream::new(self.reader)); // no .take(length)
```

It advertised `Content-Length` equal to the requested range length but wrote everything from `offset` to EOF. A `bytes=0-99` request therefore returned the whole remaining file while claiming a tiny length — a protocol violation and a response-amplification vector. (`NamedFile`'s `ChunkedFile` path is unaffected because it bounds reads by `total_size`.)

## Fix

- Limit the streamed body to the range with `self.reader.take(content_length)`, and `take(self.length)` on the full-body branch for consistency.
- Use `offset.saturating_add(length)` when constructing `ContentRange` in both `ReadSeeker` and `NamedFile` to avoid integer overflow on extreme inputs.
- Treat a zero-length suffix range (`bytes=-0`) as unsatisfiable per RFC 7233 instead of yielding `HttpRange { start: size, length: 0 }`. Adds a regression test.

## Verification

`cargo test -p salvo_core --lib` → 196 passed, 0 failed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)