### PR TITLE
Fix cache swallowing requests and caching non-success responses

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -580,11 +580,18 @@ fn cached_response(res: &Response, cache_private: bool) -> Option<CachedEntry> {
     if res.body.is_stream() || res.body.is_error() {
         return None;
     }
-    // Only cache successful responses. A missing status code defaults to `200 OK`
-    // when the response is sent, so treat `None` as cacheable. Caching error or
-    // redirect statuses (e.g. a transient `500`, or an auth-dependent `401`/`403`)
-    // would replay them to every client for the whole TTL.
-    if res.status_code.is_some_and(|status| !status.is_success()) {
+    // Only cache successful responses. Use the *effective* status: a missing
+    // status code is sent as `200 OK` when a body is present but as `404` when
+    // the body is `None` (mirrors `Response::into_hyper`). Caching error or
+    // redirect statuses (e.g. a transient `500`, an auth-dependent `401`/`403`,
+    // or an empty unmatched `404`) would replay them to every client for the
+    // whole TTL.
+    let effective_status = res.status_code.unwrap_or(if res.body.is_none() {
+        StatusCode::NOT_FOUND
+    } else {
+        StatusCode::OK
+    });
+    if !effective_status.is_success() {
         return None;
     }
     if !cache_private && response_has_private_cache_headers(res.headers()) {
@@ -849,6 +856,25 @@ mod tests {
         assert_eq!(res.status_code.unwrap(), StatusCode::OK);
         let body = res.take_string().await.unwrap();
         assert!(body.contains("Hello World"));
+    }
+
+    #[test]
+    fn test_cached_response_skips_empty_unmatched_404() {
+        // No status code + empty body is sent as `404 NOT_FOUND`
+        // (see `Response::into_hyper`), so its effective status is non-success
+        // and it must not be cached.
+        let res = Response::new();
+        assert!(res.status_code.is_none() && res.body.is_none());
+        assert!(cached_response(&res, false).is_none());
+    }
+
+    #[test]
+    fn test_cached_response_caches_default_success() {
+        // No status code but a body present is sent as `200 OK`, so it is cached.
+        let mut res = Response::new();
+        res.render("ok");
+        assert!(res.status_code.is_none());
+        assert!(cached_response(&res, false).is_some());
     }
 
     // Tests for RequestIssuer

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -580,6 +580,13 @@ fn cached_response(res: &Response, cache_private: bool) -> Option<CachedEntry> {
     if res.body.is_stream() || res.body.is_error() {
         return None;
     }
+    // Only cache successful responses. A missing status code defaults to `200 OK`
+    // when the response is sent, so treat `None` as cacheable. Caching error or
+    // redirect statuses (e.g. a transient `500`, or an auth-dependent `401`/`403`)
+    // would replay them to every client for the whole TTL.
+    if res.status_code.is_some_and(|status| !status.is_success()) {
+        return None;
+    }
     if !cache_private && response_has_private_cache_headers(res.headers()) {
         return None;
     }
@@ -640,6 +647,10 @@ where
             return;
         }
         let Some(key) = self.issuer.issue(req, depot).await else {
+            // No cache key means "do not cache this request"; still run the rest
+            // of the chain so the handler executes instead of returning an empty
+            // response.
+            ctrl.call_next(req, depot, res).await;
             return;
         };
         let Some(cache) = self.store.load_entry(&key).await else {
@@ -783,6 +794,61 @@ mod tests {
         let content2 = res.take_string().await.unwrap();
 
         assert_ne!(content0, content2);
+    }
+
+    #[handler]
+    async fn server_error(res: &mut Response) {
+        res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
+        res.render(format!("error at {}", OffsetDateTime::now_utc()));
+    }
+
+    #[tokio::test]
+    async fn test_cache_skips_non_success_status() {
+        let cache = Cache::new(
+            MokaStore::builder()
+                .time_to_live(std::time::Duration::from_secs(5))
+                .build(),
+            RequestIssuer::default(),
+        );
+        let router = Router::new().hoop(cache).goal(server_error);
+        let service = Service::new(router);
+
+        let mut res = TestClient::get("http://127.0.0.1:5802")
+            .send(&service)
+            .await;
+        assert_eq!(
+            res.status_code.unwrap(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let content0 = res.take_string().await.unwrap();
+
+        // A non-success response must not be cached, so the backend runs again
+        // and produces a fresh (different) body.
+        let mut res = TestClient::get("http://127.0.0.1:5802")
+            .send(&service)
+            .await;
+        let content1 = res.take_string().await.unwrap();
+        assert_ne!(content0, content1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_issuer_none_runs_handler() {
+        let cache = Cache::new(
+            MokaStore::builder()
+                .time_to_live(std::time::Duration::from_secs(5))
+                .build(),
+            // Issuer that never produces a key: requests must still be handled.
+            |_req: &mut Request, _depot: &Depot| Option::<String>::None,
+        );
+        let router = Router::new().hoop(cache).goal(cached);
+        let service = Service::new(router);
+
+        let mut res = TestClient::get("http://127.0.0.1:5803")
+            .send(&service)
+            .await;
+        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        let body = res.take_string().await.unwrap();
+        assert!(body.contains("Hello World"));
     }
 
     // Tests for RequestIssuer


### PR DESCRIPTION
Two correctness bugs in `crates/cache/src/lib.rs`.

### 1. Issuer returning `None` swallowed the request
The `CacheIssuer` docs say returning `None` means "the request will not be cached", but the handler did:

```rust
let Some(key) = self.issuer.issue(req, depot).await else {
    return; // never calls call_next → handler skipped, empty response
};
```

Now it runs the rest of the chain before returning.

### 2. Non-success responses were cached
`cached_response` only excluded streaming/error bodies, so a `500`/`401`/`403` with a normal body was cached and replayed to every client for the TTL. Now only 2xx responses are cached (a missing status code defaults to `200 OK`, so it stays cacheable).

> Note: this restricts caching to 2xx. If you also want to cache specific non-2xx statuses (e.g. `404`, `301`), the `status.is_success()` check is the single place to widen.

### Tests
Adds `test_cache_skips_non_success_status` and `test_cache_issuer_none_runs_handler`. `cargo test -p salvo-cache --lib` → 60 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)