### PR TITLE
Fix caching-headers reading ETag from the request

### DIFF
--- a/crates/extra/src/caching_headers.rs
+++ b/crates/extra/src/caching_headers.rs
@@ -75,12 +75,16 @@ impl Handler for ETag {
             .and_then(|etag| etag.to_str().ok())
             .and_then(|etag| etag.parse::<EntityTag>().ok());
 
-        let etag = req
+        // Prefer an ETag already set on the *response* by an upstream handler.
+        // (Reading it from the request is wrong: `ETag` is a response header, and
+        // a client could forge it to control caching and force a 304.)
+        let res_etag = res
             .headers()
             .get(ETAG)
             .and_then(|etag| etag.to_str().ok())
-            .and_then(|etag| etag.parse().ok())
-            .or_else(|| {
+            .and_then(|etag| etag.parse::<EntityTag>().ok());
+
+        let etag = res_etag.or_else(|| {
                 let etag = match &res.body {
                     ResBody::Once(bytes) => Some(EntityTag::from_data(bytes)),
                     ResBody::Chunks(bytes) => {
@@ -232,5 +236,25 @@ mod tests {
             .await;
         assert_eq!(response.status_code, Some(StatusCode::NOT_MODIFIED));
         assert!(response.body.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_caching_headers_ignores_forged_request_etag() {
+        // A client-supplied `ETag` request header must not influence the ETag the
+        // server computes from the response body, nor force a 304.
+        let router = Router::with_hoop(CachingHeaders::new()).get(hello);
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:8699/")
+            .add_header(ETAG, "\"forged\"", true)
+            .add_header(IF_NONE_MATCH, "\"forged\"", true)
+            .send(&service)
+            .await;
+
+        // The real body-derived ETag does not match the forged value, so the
+        // response is served normally instead of a spurious 304.
+        assert_eq!(response.status_code, Some(StatusCode::OK));
+        let etag = response.headers().get(ETAG).unwrap();
+        assert_ne!(etag, "\"forged\"");
     }
 }

--- a/crates/extra/src/concurrency_limiter.rs
+++ b/crates/extra/src/concurrency_limiter.rs
@@ -100,10 +100,14 @@ impl Handler for MaxConcurrency {
                         "Max concurrency semaphore is never closed, acquire should never fail: {}",
                         e
                     );
-                    res.render(StatusError::payload_too_large().brief("max concurrency reached"));
+                    res.render(
+                        StatusError::service_unavailable().brief("max concurrency reached"),
+                    );
                 }
                 TryAcquireError::NoPermits => {
-                    tracing::error!("no permits: {}", e);
+                    // Hitting the concurrency limit is an expected condition, not
+                    // an error; log it at debug level to avoid log spam.
+                    tracing::debug!("max concurrency reached, rejecting request");
                     res.render(StatusError::too_many_requests().brief("max concurrency reached"));
                 }
             },


### PR DESCRIPTION
## ETag read from the wrong message (main fix)

`ETag`/`CachingHeaders` (`crates/extra/src/caching_headers.rs`) computed the response ETag like this:

```rust
let etag = req.headers().get(ETAG)            // ETag is a RESPONSE header
    .and_then(...).or_else(|| /* compute from res.body */);
```

`ETag` is a response header. Reading it from the **request** lets a client forge an `ETag` request header to drive the `If-None-Match` comparison and force a spurious `304 Not Modified` (client believes content is unchanged when it isn't). Fixed to read any pre-set ETag from the **response**, falling back to computing it from the body. Adds `test_caching_headers_ignores_forged_request_etag`.

## Concurrency limiter (minor)

- The unreachable closed-semaphore branch returned `413 Payload Too Large`; changed to `503 Service Unavailable`.
- A normal concurrency-limit rejection was logged at `error!`; lowered to `debug!` to avoid log spam under load. (Permit handling is unchanged.)

Verified via `cargo test --workspace --all-features --lib` (the feature set under which `salvo_extra` compiles in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)