### PR TITLE
Avoid panic in flash SessionStore when SessionHandler is missing

### DIFF
--- a/crates/flash/src/session_store.rs
+++ b/crates/flash/src/session_store.rs
@@ -44,15 +44,23 @@ impl FlashStore for SessionStore {
         depot.session().and_then(|s| s.get::<Flash>(&self.name))
     }
     async fn save_flash(&self, _req: &mut Request, depot: &mut Depot, _res: &mut Response, flash: Flash) {
-        if let Err(e) = depot
-            .session_mut()
-            .expect("session must exist")
-            .insert(&self.name, flash)
-        {
+        let Some(session) = depot.session_mut() else {
+            tracing::error!(
+                "session is not available in depot; add SessionHandler before FlashHandler<SessionStore>"
+            );
+            return;
+        };
+        if let Err(e) = session.insert(&self.name, flash) {
             tracing::error!(error = ?e, "save flash to session failed");
         }
     }
     async fn clear_flash(&self, _req: &mut Request, depot: &mut Depot, _res: &mut Response) {
-        depot.session_mut().expect("session must exist").remove(&self.name);
+        let Some(session) = depot.session_mut() else {
+            tracing::error!(
+                "session is not available in depot; add SessionHandler before FlashHandler<SessionStore>"
+            );
+            return;
+        };
+        session.remove(&self.name);
     }
 }


### PR DESCRIPTION
`SessionStore::save_flash` / `clear_flash` (`crates/flash/src/session_store.rs`) did:

```rust
depot.session_mut().expect("session must exist")
```

If `FlashHandler<SessionStore>` is mounted without a `SessionHandler` upstream — a config mistake, or a route branch that skips the session middleware — this panics while handling the request.

`salvo-csrf`'s `SessionStore` already handles the same case gracefully (returns an error). This change makes flash consistent: it logs an actionable error ("add SessionHandler before FlashHandler<SessionStore>") and returns instead of panicking. The `FlashStore` trait methods return `()`, so graceful logging is the closest equivalent to csrf's `Err`.

`cargo test -p salvo-flash --lib` → 55 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)