### PR TITLE
Preserve JSON body errors and avoid panic on unknown source parser

### DIFF
--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -246,7 +246,9 @@ impl<'de> RequestDeserializer<'de> {
                 };
                 let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(s));
                 seed.deserialize(&mut de)
-                    .map_err(|_| ValError::custom("parse value error"))
+                    // Preserve the underlying serde_json error (line/column and the
+                    // expected/actual type) instead of a generic message.
+                    .map_err(ValError::custom)
             } else if let Some(value) = self.field_str_value.take() {
                 seed.deserialize(CowValue(value))
             } else if let Some(value) = self.field_vec_value.take() {
@@ -453,7 +455,11 @@ impl<'de> RequestDeserializer<'de> {
                             return false;
                         }
                         _ => {
-                            panic!("unsupported source parser: {parser:?}");
+                            // `Source` and `Metadata` are public API, so a caller
+                            // can construct an unsupported (from, parser) pair.
+                            // Skip the field instead of panicking.
+                            tracing::error!(?parser, "unsupported source parser");
+                            return false;
                         }
                     }
                 }


### PR DESCRIPTION
Two issues in `crates/core/src/serde/request.rs`.

### Discarded JSON error detail
A failed JSON body value deserialization did `.map_err(|_| ValError::custom("parse value error"))`, throwing away serde_json's line/column and expected-vs-actual type information — making request-parsing failures hard to debug. Now forwards the original error via `ValError::custom(e)`.

### Panic reachable from public API
The catch-all `(source, parser)` match arm was `panic!("unsupported source parser: ...")`. `Source` and `Metadata` are public API, so a caller can construct an unsupported combination (e.g. `SourceFrom::Body` + `SourceParser::Flat`) and trigger a panic from library code. Now logs an error and skips the field (`return false`).

`cargo test -p salvo_core --lib serde` → 27 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)