### PR TITLE
Fix incorrect error messages and doc comments across crates

### DIFF
--- a/crates/cache/src/moka_store.rs
+++ b/crates/cache/src/moka_store.rs
@@ -98,7 +98,7 @@ where
         }
     }
 }
-/// A simple in-memory store for rate limiter.
+/// A simple in-memory store for the cache.
 pub struct MokaStore<K> {
     inner: MokaCache<K, CachedEntry>,
 }

--- a/crates/core/src/http/body/channel.rs
+++ b/crates/core/src/http/body/channel.rs
@@ -62,10 +62,10 @@ impl BodySender {
     /// Send trailers on trailers channel.
     pub async fn send_trailers(&mut self, trailers: HeaderMap) -> IoResult<()> {
         let Some(tx) = self.trailers_tx.take() else {
-            return Err(IoError::other("failed to send railers"));
+            return Err(IoError::other("failed to send trailers"));
         };
         tx.send(trailers)
-            .map_err(|_| IoError::other("failed to send railers"))
+            .map_err(|_| IoError::other("failed to send trailers"))
     }
 
     /// Send error on data channel.

--- a/crates/core/src/http/body/req.rs
+++ b/crates/core/src/http/body/req.rs
@@ -180,7 +180,7 @@ impl TryFrom<ReqBody> for Incoming {
                 "ReqBody::None cannot convert to Incoming",
             )),
             ReqBody::Once(_) => Err(crate::Error::other(
-                "ReqBody::Bytes cannot convert to Incoming",
+                "ReqBody::Once cannot convert to Incoming",
             )),
             ReqBody::Hyper { inner, .. } => Ok(inner),
             ReqBody::Boxed { .. } => Err(crate::Error::other(

--- a/crates/csrf/src/finder.rs
+++ b/crates/csrf/src/finder.rs
@@ -60,7 +60,7 @@ pub struct JsonFinder {
     field_name: String,
 }
 impl JsonFinder {
-    /// Creates a new `FormFinder`.
+    /// Creates a new `JsonFinder`.
     #[inline]
     pub fn new(field_name: impl Into<String>) -> Self {
         Self {

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -146,7 +146,7 @@ impl ConstDecoder {
         )
     }
 
-    /// If you know what you're doing and have a RSA EC encoded public key, use this.
+    /// If you know what you're doing and have an EC DER encoded public key, use this.
     #[must_use]
     pub fn from_ec_der(der: &[u8]) -> Self {
         Self::with_validation(

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -449,6 +449,6 @@ fn parse_path_or_lit_str(expr: &Expr) -> syn::Result<String> {
             lit: Lit::Str(s), ..
         }) => Ok(s.value()),
         Expr::Path(ExprPath { path, .. }) => Ok(path.require_ident()?.to_string()),
-        _ => Err(Error::new_spanned(expr, "invalid indent or lit str")),
+        _ => Err(Error::new_spanned(expr, "invalid ident or lit str")),
     }
 }

--- a/crates/oapi-macros/src/feature.rs
+++ b/crates/oapi-macros/src/feature.rs
@@ -188,7 +188,7 @@ impl Feature {
                     "multiple_of",
                     "maximum",
                     "minimum",
-                    "exclusive_<aximum",
+                    "exclusive_maximum",
                     "exclusive_minimum",
                     "max_length",
                     "min_length",

--- a/crates/oapi-macros/src/parse_utils.rs
+++ b/crates/oapi-macros/src/parse_utils.rs
@@ -147,7 +147,7 @@ pub(crate) fn parse_path_or_lit_str(input: ParseStream) -> syn::Result<String> {
     } else if let Ok(lit) = input.parse::<LitStr>() {
         Ok(lit.value())
     } else {
-        Err(syn::Error::new(input.span(), "invalid indent or lit str"))
+        Err(syn::Error::new(input.span(), "invalid ident or lit str"))
     }
 }
 


### PR DESCRIPTION
Purely textual corrections — no behavior change.

| Location | Before | After |
| --- | --- | --- |
| `core` `http/body/channel.rs` (x2) | `failed to send railers` | `failed to send trailers` |
| `core` `http/body/req.rs` | `ReqBody::Bytes cannot convert to Incoming` | `ReqBody::Once ...` (the `Once` arm) |
| `jwt-auth` `decoder.rs` | `from_ec_der` doc: "RSA EC encoded public key" | "EC DER encoded public key" |
| `csrf` `finder.rs` | `JsonFinder::new` doc: "Creates a new `FormFinder`." | "...`JsonFinder`." |
| `oapi-macros` `feature.rs` | expected-attr list `exclusive_<aximum` | `exclusive_maximum` |
| `oapi-macros` `parse_utils.rs` / `macros` `extract.rs` | `invalid indent or lit str` | `invalid ident or lit str` |
| `cache` `moka_store.rs` | `MokaStore` doc: "store for rate limiter" | "store for the cache" |

Affected crates build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)