### PR TITLE
Fix request_body = ref(Type) generating uncompilable code

### DIFF
--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -184,4 +184,31 @@ mod tests {
         let attr = parse_str::<EndpointAttr>(input).unwrap();
         assert!(attr.request_body.is_some());
     }
+
+    #[test]
+    fn test_request_body_ref_generates_to_schema() {
+        use proc_macro2::TokenStream;
+
+        use crate::shared::TryToTokens;
+
+        // Regression: `request_body = ref(Type)` previously generated a call to
+        // `Schema::to_schema`, but `Schema` is an enum without that method, so the
+        // documented feature failed to compile. It must use the `ToSchema` trait
+        // (matching the response `ref(...)` path).
+        let attr = parse_str::<EndpointAttr>("request_body = ref(PetSchema)").unwrap();
+        let body = attr.request_body.expect("request_body parsed");
+        let mut tokens = TokenStream::new();
+        if body.try_to_tokens(&mut tokens).is_err() {
+            panic!("request_body = ref(...) code generation failed");
+        }
+        let generated = tokens.to_string();
+        assert!(
+            generated.contains("ToSchema"),
+            "request_body = ref(...) should call the ToSchema trait: {generated}"
+        );
+        assert!(
+            !generated.contains("schema :: Schema"),
+            "request_body = ref(...) must not reference the Schema enum: {generated}"
+        );
+    }
 }

--- a/crates/oapi-macros/src/operation/request_body.rs
+++ b/crates/oapi-macros/src/operation/request_body.rs
@@ -160,7 +160,7 @@ impl TryToTokens for RequestBodyAttr<'_> {
         if let Some(body_type) = &self.content {
             let media_type_schema = match body_type {
                 PathType::RefPath(ref_type) => quote! {
-                    <#ref_type as #oapi::oapi::schema::Schema>::to_schema(components)
+                    <#ref_type as #oapi::oapi::ToSchema>::to_schema(components)
                 },
                 PathType::MediaType(body_type) => {
                     let type_tree = body_type.as_type_tree()?;


### PR DESCRIPTION
`#[endpoint(request_body = ref(Type))]` (`crates/oapi-macros/src/operation/request_body.rs`) generated:

```rust
<#ref_type as #oapi::oapi::schema::Schema>::to_schema(components)
```

But `schema::Schema` is an **enum** with no `to_schema` method — the documented `ref(...)` request-body feature fails to compile. The response side already uses the correct trait (`response.rs:322`: `<#ref_type as #oapi::oapi::ToSchema>::to_schema(...)`).

Switched the request-body `RefPath` arm to `ToSchema`. The existing `test_parse_request_body_ref*` tests only covered **parsing** (which is why the codegen bug slipped through); this adds `test_request_body_ref_generates_to_schema`, which runs `try_to_tokens` and asserts the emitted code calls `ToSchema` and never references the `Schema` enum.

`cargo test -p salvo-oapi-macros --lib` → passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)