### PR TITLE
Use resolved salvo crate path in generic Extractible derive bounds

### DIFF
--- a/crates/core/src/serde.rs
+++ b/crates/core/src/serde.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
 use std::hash::Hash;
 
+// Re-exported so macro-generated code (e.g. `#[derive(Extractible)]` bounds on
+// generic parameters) can reference `Deserialize` through the resolved salvo
+// crate path instead of assuming a top-level `serde` dependency.
+pub use serde::de::Deserialize;
 pub use serde::de::value::{Error as ValError, MapDeserializer, SeqDeserializer};
 use serde::de::{
-    Deserialize, DeserializeSeed, EnumAccess, Error as DeError, IntoDeserializer, VariantAccess,
-    Visitor,
+    DeserializeSeed, EnumAccess, Error as DeError, IntoDeserializer, VariantAccess, Visitor,
 };
 
 mod request;

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -264,7 +264,7 @@ pub(crate) fn generate(args: DeriveInput) -> Result<TokenStream, Error> {
     let where_predicate = args.generics.type_params().map(|t| {
         let ty = &t.ident;
         quote! {
-            #ty: salvo::extract::Extractible<'__macro_gen_ex> + ::serde::de::Deserialize<'__macro_gen_ex>,
+            #ty: #salvo::extract::Extractible<'__macro_gen_ex> + #salvo::serde::Deserialize<'__macro_gen_ex>,
         }
     }).collect::<Punctuated<_, Token![,]>>();
 


### PR DESCRIPTION
## Problem

The generated `where` predicate for generic `#[derive(Extractible)]` type parameters (`crates/macros/src/extract.rs`) was hardcoded:

```rust
#ty: salvo::extract::Extractible<'…> + ::serde::de::Deserialize<'…>,
```

Every other reference in the derive uses the crate resolved by `salvo_crate()` (`#salvo`). The literal `salvo` happens to resolve in two contexts that hide the bug:
- inside `salvo_core` itself (`crates/core/src/lib.rs:37` has `extern crate self as salvo;`), which is why the existing `test_generic_struct` compiles;
- inside the `salvo` umbrella crate.

But a **third-party crate depending on `salvo_core` directly** (or one that renames the `salvo` dependency) gets `unresolved crate or module 'salvo'`, so deriving `Extractible` on any generic struct fails to compile.

## Fix

- Emit the bounds via `#salvo::extract::Extractible` and `#salvo::serde::Deserialize`, matching the rest of the generated code.
- Re-export `Deserialize` from `salvo_core::serde` (next to the existing `pub use serde::de::value::…`) so `#salvo::serde::Deserialize` resolves through whichever crate path is in use.

`test_generic_struct` (a generic `Outer<T>`) exercises both bounds — now resolving to `salvo_core::extract::Extractible` / `salvo_core::serde::Deserialize`. `cargo test -p salvo_core --lib` → 196 passed; `-p salvo_macros` → 5 passed; clippy clean.

(A fail-on-old test can't be expressed inside this workspace because both `salvo_core`'s self-alias and the real `salvo` crate make the literal `salvo::` resolve.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)