### PR TITLE
Stop reflecting Access-Control-Request-Headers in tus preflight

### DIFF
--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -25,7 +25,7 @@ use crate::{H_TUS_RESUMABLE, TUS_VERSION};
 
 pub(crate) const EXPOSE_HEADERS: &str = "Location, Upload-Offset, Upload-Length, Upload-Metadata, Upload-Expires, Tus-Resumable, Tus-Version, Tus-Extension, Tus-Max-Size";
 pub(crate) const DEFAULT_ALLOW_HEADERS: &str =
-    "Tus-Resumable, Upload-Length, Upload-Offset, Upload-Metadata, Content-Type, Content-Length";
+    "Tus-Resumable, Upload-Length, Upload-Defer-Length, Upload-Offset, Upload-Metadata, Upload-Concat, Content-Type, Content-Length";
 
 pub(crate) fn apply_common_headers<'a>(
     req: &Request,

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -7,8 +7,7 @@ use crate::handlers::{DEFAULT_ALLOW_HEADERS, apply_options_headers, insert_joine
 use crate::stores::Extension;
 use crate::{
     H_ACCESS_CONTROL_ALLOW_HEADERS, H_ACCESS_CONTROL_ALLOW_METHODS, H_ACCESS_CONTROL_MAX_AGE,
-    H_ACCESS_CONTROL_REQUEST_HEADERS, H_TUS_EXTENSION, H_TUS_MAX_SIZE, H_TUS_VERSION, TUS_VERSION,
-    Tus,
+    H_TUS_EXTENSION, H_TUS_MAX_SIZE, H_TUS_VERSION, TUS_VERSION, Tus,
 };
 
 #[handler]
@@ -41,16 +40,11 @@ async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             DEFAULT_ALLOW_HEADERS,
             &opts.allowed_headers,
         );
-    } else if let Some(h) = req
-        .headers()
-        .get(H_ACCESS_CONTROL_REQUEST_HEADERS)
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Ok(v) = HeaderValue::from_str(h) {
-            headers.insert(H_ACCESS_CONTROL_ALLOW_HEADERS, v);
-        }
     } else {
-        // fallback allow list
+        // Advertise a fixed allow-list instead of reflecting the client's
+        // `Access-Control-Request-Headers`. Echoing that header back unchanged
+        // mirrors arbitrary attacker-chosen header names and, combined with
+        // origin reflection, widens the CORS attack surface.
         headers.insert(
             H_ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static(DEFAULT_ALLOW_HEADERS),


### PR DESCRIPTION
In `crates/tus/src/handlers/options.rs`, when no `allowed_headers` were configured the OPTIONS preflight handler reflected the client's `Access-Control-Request-Headers` value directly into `Access-Control-Allow-Headers`:

```rust
} else if let Some(h) = req.headers().get(H_ACCESS_CONTROL_REQUEST_HEADERS)... {
    headers.insert(H_ACCESS_CONTROL_ALLOW_HEADERS, v); // echoes arbitrary header names
} else { /* DEFAULT_ALLOW_HEADERS */ }
```

Echoing the request header back unchanged mirrors arbitrary attacker-chosen header names, and combined with origin reflection (#1554) widens the CORS attack surface. The handler now always advertises the fixed `DEFAULT_ALLOW_HEADERS` allow-list when no explicit `allowed_headers` are set; configuring `allowed_headers` is unchanged. (Removed the now-unused `H_ACCESS_CONTROL_REQUEST_HEADERS` import.)

`cargo test -p salvo-tus --lib` → 238 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)