### PR TITLE
Simplify BcryptCipher URL-safe rewriting and drop dead code

### DIFF
--- a/crates/csrf/src/bcrypt_cipher.rs
+++ b/crates/csrf/src/bcrypt_cipher.rs
@@ -53,16 +53,18 @@ impl CsrfCipher for BcryptCipher {
             .decode(token.as_bytes())
             .unwrap_or_else(|_| vec![0u8; self.token_size]);
 
-        let proof = proof.replace('_', "/").replace('-', "+");
+        // bcrypt hashes only use the `./0-9A-Za-z$` alphabet; `generate` rewrites
+        // `/` to `_` for URL safety, so the inverse here is just `_` -> `/`.
+        let proof = proof.replace('_', "/");
 
         // Always perform bcrypt verification to maintain constant time
         bcrypt::verify(&token_bytes, &proof).unwrap_or(false)
     }
     fn generate(&self) -> (String, String) {
         let token = self.random_bytes(self.token_size);
+        // bcrypt output never contains `+`; only `/` needs URL-safe rewriting.
         let proof = bcrypt::hash(&token, self.cost)
             .expect("bcrypt hash failed")
-            .replace('+', "/")
             .replace('/', "_");
 
         (URL_SAFE_NO_PAD.encode(token), proof)


### PR DESCRIPTION
`BcryptCipher::generate` (`crates/csrf/src/bcrypt_cipher.rs`) did:

```rust
bcrypt::hash(..)?.replace('+', "/").replace('/', "_")
```

The chained replaces fold **both** original `+` and original `/` into `_` for any input containing `+`, while `verify` only reverses `_` -> `/` (and a dead `-` -> `+`). Because bcrypt output uses the `./0-9A-Za-z$` alphabet — never `+` or `-` — the round trip works today, but the asymmetric `+`/`-` handling is dead and misleading (and would silently corrupt data if reused for a different encoding).

Keeps only the `/` <-> `_` mapping bcrypt actually needs. Behavior is unchanged for real bcrypt hashes; the existing generate/verify round-trip test still passes (9 bcrypt tests pass, clippy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)