### PR TITLE
Set HMAC algorithm explicitly for ConstDecoder secret constructors

### DIFF
--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -195,4 +195,13 @@ mod tests {
 
         assert_eq!(decoder.validation.algorithms, [Algorithm::RS256]);
     }
+
+    #[test]
+    fn secret_constructors_pin_hs256() {
+        let decoder = ConstDecoder::from_secret(b"secret");
+        assert_eq!(decoder.validation.algorithms, [Algorithm::HS256]);
+
+        let decoder = ConstDecoder::from_base64_secret("c2VjcmV0").unwrap();
+        assert_eq!(decoder.validation.algorithms, [Algorithm::HS256]);
+    }
 }

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -85,13 +85,16 @@ impl ConstDecoder {
     /// This is the most common method for symmetric key validation.
     #[must_use]
     pub fn from_secret(secret: &[u8]) -> Self {
-        Self::with_validation(DecodingKey::from_secret(secret), Validation::default())
+        Self::with_validation(
+            DecodingKey::from_secret(secret),
+            Validation::new(Algorithm::HS256),
+        )
     }
 
     /// Creates a decoder from a base64-encoded secret string for HMAC verification.
     pub fn from_base64_secret(secret: &str) -> Result<Self, JwtError> {
         DecodingKey::from_base64_secret(secret)
-            .map(|key| Self::with_validation(key, Validation::default()))
+            .map(|key| Self::with_validation(key, Validation::new(Algorithm::HS256)))
     }
 
     /// Creates a decoder from an RSA public key in PEM format.


### PR DESCRIPTION
`ConstDecoder::from_secret` / `from_base64_secret` (`crates/jwt-auth/src/decoder.rs`) created their `Validation` via `Validation::default()`, relying on jsonwebtoken's default `algorithms` value (`[HS256]`). Every other constructor pins the algorithm explicitly (`Validation::new(Algorithm::RS256)`, etc.).

For a security-sensitive crate, the symmetric path should be explicit too, so the accepted-algorithm set doesn't silently depend on an upstream default (defense against algorithm confusion). Switched to `Validation::new(Algorithm::HS256)`.

Behavior is unchanged for the current jsonwebtoken default. `cargo test -p salvo-jwt-auth --lib` → 61 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)