### PR TITLE
Strengthen brotli encoder test to cover stream finalization

### DIFF
--- a/crates/compression/src/encoder.rs
+++ b/crates/compression/src/encoder.rs
@@ -214,6 +214,27 @@ mod tests {
         assert_eq!(decompressed, *b"hello");
     }
 
+    #[cfg(feature = "brotli")]
+    #[test]
+    fn test_brotli_encoder_finishes_multiblock_stream() {
+        use brotli::Decompressor;
+        // Larger-than-buffer input written in several chunks, so `finish` must
+        // emit a complete (finalized) brotli stream. `read_to_end` fully decodes
+        // it and fails if the terminating block is missing.
+        let input: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let mut encoder = Encoder::new(CompressionAlgo::Brotli, CompressionLevel::Default);
+        for chunk in input.chunks(7000) {
+            encoder.write(chunk).unwrap();
+        }
+        let compressed = encoder.finish().unwrap();
+
+        let mut decompressed = Vec::new();
+        Decompressor::new(&compressed[..], 4096)
+            .read_to_end(&mut decompressed)
+            .expect("brotli stream should be a complete, decodable stream");
+        assert_eq!(decompressed, input);
+    }
+
     #[cfg(feature = "deflate")]
     #[test]
     fn test_deflate_encoder() {


### PR DESCRIPTION
While investigating a report that brotli's `finish` (`crates/compression/src/encoder.rs`) might emit an incomplete stream (it uses `flush()` + `into_inner()` rather than an explicit `finish()` like the other encoders), I added a stronger test and **confirmed the current code is correct** — `brotli::CompressorWriter::into_inner()` finalizes the stream.

The existing `test_brotli_encoder` compressed only `"hello"` and decoded with `read_exact(5)`, which succeeds even from a non-finalized stream, so it couldn't have caught a missing terminating block. This adds `test_brotli_encoder_finishes_multiblock_stream`: 200 KB written in several chunks and decoded with `read_to_end`, which fully validates the stream is complete.

No behavior change — this is a regression guard only. `cargo test -p salvo-compression --features full --lib encoder` → 5 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)