### PR TITLE
Format DEFAULT_ALLOW_HEADERS to satisfy nightly rustfmt CI

### DIFF
--- a/crates/tus/src/handlers/mod.rs
+++ b/crates/tus/src/handlers/mod.rs
@@ -24,8 +24,7 @@ use crate::options::TusOptions;
 use crate::{H_TUS_RESUMABLE, TUS_VERSION};
 
 pub(crate) const EXPOSE_HEADERS: &str = "Location, Upload-Offset, Upload-Length, Upload-Metadata, Upload-Expires, Tus-Resumable, Tus-Version, Tus-Extension, Tus-Max-Size";
-pub(crate) const DEFAULT_ALLOW_HEADERS: &str =
-    "Tus-Resumable, Upload-Length, Upload-Defer-Length, Upload-Offset, Upload-Metadata, Upload-Concat, Content-Type, Content-Length";
+pub(crate) const DEFAULT_ALLOW_HEADERS: &str = "Tus-Resumable, Upload-Length, Upload-Defer-Length, Upload-Offset, Upload-Metadata, Upload-Concat, Content-Type, Content-Length";
 
 pub(crate) fn apply_common_headers<'a>(
     req: &Request,


### PR DESCRIPTION
`main` is currently failing the format CI job (`cargo +nightly fmt --all -- --check`).

When #1563 added `Upload-Defer-Length`/`Upload-Concat` to `DEFAULT_ALLOW_HEADERS`, the constant was left wrapped; nightly rustfmt wants it on a single line (matching the adjacent `EXPOSE_HEADERS`). The rustfmt commit was pushed to that PR branch only after it had already merged, so it never reached `main`. This reformats it; `cargo +nightly fmt --all -- --check` is clean again afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)