### PR TITLE
Improve oapi-macros validation diagnostics

### DIFF
--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -25,7 +25,7 @@ pub(crate) struct EndpointAttr<'p> {
 
 impl Parse for EndpointAttr<'_> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        const EXPECTED_ATTRIBUTE_MESSAGE: &str = "unexpected identifier, expected any of: operation_id, path, get, post, put, delete, options, head, patch, trace, connect, request_body, responses, params, tag, security, context_path, description, summary";
+        const EXPECTED_ATTRIBUTE_MESSAGE: &str = "unexpected identifier, expected any of: operation_id, request_body, responses, status_codes, parameters, tags, security, description, summary";
         let mut attr = EndpointAttr::default();
 
         while !input.is_empty() {

--- a/crates/oapi-macros/src/feature/validation.rs
+++ b/crates/oapi-macros/src/feature/validation.rs
@@ -101,7 +101,7 @@ impl Parse for Minimum {
     where
         Self: Sized,
     {
-        parse_number(input).map(|maximum| Self(maximum, ident))
+        parse_number(input).map(|minimum| Self(minimum, ident))
     }
 }
 impl ToTokens for Minimum {
@@ -241,7 +241,7 @@ impl Parse for MinLength {
     where
         Self: Sized,
     {
-        parse_integer(input).map(|max_length| Self(max_length, ident))
+        parse_integer(input).map(|min_length| Self(min_length, ident))
     }
 }
 impl ToTokens for MinLength {
@@ -312,7 +312,9 @@ impl Parse for MaxItems {
     where
         Self: Sized,
     {
-        parse_number(input).map(|max_items| Self(max_items, ident))
+        // `maxItems` is an integer count; use `parse_integer` (like `MaxLength`)
+        // so a float literal is rejected with a clear error.
+        parse_integer(input).map(|max_items| Self(max_items, ident))
     }
 }
 impl ToTokens for MaxItems {
@@ -347,7 +349,9 @@ impl Parse for MinItems {
     where
         Self: Sized,
     {
-        parse_number(input).map(|max_items| Self(max_items, ident))
+        // `minItems` is an integer count; use `parse_integer` (like `MinLength`)
+        // so a float literal is rejected with a clear error.
+        parse_integer(input).map(|min_items| Self(min_items, ident))
     }
 }
 impl ToTokens for MinItems {


### PR DESCRIPTION
Three diagnostic/quality fixes in `oapi-macros` (no schema-output change for valid input).

- **`max_items`/`min_items` accept floats.** They are integer counts but were parsed with `parse_number` (which also accepts float literals), so `max_items = 3.5` produced a confusing downstream error. Switched to `parse_integer` (matching `MaxLength`/`MinLength`), which rejects a float cleanly.
- **Stale endpoint attribute error message.** `EXPECTED_ATTRIBUTE_MESSAGE` listed attributes with no match arm (`path/get/post/.../params/tag/context_path`) and omitted real ones (`status_codes/parameters/tags`). Now lists exactly what the parser accepts: `operation_id, request_body, responses, status_codes, parameters, tags, security, description, summary`.
- **Misleading closure bindings.** `Minimum`/`MinLength`/`MinItems` bound their parsed value as `maximum`/`max_length`/`max_items`; renamed for clarity.

`cargo test -p salvo-oapi-macros --lib` → 89 passed; `cargo test -p salvo-oapi --lib --features non-strict-integers` → 279 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)