### PR TITLE
Strip wildcard capture from path exactly once

### DIFF
--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -466,7 +466,11 @@ impl PathWisp for CombWisp {
                 if let Some(value) = caps.name(name) {
                     state.params.insert(name, value.as_str().to_owned());
                     if self.wild_regex.is_some() {
-                        wild_path = wild_path.trim_start_matches(value.as_str());
+                        // Strip the captured value exactly once. `trim_start_matches`
+                        // removes every leading repetition (e.g. a value of "a"
+                        // would strip all of "aaa…"), corrupting the remaining wild
+                        // path.
+                        wild_path = wild_path.strip_prefix(value.as_str()).unwrap_or(wild_path);
                     }
                     #[cfg(feature = "matched-path")]
                     {


### PR DESCRIPTION
In `PathFilter::detect` (`crates/core/src/routing/filters/path.rs`), after capturing a named value the remaining wild path was trimmed with:

```rust
wild_path = wild_path.trim_start_matches(value.as_str());
```

`trim_start_matches` removes **every** leading repetition of the pattern, not just one. So a captured value of `"a"` against a wild path beginning `"aaa…"` strips all the leading `a`s, corrupting the remainder and any subsequent captures. Replaced with `strip_prefix(...).unwrap_or(wild_path)` to remove the captured value exactly once.

`cargo test -p salvo_core --lib routing::filters::path` → 37 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)