### PR TITLE
Guard tus disk store offset accumulation against overflow

### DIFF
--- a/crates/tus/src/stores/disk.rs
+++ b/crates/tus/src/stores/disk.rs
@@ -539,8 +539,18 @@ impl DataStore for DiskStore {
                 }
                 Err(e) => return Err(TusError::Internal(e.to_string())),
             };
+            // Accumulate with overflow checks: `write` is a public `DataStore`
+            // API and, on the deferred-size path (`meta.size == None`), there is
+            // no upper bound, so an extreme starting offset could otherwise wrap.
+            let new_offset = written
+                .checked_add(chunk.len() as u64)
+                .and_then(|w| original_offset.checked_add(w));
+            let Some(new_offset) = new_offset else {
+                let _ = file.set_len(original_offset).await;
+                return Err(TusError::PayloadTooLarge);
+            };
             if let Some(size) = meta.size
-                && original_offset + written + chunk.len() as u64 > size
+                && new_offset > size
             {
                 let _ = file.set_len(original_offset).await;
                 return Err(TusError::PayloadTooLarge);
@@ -555,7 +565,9 @@ impl DataStore for DiskStore {
             .await
             .map_err(|e| TusError::Internal(e.to_string()))?;
 
-        meta.offset = original_offset + written;
+        // `original_offset + written` was validated each iteration above, so this
+        // cannot overflow; `saturating_add` is a belt-and-braces guard.
+        meta.offset = original_offset.saturating_add(written);
         self.try_finalize_if_complete(&mut meta).await;
         self.write_meta_atomic(&meta).await?;
 


### PR DESCRIPTION
`DiskStore::write` (`crates/tus/src/stores/disk.rs`) is a public `DataStore` API. On the deferred-length path (`meta.size == None`) there is no upper bound on the data, so the offset arithmetic `original_offset + written + chunk.len()` and the final `meta.offset = original_offset + written` could overflow `u64` (debug panic / release wraparound) given an extreme starting `offset`.

Compute the projected offset with `checked_add` and return `PayloadTooLarge` on overflow; the final `meta.offset` then uses `saturating_add` as a belt-and-braces guard (it is already validated each iteration).

`cargo test -p salvo-tus --lib` → 238 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)