### PR TITLE
Avoid panic on spawn_blocking JoinError in FilePart::create

### DIFF
--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -181,10 +181,12 @@ impl FilePart {
     /// deleted once the FilePart object goes out of scope).
     pub async fn create(field: &mut Field<'_>) -> Result<Self, ParseError> {
         // Setup a file to capture the contents.
+        // Map the `JoinError` to a `ParseError` instead of panicking, so a
+        // runtime issue (e.g. shutdown) on this request path doesn't abort.
         let mut path =
             tokio::task::spawn_blocking(|| Builder::new().prefix("salvo_http_multipart").tempdir())
                 .await
-                .expect("Runtime spawn blocking poll error")?
+                .map_err(ParseError::other)??
                 .keep();
         let temp_dir = Some(path.clone());
         let name = field.file_name().map(|s| {


### PR DESCRIPTION
`FilePart::create` (`crates/core/src/http/form.rs`) joined a `spawn_blocking` task with `.expect("Runtime spawn blocking poll error")`, so a `JoinError` (e.g. the runtime shutting down) becomes a panic on the request-handling path — inconsistent with the `?`-based error handling everywhere else in the function (the tempdir's own `io::Error` is already propagated as `ParseError`).

Map the `JoinError` to `ParseError` via `ParseError::other` so it propagates as a normal error.

`cargo test -p salvo_core --lib form` → 12 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)