### PR TITLE
Apply exclude filters to default files and compressed variants

### DIFF
--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -379,7 +379,9 @@ impl StaticDir {
             path: root.to_owned(),
             canonical_path: root.to_owned(),
         };
-        self.resolve_root_path(&synthetic_root, path, false).await
+        // Apply exclude filters here too: default files (e.g. `index.html`) and
+        // compressed variants (e.g. `.gz`) must not bypass `exclude_filters`.
+        self.resolve_root_path(&synthetic_root, path, true).await
     }
 }
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
`StaticDir::resolve_child_path` (`crates/serve-static/src/dir.rs`) resolves default files (e.g. `index.html`) and compressed variants (e.g. `.gz`), but called `resolve_root_path` with `apply_exclude_filters = false`. So a file matched by a configured `exclude(...)` filter could still be reached through the default-file or compressed-variant routes — an exclude bypass.

Pass `true` so exclude filters apply consistently (matching `resolve_relative_path`, which already passes `true`).

`cargo test -p salvo-serve-static --lib` → 7 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)