### PR TITLE
Back off on accept errors to avoid busy-looping the server

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -130,6 +130,7 @@ tokio = { workspace = true, features = [
     "macros",
     "net",
     "rt-multi-thread",
+    "time",
 ] }
 tokio-native-tls = { workspace = true, optional = true }
 tokio-openssl = { workspace = true, optional = true }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -439,6 +439,10 @@ impl<A: Acceptor + Send> Server<A> {
                 }
                 Err(e) => {
                     tracing::error!(error = ?e, "accept connection failed");
+                    // Back off briefly so a persistent accept error (e.g. `EMFILE`
+                    // when the process is out of file descriptors) does not spin
+                    // this loop at 100% CPU and flood the logs.
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                 }
             }
         }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -338,6 +338,10 @@ impl<A: Acceptor + Send> Server<A> {
                             },
                             Err(e) => {
                                 tracing::error!(error = ?e, "accept connection failed");
+                                // Back off briefly so a persistent accept error
+                                // (e.g. `EMFILE` when out of file descriptors) does
+                                // not spin this loop at 100% CPU and flood the logs.
+                                tokio::time::sleep(Duration::from_millis(10)).await;
                             }
                         }
                     }


### PR DESCRIPTION
The accept loop in `crates/core/src/server.rs` logged an accept error and immediately retried:

```rust
Err(e) => { tracing::error!(error = ?e, "accept connection failed"); }
```

A persistent error — most notably `EMFILE`/`ENFILE` when the process is out of file descriptors — makes `accept()` fail instantly on every iteration, spinning the loop at 100% CPU and flooding the logs until descriptors free up. Added a short (10ms) backoff sleep after an accept error so the server degrades gracefully and recovers on its own.

`cargo test -p salvo_core --lib server` → 3 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)