### PR TITLE
Use parsed identifier for #[handler] extractor params

### DIFF
--- a/crates/macros/src/handler.rs
+++ b/crates/macros/src/handler.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
+use quote::quote;
+use syn::ext::IdentExt;
 use syn::{Ident, ImplItem, Item, Pat, ReturnType, Signature, Type};
 
 use crate::shared::*;
@@ -105,15 +106,15 @@ fn handle_fn(salvo: &Ident, sig: &Signature) -> syn::Result<TokenStream> {
                 ));
             }
             InputType::NoReference(pat) => {
-                if let (Pat::Ident(ident), Type::Path(ty)) = (&*pat.pat, &*pat.ty) {
-                    call_args.push(ident.ident.clone());
+                if let (Pat::Ident(pat_ident), Type::Path(ty)) = (&*pat.pat, &*pat.ty) {
+                    let id = pat_ident.ident.clone();
+                    call_args.push(id.clone());
                     let ty = omit_type_path_lifetimes(ty);
-                    let idv = pat.pat.to_token_stream().to_string();
-                    let idv = idv
-                        .rsplit_once(' ')
-                        .map(|(_, v)| v.to_owned())
-                        .unwrap_or(idv);
-                    let id = Ident::new(&idv, Span::call_site());
+                    // Derive the extractor arg name from the parsed identifier
+                    // directly. The previous code re-stringified the whole pattern
+                    // and rebuilt it with `Ident::new`, which panics on a raw
+                    // identifier such as `r#type`. `unraw` drops a leading `r#`.
+                    let idv = id.unraw().to_string();
                     let idv = idv.trim_start_matches('_');
 
                     extract_ts.push(quote!{


### PR DESCRIPTION
For a non-reference handler parameter (an extractor arg), `#[handler]` (`crates/macros/src/handler.rs`) derived the binding identifier like this:

```rust
let idv = pat.pat.to_token_stream().to_string();        // e.g. "mut foo" or "r#type"
let idv = idv.rsplit_once(' ').map(...).unwrap_or(idv); // strip "mut "
let id = Ident::new(&idv, Span::call_site());           // panics on "r#type"
```

`Ident::new("r#type", _)` panics because a raw identifier is not a valid *plain* identifier, so a handler with a parameter named `r#type` (or any raw ident) aborts macro expansion.

The pattern was already destructured as `Pat::Ident(..)`, so use `PatIdent::ident` directly for the binding and `ident.unraw().to_string()` for the extractor arg name. This handles `mut` bindings and raw identifiers correctly without re-parsing a string.

`cargo test -p salvo_macros --lib` → 5 passed; `cargo test -p salvo_core --lib handler` → 3 passed; clippy clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)