### PR TITLE
Harden flatten field lookup against invalid index

### DIFF
--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -204,12 +204,16 @@ impl<'de> RequestDeserializer<'de> {
         T: de::DeserializeSeed<'de>,
     {
         if self.field_flatten {
-            let field = self
-                .metadata
-                .fields
-                .get(self.field_index as usize)
-                .expect("field must exist");
-            let metadata = field.metadata.expect("field's metadata must exist");
+            // `field_index` is an `isize` cursor whose `-1` sentinel means
+            // "before the first field"; guard the conversion so a broken
+            // invariant returns an error instead of indexing with `usize::MAX`.
+            let field = usize::try_from(self.field_index)
+                .ok()
+                .and_then(|index| self.metadata.fields.get(index))
+                .ok_or_else(|| ValError::custom("flatten field index out of range"))?;
+            let Some(metadata) = field.metadata else {
+                return Err(ValError::custom("flatten field has no metadata"));
+            };
             seed.deserialize(RequestDeserializer {
                 params: self.params,
                 queries: self.queries,


### PR DESCRIPTION
The flatten branch of `RequestDeserializer::deserialize_value` (`crates/core/src/serde/request.rs`) did:

```rust
let field = self.metadata.fields.get(self.field_index as usize).expect("field must exist");
let metadata = field.metadata.expect("field's metadata must exist");
```

`field_index` is an `isize` cursor whose `-1` sentinel means "before the first field". If the `MapAccess` call ordering is ever off, `-1 as usize` becomes `usize::MAX`, `get` returns `None`, and `.expect` panics on the request path. Use `usize::try_from` and return a `ValError` (for both the out-of-range index and the missing-metadata case) instead of panicking. Normal flows are unchanged.

`cargo test -p salvo_core --lib serde` → 27 passed, `-- extract` passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)