### PR TITLE
Remove dead wildcard check in path validate

### DIFF
--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -992,16 +992,10 @@ impl PathParser {
         Ok(wisps)
     }
     fn validate(&self, wisps: &[WispKind], all_names: &mut IndexSet<String>) -> Result<(), String> {
-        if !wisps.is_empty() {
-            let wild_name = all_names.iter().find(|v| v.starts_with('*'));
-            if let Some(wild_name) = wild_name {
-                return Err(format!(
-                    "wildcard name `{}` must added at the last in url: `{}`",
-                    wild_name,
-                    self.path.iter().collect::<String>()
-                ));
-            }
-        }
+        // Note: `validate` is only ever called once with an empty `all_names`,
+        // so a wildcard check here would always see an empty set. The real
+        // wildcard-position and duplicate-name validation happens below, after
+        // `all_names` is populated from `wisps`.
         for (index, wisp) in wisps.iter().enumerate() {
             let name = match wisp {
                 WispKind::Named(wisp) => Some(&wisp.0),


### PR DESCRIPTION
`PathParser::validate` (`crates/core/src/routing/filters/path.rs`) opened with:

```rust
if !wisps.is_empty() {
    let wild_name = all_names.iter().find(|v| v.starts_with('*'));
    if let Some(wild_name) = wild_name { return Err(...); }
}
```

`validate` is called exactly once (with a freshly created, empty `all_names`) and is not recursive, so `all_names` is always empty at this point — the branch can never fire. The actual wildcard-position and duplicate-name validation runs afterwards, once `all_names` is populated from `wisps`. Removed the dead block (behavior unchanged).

`cargo test -p salvo_core --lib routing` → 62 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)