### PR TITLE
Converge inconsistent public names (jwt/acme/tus)

### DIFF
--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -70,11 +70,21 @@ impl<T> AcmeListenerBuilder<T> {
     /// Defaults to Let's Encrypt production.
     #[inline]
     #[must_use]
-    pub fn get_directory(self, name: impl Into<String>, url: impl Into<String>) -> Self {
+    pub fn directory(self, name: impl Into<String>, url: impl Into<String>) -> Self {
         Self {
             config_builder: self.config_builder.directory(name, url),
             ..self
         }
+    }
+
+    /// Deprecated alias for [`Self::directory`].
+    ///
+    /// The `get_` prefix was misleading: this is a setter, not a getter.
+    #[deprecated(since = "0.94.0", note = "use `directory` instead")]
+    #[inline]
+    #[must_use]
+    pub fn get_directory(self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        self.directory(name, url)
     }
 
     /// Sets domains.

--- a/crates/jwt-auth/src/finder.rs
+++ b/crates/jwt-auth/src/finder.rs
@@ -45,7 +45,7 @@ pub trait JwtTokenFinder: Send + Sync {
 pub struct HeaderFinder {
     /// Allowed HTTP methods for which this finder should extract tokens.
     /// If the request's method is not in this list, the finder will not attempt extraction.
-    pub cared_methods: Vec<Method>,
+    pub allowed_methods: Vec<Method>,
 
     /// List of headers names to check for Bearer tokens.
     pub header_names: Vec<HeaderName>,
@@ -56,7 +56,7 @@ impl HeaderFinder {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            cared_methods: ALL_METHODS.to_vec(),
+            allowed_methods: ALL_METHODS.to_vec(),
             header_names: vec![AUTHORIZATION],
         }
     }
@@ -78,13 +78,13 @@ impl HeaderFinder {
     /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
     pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
-        &mut self.cared_methods
+        &mut self.allowed_methods
     }
     /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
     pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
-        self.cared_methods = methods;
+        self.allowed_methods = methods;
         self
     }
     /// Deprecated alias for [`Self::allowed_methods_mut`].
@@ -105,7 +105,7 @@ impl HeaderFinder {
 impl JwtTokenFinder for HeaderFinder {
     #[inline]
     async fn find_token(&self, req: &mut Request) -> Option<String> {
-        if self.cared_methods.contains(req.method()) {
+        if self.allowed_methods.contains(req.method()) {
             for header_name in &self.header_names {
                 if let Some(Ok(auth)) = req.headers().get(header_name).map(|auth| auth.to_str())
                     && let Some((scheme, token)) = auth.split_once(' ')
@@ -169,7 +169,7 @@ mod tests {
 #[non_exhaustive]
 pub struct FormFinder {
     /// Allowed HTTP methods for which this finder should extract tokens.
-    pub cared_methods: Vec<Method>,
+    pub allowed_methods: Vec<Method>,
 
     /// Name of the form field containing the token.
     pub field_name: Cow<'static, str>,
@@ -180,19 +180,19 @@ impl FormFinder {
     pub fn new<T: Into<Cow<'static, str>>>(field_name: T) -> Self {
         Self {
             field_name: field_name.into(),
-            cared_methods: ALL_METHODS.to_vec(),
+            allowed_methods: ALL_METHODS.to_vec(),
         }
     }
     /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
     pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
-        &mut self.cared_methods
+        &mut self.allowed_methods
     }
     /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
     pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
-        self.cared_methods = methods;
+        self.allowed_methods = methods;
         self
     }
     /// Deprecated alias for [`Self::allowed_methods_mut`].
@@ -213,7 +213,7 @@ impl FormFinder {
 impl JwtTokenFinder for FormFinder {
     #[inline]
     async fn find_token(&self, req: &mut Request) -> Option<String> {
-        if self.cared_methods.contains(req.method()) {
+        if self.allowed_methods.contains(req.method()) {
             req.form(&self.field_name).await
         } else {
             None
@@ -241,7 +241,7 @@ impl JwtTokenFinder for FormFinder {
 #[non_exhaustive]
 pub struct QueryFinder {
     /// Allowed HTTP methods for which this finder should extract tokens.
-    pub cared_methods: Vec<Method>,
+    pub allowed_methods: Vec<Method>,
 
     /// Name of the query parameter containing the token.
     pub query_name: Cow<'static, str>,
@@ -252,19 +252,19 @@ impl QueryFinder {
     pub fn new<T: Into<Cow<'static, str>>>(query_name: T) -> Self {
         Self {
             query_name: query_name.into(),
-            cared_methods: ALL_METHODS.to_vec(),
+            allowed_methods: ALL_METHODS.to_vec(),
         }
     }
     /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
     pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
-        &mut self.cared_methods
+        &mut self.allowed_methods
     }
     /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
     pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
-        self.cared_methods = methods;
+        self.allowed_methods = methods;
         self
     }
     /// Deprecated alias for [`Self::allowed_methods_mut`].
@@ -286,7 +286,7 @@ impl QueryFinder {
 impl JwtTokenFinder for QueryFinder {
     #[inline]
     async fn find_token(&self, req: &mut Request) -> Option<String> {
-        if self.cared_methods.contains(req.method()) {
+        if self.allowed_methods.contains(req.method()) {
             req.query(&self.query_name)
         } else {
             None
@@ -314,7 +314,7 @@ impl JwtTokenFinder for QueryFinder {
 #[non_exhaustive]
 pub struct CookieFinder {
     /// Allowed HTTP methods for which this finder should extract tokens.
-    pub cared_methods: Vec<Method>,
+    pub allowed_methods: Vec<Method>,
 
     /// Name of the cookie containing the token.
     pub cookie_name: Cow<'static, str>,
@@ -325,19 +325,19 @@ impl CookieFinder {
     pub fn new<T: Into<Cow<'static, str>>>(cookie_name: T) -> Self {
         Self {
             cookie_name: cookie_name.into(),
-            cared_methods: ALL_METHODS.to_vec(),
+            allowed_methods: ALL_METHODS.to_vec(),
         }
     }
     /// Returns a mutable reference to the allowed HTTP methods.
     #[inline]
     pub fn allowed_methods_mut(&mut self) -> &mut Vec<Method> {
-        &mut self.cared_methods
+        &mut self.allowed_methods
     }
     /// Sets the allowed HTTP methods and returns `Self`.
     #[inline]
     #[must_use]
     pub fn allowed_methods(mut self, methods: Vec<Method>) -> Self {
-        self.cared_methods = methods;
+        self.allowed_methods = methods;
         self
     }
     /// Deprecated alias for [`Self::allowed_methods_mut`].
@@ -358,7 +358,7 @@ impl CookieFinder {
 impl JwtTokenFinder for CookieFinder {
     #[inline]
     async fn find_token(&self, req: &mut Request) -> Option<String> {
-        if self.cared_methods.contains(req.method()) {
+        if self.allowed_methods.contains(req.method()) {
             req.cookie(&self.cookie_name).map(|c| c.value().to_owned())
         } else {
             None

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -561,16 +561,16 @@ mod tests {
     #[test]
     fn test_header_finder_new() {
         let finder = HeaderFinder::new();
-        assert_eq!(finder.cared_methods.len(), 9); // All methods
+        assert_eq!(finder.allowed_methods.len(), 9); // All methods
         assert_eq!(finder.header_names.len(), 1); // Authorization
     }
 
     #[test]
     fn test_header_finder_allowed_methods() {
         let finder = HeaderFinder::new().allowed_methods(vec![Method::GET, Method::POST]);
-        assert_eq!(finder.cared_methods.len(), 2);
-        assert!(finder.cared_methods.contains(&Method::GET));
-        assert!(finder.cared_methods.contains(&Method::POST));
+        assert_eq!(finder.allowed_methods.len(), 2);
+        assert!(finder.allowed_methods.contains(&Method::GET));
+        assert!(finder.allowed_methods.contains(&Method::POST));
     }
 
     #[test]
@@ -596,7 +596,7 @@ mod tests {
     fn test_query_finder_new() {
         let finder = QueryFinder::new("token");
         assert_eq!(finder.query_name, "token");
-        assert_eq!(finder.cared_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), 9);
     }
 
     #[test]
@@ -614,8 +614,8 @@ mod tests {
     #[test]
     fn test_query_finder_allowed_methods() {
         let finder = QueryFinder::new("token").allowed_methods(vec![Method::GET]);
-        assert_eq!(finder.cared_methods.len(), 1);
-        assert!(finder.cared_methods.contains(&Method::GET));
+        assert_eq!(finder.allowed_methods.len(), 1);
+        assert!(finder.allowed_methods.contains(&Method::GET));
     }
 
     // ==================== CookieFinder Tests ====================
@@ -624,20 +624,20 @@ mod tests {
     fn test_cookie_finder_new() {
         let finder = CookieFinder::new("session");
         assert_eq!(finder.cookie_name, "session");
-        assert_eq!(finder.cared_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), 9);
     }
 
     #[test]
     fn test_cookie_finder_allowed_methods() {
         let finder = CookieFinder::new("jwt").allowed_methods(vec![Method::GET, Method::POST]);
-        assert_eq!(finder.cared_methods.len(), 2);
+        assert_eq!(finder.allowed_methods.len(), 2);
     }
 
     #[test]
     fn test_cookie_finder_mut_methods() {
         let mut finder = CookieFinder::new("token");
         finder.allowed_methods_mut().clear();
-        assert!(finder.cared_methods.is_empty());
+        assert!(finder.allowed_methods.is_empty());
     }
 
     // ==================== FormFinder Tests ====================
@@ -646,14 +646,14 @@ mod tests {
     fn test_form_finder_new() {
         let finder = FormFinder::new("token");
         assert_eq!(finder.field_name, "token");
-        assert_eq!(finder.cared_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), 9);
     }
 
     #[test]
     fn test_form_finder_allowed_methods() {
         let finder = FormFinder::new("access_token").allowed_methods(vec![Method::POST]);
-        assert_eq!(finder.cared_methods.len(), 1);
-        assert!(finder.cared_methods.contains(&Method::POST));
+        assert_eq!(finder.allowed_methods.len(), 1);
+        assert!(finder.allowed_methods.contains(&Method::POST));
     }
 
     // ==================== JwtAuthState Tests ====================

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -17,10 +17,11 @@ use crate::utils::is_safe_upload_id;
 /// Optional tus upload ID passed to size and URL callbacks.
 pub type MaybeUploadId = Option<String>;
 
-/// Optional tus upload ID passed to size and URL callbacks.
+/// Deprecated alias for [`MaybeUploadId`].
 ///
-/// This alias is kept for compatibility. New internal code should prefer
-/// [`MaybeUploadId`] when the optional nature matters at the call site.
+/// The name was misleading — it is `Option<String>`, not an upload id — and was
+/// identical in meaning to [`MaybeUploadId`]. Use [`MaybeUploadId`] instead.
+#[deprecated(since = "0.94.0", note = "use `MaybeUploadId` instead")]
 pub type UploadId = MaybeUploadId;
 
 static RE_FILE_ID: OnceLock<Regex> = OnceLock::new();
@@ -38,7 +39,7 @@ pub enum MaxSize {
     Fixed(u64),
     /// Callback that computes the maximum number of bytes for each request.
     #[allow(clippy::type_complexity)]
-    Dynamic(Arc<dyn Fn(&Request, UploadId) -> BoxFuture<'static, u64> + Send + Sync>),
+    Dynamic(Arc<dyn Fn(&Request, MaybeUploadId) -> BoxFuture<'static, u64> + Send + Sync>),
 }
 
 impl fmt::Debug for MaxSize {


### PR DESCRIPTION
Three naming clean-ups from the audit. Public-facing renames keep a deprecated alias where one is possible.

### jwt-auth — finder field `cared_methods` → `allowed_methods`
The token finders (`HeaderFinder`, `FormFinder`, `QueryFinder`, `CookieFinder`) exposed a public field `cared_methods`, but the accessor methods had already been migrated to `allowed_methods`/`allowed_methods_mut` (with `cared_methods`/`cared_methods_mut` kept as deprecated method aliases). Renamed the field to match the accessors. (A struct field cannot carry a `#[deprecated]` alias, so direct field access via the old name no longer compiles; the accessor methods are the supported API and are unchanged.)

### acme — `get_directory` → `directory`
`get_directory` is a builder **setter** ("Sets the directory."), so the `get_` prefix was misleading. Renamed to `directory`; `get_directory` remains as a `#[deprecated]` alias.

### tus — deprecate `UploadId`
`UploadId` was a second public alias for `Option<String>`, identical in meaning to `MaybeUploadId` (same summary doc). Marked `UploadId` `#[deprecated]` (with a doc explaining the name was misleading) and switched the internal `MaxSize::Dynamic` signature to `MaybeUploadId`.

`cargo test -p salvo-jwt-auth --lib` → 62 passed; `-p salvo-tus --lib` → 238 passed; acme builds; clippy + nightly-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)