### PR TITLE
Document the trust implication of RequestId overwrite=false

### DIFF
--- a/crates/extra/src/request_id.rs
+++ b/crates/extra/src/request_id.rs
@@ -47,6 +47,11 @@ pub struct RequestId {
     /// The header name used to carry the request id.
     pub header_name: HeaderName,
     /// Whether to overwrite an existing request id. Default is `true`.
+    ///
+    /// When set to `false`, a client-supplied id in the request header is trusted
+    /// and propagated to logs, the response and the depot. Only disable this
+    /// behind a trusted proxy that sets/sanitizes the header, otherwise a client
+    /// can inject arbitrary ids (log forging / trace-correlation confusion).
     pub overwrite: bool,
     /// The generator used to produce request ids.
     pub generator: Box<dyn IdGenerator + Send + Sync>,
@@ -80,6 +85,12 @@ impl RequestId {
     }
 
     /// Set whether to overwrite an existing request id. Default is `true`.
+    ///
+    /// # Security
+    ///
+    /// With `false`, a client-supplied id is trusted and forwarded to logs, the
+    /// response and the depot. Only disable overwriting when a trusted proxy
+    /// sets/sanitizes the header; otherwise clients can inject arbitrary ids.
     #[must_use]
     pub fn overwrite(mut self, overwrite: bool) -> Self {
         self.overwrite = overwrite;


### PR DESCRIPTION
The `RequestId` middleware defaults to `overwrite = true` (it always generates a fresh id). When set to `false`, a **client-supplied** value in the request header is trusted and propagated to logs, the response and the depot — so a client can inject arbitrary request ids (log forging, trace-correlation confusion).

This was undocumented. Adds a security note to both the `overwrite` field and the `overwrite()` builder method explaining that `overwrite=false` should only be used behind a trusted proxy that sets/sanitizes the header. Doc-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)