### PR TITLE
Elide lifetimes via VisitMut instead of regex string rewriting

### DIFF
--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -24,9 +24,8 @@ proc-macro = true
 proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-regex = { workspace = true }
 salvo-serde-util = { workspace = true }
-syn = { workspace = true, features = ["full", "parsing"] }
+syn = { workspace = true, features = ["full", "parsing", "visit-mut"] }
 
 [lints]
 workspace = true

--- a/crates/macros/src/shared.rs
+++ b/crates/macros/src/shared.rs
@@ -72,7 +72,7 @@ pub(crate) fn parse_input_type(input: &FnArg) -> InputType<'_> {
 /// `'static` intact, so the type can be used in an `Extractible` bound without
 /// carrying caller lifetimes. Operates on the AST via [`VisitMut`] rather than
 /// re-parsing a stringified type, which avoids a per-call regex compile, the
-/// previous `'static` mis-rewrite, and the parse `expect` panic.
+/// previous incorrect rewriting of `'static`, and the parse `expect` panic.
 pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
     struct ElideLifetimes {
         elided: syn::Lifetime,

--- a/crates/macros/src/shared.rs
+++ b/crates/macros/src/shared.rs
@@ -1,7 +1,5 @@
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::Span;
-use quote::ToTokens;
-use regex::Regex;
 use syn::{FnArg, Ident, PatType, Receiver, Type, TypePath};
 
 #[allow(dead_code)]
@@ -70,9 +68,51 @@ pub(crate) fn parse_input_type(input: &FnArg) -> InputType<'_> {
     }
 }
 
+/// Replace every named lifetime in a type path with the elided `'_`, leaving
+/// `'static` intact, so the type can be used in an `Extractible` bound without
+/// carrying caller lifetimes. Operates on the AST via [`VisitMut`] rather than
+/// re-parsing a stringified type, which avoids a per-call regex compile, the
+/// previous `'static` mis-rewrite, and the parse `expect` panic.
 pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
-    let reg = Regex::new(r"'\w+").expect("invalid regex");
-    let ty_path = ty_path.into_token_stream().to_string();
-    let ty_path = reg.replace_all(&ty_path, "'_");
-    syn::parse_str(ty_path.as_ref()).expect("invalid type path")
+    struct ElideLifetimes {
+        elided: syn::Lifetime,
+    }
+    impl syn::visit_mut::VisitMut for ElideLifetimes {
+        fn visit_lifetime_mut(&mut self, lifetime: &mut syn::Lifetime) {
+            if lifetime.ident != "static" {
+                *lifetime = self.elided.clone();
+            }
+        }
+    }
+    let mut ty_path = ty_path.clone();
+    syn::visit_mut::VisitMut::visit_type_path_mut(
+        &mut ElideLifetimes {
+            elided: syn::parse_quote!('_),
+        },
+        &mut ty_path,
+    );
+    ty_path
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens;
+    use syn::TypePath;
+
+    use super::omit_type_path_lifetimes;
+
+    fn elide(src: &str) -> String {
+        let ty: TypePath = syn::parse_str(src).unwrap();
+        omit_type_path_lifetimes(&ty)
+            .into_token_stream()
+            .to_string()
+    }
+
+    #[test]
+    fn omit_replaces_named_lifetimes_but_keeps_static() {
+        assert_eq!(elide("QueryParam<'a, T>"), "QueryParam < '_ , T >");
+        assert_eq!(elide("Cow<'static, str>"), "Cow < 'static , str >");
+        assert_eq!(elide("Foo<'a, 'static, T>"), "Foo < '_ , 'static , T >");
+        assert_eq!(elide("Vec<String>"), "Vec < String >");
+    }
 }

--- a/crates/macros/src/shared.rs
+++ b/crates/macros/src/shared.rs
@@ -83,6 +83,13 @@ pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
                 *lifetime = self.elided.clone();
             }
         }
+        fn visit_macro_mut(&mut self, mac: &mut syn::Macro) {
+            // `VisitMut` does not parse macro bodies, so a lifetime carried inside a
+            // type macro (e.g. `JsonBody<borrowed!('a)>`) would otherwise survive.
+            // Rewrite the raw tokens so it is elided like any other.
+            let tokens = std::mem::take(&mut mac.tokens);
+            mac.tokens = elide_lifetimes_in_tokens(tokens, &self.elided);
+        }
     }
     let mut ty_path = ty_path.clone();
     syn::visit_mut::VisitMut::visit_type_path_mut(
@@ -92,6 +99,43 @@ pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
         &mut ty_path,
     );
     ty_path
+}
+
+/// Rewrite lifetime tokens (`'name`, except `'static`) to the elided `'_` inside a
+/// raw token stream, recursing through groups. Used for macro bodies that
+/// [`VisitMut`] does not descend into.
+fn elide_lifetimes_in_tokens(
+    tokens: proc_macro2::TokenStream,
+    elided: &syn::Lifetime,
+) -> proc_macro2::TokenStream {
+    use proc_macro2::{Group, TokenStream, TokenTree};
+    use quote::ToTokens;
+
+    let mut out = TokenStream::new();
+    let mut iter = tokens.into_iter().peekable();
+    while let Some(tt) = iter.next() {
+        match tt {
+            TokenTree::Group(group) => {
+                let inner = elide_lifetimes_in_tokens(group.stream(), elided);
+                let mut new_group = Group::new(group.delimiter(), inner);
+                new_group.set_span(group.span());
+                out.extend([TokenTree::Group(new_group)]);
+            }
+            TokenTree::Punct(punct) if punct.as_char() == '\'' => {
+                // A lifetime is an apostrophe immediately followed by an identifier.
+                if let Some(TokenTree::Ident(ident)) = iter.peek()
+                    && *ident != "static"
+                {
+                    elided.to_tokens(&mut out);
+                    iter.next(); // consume the lifetime name
+                    continue;
+                }
+                out.extend([TokenTree::Punct(punct)]);
+            }
+            other => out.extend([other]),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -114,5 +158,15 @@ mod tests {
         assert_eq!(elide("Cow<'static, str>"), "Cow < 'static , str >");
         assert_eq!(elide("Foo<'a, 'static, T>"), "Foo < '_ , 'static , T >");
         assert_eq!(elide("Vec<String>"), "Vec < String >");
+    }
+
+    #[test]
+    fn omit_rewrites_lifetimes_inside_type_macros() {
+        // `VisitMut` does not descend into macro bodies, so the raw tokens are
+        // rewritten directly; `'static` is still preserved.
+        let out = elide("JsonBody<borrowed!('a, 'static)>");
+        assert!(out.contains("'_"), "{out}");
+        assert!(out.contains("'static"), "{out}");
+        assert!(!out.contains("'a"), "{out}");
     }
 }

--- a/crates/oapi-macros/Cargo.toml
+++ b/crates/oapi-macros/Cargo.toml
@@ -41,7 +41,7 @@ proc-macro-crate = { workspace = true }
 proc-macro2-diagnostics = { workspace = true }
 regex = { workspace = true }
 salvo-serde-util = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits"] }
+syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
 salvo_core = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oapi-macros/src/shared.rs
+++ b/crates/oapi-macros/src/shared.rs
@@ -96,7 +96,7 @@ pub(crate) fn parse_input_type(input: &FnArg) -> InputType<'_> {
 /// `'static` intact, so the type can be used in an `Extractible` bound without
 /// carrying caller lifetimes. Operates on the AST via [`VisitMut`] rather than
 /// re-parsing a stringified type, which avoids a per-call regex compile, the
-/// previous `'static` mis-rewrite, and the parse `expect` panic.
+/// previous incorrect rewriting of `'static`, and the parse `expect` panic.
 pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
     struct ElideLifetimes {
         elided: syn::Lifetime,

--- a/crates/oapi-macros/src/shared.rs
+++ b/crates/oapi-macros/src/shared.rs
@@ -107,6 +107,13 @@ pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
                 *lifetime = self.elided.clone();
             }
         }
+        fn visit_macro_mut(&mut self, mac: &mut syn::Macro) {
+            // `VisitMut` does not parse macro bodies, so a lifetime carried inside a
+            // type macro (e.g. `JsonBody<borrowed!('a)>`) would otherwise survive.
+            // Rewrite the raw tokens so it is elided like any other.
+            let tokens = std::mem::take(&mut mac.tokens);
+            mac.tokens = elide_lifetimes_in_tokens(tokens, &self.elided);
+        }
     }
     let mut ty_path = ty_path.clone();
     syn::visit_mut::VisitMut::visit_type_path_mut(
@@ -116,6 +123,39 @@ pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
         &mut ty_path,
     );
     ty_path
+}
+
+/// Rewrite lifetime tokens (`'name`, except `'static`) to the elided `'_` inside a
+/// raw token stream, recursing through groups. Used for macro bodies that
+/// [`VisitMut`] does not descend into.
+fn elide_lifetimes_in_tokens(tokens: TokenStream, elided: &syn::Lifetime) -> TokenStream {
+    use proc_macro2::TokenTree;
+
+    let mut out = TokenStream::new();
+    let mut iter = tokens.into_iter().peekable();
+    while let Some(tt) = iter.next() {
+        match tt {
+            TokenTree::Group(group) => {
+                let inner = elide_lifetimes_in_tokens(group.stream(), elided);
+                let mut new_group = Group::new(group.delimiter(), inner);
+                new_group.set_span(group.span());
+                out.extend([TokenTree::Group(new_group)]);
+            }
+            TokenTree::Punct(punct) if punct.as_char() == '\'' => {
+                // A lifetime is an apostrophe immediately followed by an identifier.
+                if let Some(TokenTree::Ident(ident)) = iter.peek()
+                    && *ident != "static"
+                {
+                    elided.to_tokens(&mut out);
+                    iter.next(); // consume the lifetime name
+                    continue;
+                }
+                out.extend([TokenTree::Punct(punct)]);
+            }
+            other => out.extend([other]),
+        }
+    }
+    out
 }
 
 pub(crate) trait TryToTokens {
@@ -497,5 +537,15 @@ mod tests {
     #[test]
     fn omit_leaves_lifetime_free_types_untouched() {
         assert_eq!(elide("Vec<String>"), "Vec < String >");
+    }
+
+    #[test]
+    fn omit_rewrites_lifetimes_inside_type_macros() {
+        // `VisitMut` does not descend into macro bodies, so the raw tokens are
+        // rewritten directly; `'static` is still preserved.
+        let out = elide("JsonBody<borrowed!('a, 'static)>");
+        assert!(out.contains("'_"), "{out}");
+        assert!(out.contains("'static"), "{out}");
+        assert!(!out.contains("'a"), "{out}");
     }
 }

--- a/crates/oapi-macros/src/shared.rs
+++ b/crates/oapi-macros/src/shared.rs
@@ -5,7 +5,6 @@ use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Delimiter, Group, Punct, Span, TokenStream};
 use proc_macro2_diagnostics::Diagnostic;
 use quote::{ToTokens, TokenStreamExt, quote};
-use regex::Regex;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
@@ -93,11 +92,30 @@ pub(crate) fn parse_input_type(input: &FnArg) -> InputType<'_> {
     }
 }
 
+/// Replace every named lifetime in a type path with the elided `'_`, leaving
+/// `'static` intact, so the type can be used in an `Extractible` bound without
+/// carrying caller lifetimes. Operates on the AST via [`VisitMut`] rather than
+/// re-parsing a stringified type, which avoids a per-call regex compile, the
+/// previous `'static` mis-rewrite, and the parse `expect` panic.
 pub(crate) fn omit_type_path_lifetimes(ty_path: &TypePath) -> TypePath {
-    let reg = Regex::new(r"'\w+").expect("invalid regex");
-    let ty_path = ty_path.into_token_stream().to_string();
-    let ty_path = reg.replace_all(&ty_path, "'_");
-    syn::parse_str(ty_path.as_ref()).expect("failed to parse type path")
+    struct ElideLifetimes {
+        elided: syn::Lifetime,
+    }
+    impl syn::visit_mut::VisitMut for ElideLifetimes {
+        fn visit_lifetime_mut(&mut self, lifetime: &mut syn::Lifetime) {
+            if lifetime.ident != "static" {
+                *lifetime = self.elided.clone();
+            }
+        }
+    }
+    let mut ty_path = ty_path.clone();
+    syn::visit_mut::VisitMut::visit_type_path_mut(
+        &mut ElideLifetimes {
+            elided: syn::parse_quote!('_),
+        },
+        &mut ty_path,
+    );
+    ty_path
 }
 
 pub(crate) trait TryToTokens {
@@ -446,5 +464,38 @@ pub(crate) struct FieldRename;
 impl Rename for FieldRename {
     fn rename(rule: RenameRule, value: &str) -> String {
         rule.apply_to_field(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens;
+    use syn::TypePath;
+
+    use super::omit_type_path_lifetimes;
+
+    fn elide(src: &str) -> String {
+        let ty: TypePath = syn::parse_str(src).unwrap();
+        omit_type_path_lifetimes(&ty)
+            .into_token_stream()
+            .to_string()
+    }
+
+    #[test]
+    fn omit_replaces_named_lifetimes_with_elided() {
+        assert_eq!(elide("QueryParam<'a, T>"), "QueryParam < '_ , T >");
+        assert_eq!(elide("Foo<'a, 'b, T>"), "Foo < '_ , '_ , T >");
+    }
+
+    #[test]
+    fn omit_keeps_static_lifetime() {
+        assert_eq!(elide("Cow<'static, str>"), "Cow < 'static , str >");
+        // Mixed: only the named lifetime is elided, `'static` is preserved.
+        assert_eq!(elide("Foo<'a, 'static, T>"), "Foo < '_ , 'static , T >");
+    }
+
+    #[test]
+    fn omit_leaves_lifetime_free_types_untouched() {
+        assert_eq!(elide("Vec<String>"), "Vec < String >");
     }
 }


### PR DESCRIPTION
## Problem

`omit_type_path_lifetimes` (duplicated in `salvo_macros` and `salvo-oapi-macros`) anonymized lifetimes by stringifying the type and running a regex:

```rust
let reg = Regex::new(r"'\w+").expect("invalid regex");
let ty_path = ty_path.into_token_stream().to_string();
let ty_path = reg.replace_all(&ty_path, "'_");
syn::parse_str(ty_path.as_ref()).expect("failed to parse type path")
```

Three issues:
1. **Recompiles the regex on every call** (every extractible param of every `#[handler]`/`#[endpoint]`).
2. **Mis-rewrites `'static`** — `'\w+` matches `'static` too, silently turning `Cow<'static, str>` into `Cow<'_, str>`.
3. **Panics** via `expect` if the round-tripped string fails to re-parse.

## Fix

Walk the cloned AST with a `syn::visit_mut::VisitMut` pass and replace each named lifetime with the elided `'_`, leaving `'static` untouched. No stringification, no regex, no panic path.

`regex` was the **only** dependency use in `salvo_macros`, so it is removed from that crate's `Cargo.toml`. `salvo-oapi-macros` keeps `regex` (still used by `schema_type.rs`). Both crates enable syn's `visit-mut` feature.

## Tests
New unit tests in both crates cover:
- `QueryParam<'a, T>` → `QueryParam<'_, T>`
- `Cow<'static, str>` → unchanged
- `Foo<'a, 'static, T>` → `Foo<'_, 'static, T>` (mixed)
- `Vec<String>` → unchanged

## Verification
- `cargo test -p salvo_macros -p salvo-oapi-macros` — all pass.
- `cargo build -p salvo_core --all-features --tests` — passes (`#[handler]` expansion).
- `cargo tree -p salvo_macros -i regex` — regex no longer in the tree.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)