### PR TITLE
docs(core): fix alt-svc format example in `auto_alt_svc_header`

### DIFF
--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -74,7 +74,7 @@ impl Builder {
     ///
     /// The automatically generated header follows this format:
     /// ```text
-    /// h3="{port}"; ma=2592000,h3-29="{port}"; ma=2592000
+    /// h3=":{port}"; ma=2592000,h3-29=":{port}"; ma=2592000
     /// ```
     ///
     /// By default, this is set to `true`.


### PR DESCRIPTION
Follow-up to #1585.

The doc example for `quinn::Builder::auto_alt_svc_header` omitted the leading colon before the port:

```text
h3="{port}"; ...
```

but the header actually produced in `server.rs` is `h3=":{port}"; ...`. This aligns the doc example with the real output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)