### PR TITLE
Bind the csrf token by value instead of borrowing a temporary

### DIFF
--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -347,9 +347,9 @@ impl<C: CsrfCipher, S: CsrfStore> Handler for Csrf<C, S> {
         match self.store.load(req, depot, &self.cipher).await {
             Some((current_token, proof)) => {
                 if !skipped {
-                    if let Some(token) = &self.find_token(req).await {
+                    if let Some(token) = self.find_token(req).await {
                         tracing::debug!("csrf token found in request");
-                        if !self.cipher.verify(token, &proof) {
+                        if !self.cipher.verify(&token, &proof) {
                             tracing::debug!(
                                 "rejecting request due to invalid or expired csrf token"
                             );


### PR DESCRIPTION
## What

`CsrfFinder::find_token` returns an owned `Option<String>`, but `Csrf::handle` matched on a reference to the temporary:

```rust
if let Some(token) = &self.find_token(req).await {
    if !self.cipher.verify(token, &proof) { ... }
```

Binding `token` by value is clearer and idiomatic; `verify` takes `&str`, so the call passes `&token`. No behavior change.

## Verification
- `cargo build/clippy -p salvo-csrf --all-features` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)