### PR TITLE
Document open-redirect risk and fallible Redirect construction

### DIFF
--- a/crates/core/src/writing/redirect.rs
+++ b/crates/core/src/writing/redirect.rs
@@ -38,6 +38,18 @@ const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
 /// characters (e.g., Chinese characters, emoji), so both pre-encoded and
 /// unencoded URLs are accepted.
 ///
+/// # Security
+///
+/// Never build a redirect target directly from untrusted input (a query
+/// parameter, form field, `Referer`, etc.) without validating it first.
+/// Redirecting to an attacker-controlled URL is an [open redirect][owasp],
+/// commonly abused for phishing and for laundering OAuth/SSO callbacks. When
+/// the destination comes from the client, restrict it to a known allowlist or
+/// to same-origin paths (e.g. require it to start with a single `/` and reject
+/// `//`, scheme-relative, and absolute URLs) before constructing the redirect.
+///
+/// [owasp]: https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+///
 /// # Example
 ///
 /// ```
@@ -75,7 +87,8 @@ impl Redirect {
     ///
     /// # Panics
     ///
-    /// If `uri` isn't a valid header value after percent-encoding.
+    /// If `uri` isn't a valid header value after percent-encoding. Use
+    /// [`Redirect::with_status_code`] for a fallible, non-panicking variant.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
     pub fn other(uri: impl AsRef<str>) -> Self {
@@ -86,7 +99,8 @@ impl Redirect {
     ///
     /// # Panics
     ///
-    /// If `uri` isn't a valid header value after percent-encoding.
+    /// If `uri` isn't a valid header value after percent-encoding. Use
+    /// [`Redirect::with_status_code`] for a fallible, non-panicking variant.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
     pub fn temporary(uri: impl AsRef<str>) -> Self {
@@ -97,7 +111,8 @@ impl Redirect {
     ///
     /// # Panics
     ///
-    /// If `uri` isn't a valid header value after percent-encoding.
+    /// If `uri` isn't a valid header value after percent-encoding. Use
+    /// [`Redirect::with_status_code`] for a fallible, non-panicking variant.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
     pub fn permanent(uri: impl AsRef<str>) -> Self {
@@ -113,7 +128,8 @@ impl Redirect {
     ///
     /// # Panics
     ///
-    /// If `uri` isn't a valid header value after percent-encoding.
+    /// If `uri` isn't a valid header value after percent-encoding. Use
+    /// [`Redirect::with_status_code`] for a fallible, non-panicking variant.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
     pub fn found(uri: impl AsRef<str>) -> Self {


### PR DESCRIPTION
## What

Docs-only hardening for `Redirect`:

1. **`# Security` section** on the `Redirect` type warning that constructing a redirect target from untrusted input (query param, form field, `Referer`, …) is an [open redirect](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html), with guidance to allowlist or restrict to same-origin paths.
2. The panicking convenience constructors (`other`/`temporary`/`permanent`/`found`) now point at `Redirect::with_status_code` as the fallible, non-panicking alternative for callers that build URIs from dynamic input.

No code or behavior change.

## Verification
- `cargo test -p salvo_core --doc redirect` — 2 doctests pass.
- The new `[Redirect::with_status_code]` intra-doc link resolves.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)