### PR TITLE
Fix RateIssuer::issue doc to match the 400-on-None behavior

### DIFF
--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -135,7 +135,13 @@ cfg_feature! {
 pub trait RateIssuer: Send + Sync + 'static {
     /// The key type that uniquely identifies a rate-limited subject (e.g. client IP, user id).
     type Key: Hash + Eq + Send + Sync + 'static;
-    /// Issue a key for the request. If it returns `None`, the request will not be rate-limited.
+    /// Issue a key identifying the rate-limited subject for this request.
+    ///
+    /// Returning `None` means the subject could not be identified: the
+    /// [`RateLimiter`] handler then rejects the request with `400 Bad Request`
+    /// (`"invalid identifier"`) and skips the rest of the chain. It does **not**
+    /// let the request through unlimited, so an issuer that wants to exempt
+    /// certain requests should pair the limiter with a [`Skipper`] instead.
     fn issue(
         &self,
         req: &mut Request,


### PR DESCRIPTION
## What

`RateIssuer::issue` was documented as: *"If it returns `None`, the request will not be rate-limited."*

But the handler does the opposite — on `None` it renders `400 Bad Request` (`"invalid identifier"`) and skips the rest of the chain. This is the intended, tested behavior (`test_missing_identifier_renders_consistent_message`).

Reworded the doc to describe the real semantics and to point users at a `Skipper` when they actually want to exempt certain requests from limiting. Docs only.

## Verification
- `cargo doc -p salvo-rate-limiter` with `-D rustdoc::broken_intra_doc_links` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)