### PR TITLE
Avoid string round-trip in guess_accept_mime

### DIFF
--- a/crates/core/src/http/mime.rs
+++ b/crates/core/src/http/mime.rs
@@ -9,12 +9,9 @@ use crate::http::Request;
 pub fn guess_accept_mime(req: &Request, default_type: Option<Mime>) -> Mime {
     let dmime: Mime = default_type.unwrap_or(mime::TEXT_HTML);
     let accept = req.accept();
-    accept
-        .first()
-        .unwrap_or(&dmime)
-        .to_string()
-        .parse()
-        .unwrap_or(dmime)
+    // `accept.first()` is already a `Mime`; clone it directly instead of
+    // round-tripping through `to_string().parse()`.
+    accept.first().cloned().unwrap_or(dmime)
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
## What

`guess_accept_mime` recovered an owned `Mime` from `accept.first()` (an `Option<&Mime>`) by stringifying and re-parsing it:

```rust
accept.first().unwrap_or(&dmime).to_string().parse().unwrap_or(dmime)
```

That allocates a `String` and runs the mime parser on every call just to clone a value that's already a valid `Mime`. Replaced with a direct `.cloned()`:

```rust
accept.first().cloned().unwrap_or(dmime)
```

Same result, no allocation or parse. Behavior is identical (a `Mime` re-parsed from its own `to_string()` yields the same `Mime`).

## Verification
- `cargo build -p salvo_core --all-features` — clean.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)