### PR TITLE
Document Host-injection risk for absolute tus Location headers

### DIFF
--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -117,9 +117,28 @@ pub struct TusOptions {
     pub relative_location: bool,
 
     /// Canonical origin used for absolute `Location` headers.
+    ///
+    /// # Security
+    ///
+    /// When `relative_location` is `false` and `canonical_origin` is `None`, the
+    /// absolute `Location` is built from the request's `Host` (and, if
+    /// [`respect_forwarded_headers`](Self::respect_forwarded_headers) is set,
+    /// `Forwarded`/`X-Forwarded-*`) headers, all of which are client-controlled.
+    /// An attacker can then poison the returned upload URL via `Host` header
+    /// injection. In production prefer a relative `Location` or set
+    /// `canonical_origin` to a fixed, trusted origin so the host is never taken
+    /// from request headers.
     pub canonical_origin: Option<String>,
 
     /// Allows trusted forwarded headers to override the host and protocol used for `Location`.
+    ///
+    /// # Security
+    ///
+    /// Only enable this behind a proxy that overwrites `Forwarded` /
+    /// `X-Forwarded-Host` / `X-Forwarded-Proto`. If clients can reach the server
+    /// directly, these headers are spoofable and can poison the `Location`
+    /// header; set [`canonical_origin`](Self::canonical_origin) to avoid relying
+    /// on request headers at all.
     pub respect_forwarded_headers: bool,
 
     /// Additional headers sent in `Access-Control-Allow-Headers`.

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -123,8 +123,9 @@ pub struct TusOptions {
     /// When `relative_location` is `false` and `canonical_origin` is `None`, the
     /// absolute `Location` is built from the request's `Host` (and, if
     /// [`respect_forwarded_headers`](Self::respect_forwarded_headers) is set,
-    /// `Forwarded`/`X-Forwarded-*`) headers, all of which are client-controlled.
-    /// An attacker can then poison the returned upload URL via `Host` header
+    /// `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and
+    /// `X-Forwarded-Ssl`) headers, all of which are client-controlled. An
+    /// attacker can then poison the returned upload URL via `Host` header
     /// injection. In production prefer a relative `Location` or set
     /// `canonical_origin` to a fixed, trusted origin so the host is never taken
     /// from request headers.
@@ -134,11 +135,12 @@ pub struct TusOptions {
     ///
     /// # Security
     ///
-    /// Only enable this behind a proxy that overwrites `Forwarded` /
-    /// `X-Forwarded-Host` / `X-Forwarded-Proto`. If clients can reach the server
-    /// directly, these headers are spoofable and can poison the `Location`
-    /// header; set [`canonical_origin`](Self::canonical_origin) to avoid relying
-    /// on request headers at all.
+    /// Only enable this behind a proxy that overwrites every host/proto
+    /// forwarding header it honours — `Forwarded`, `X-Forwarded-Host`,
+    /// `X-Forwarded-Proto`, and `X-Forwarded-Ssl`. If clients can reach the
+    /// server directly, these headers are spoofable and can poison the
+    /// `Location` header; set [`canonical_origin`](Self::canonical_origin) to
+    /// avoid relying on request headers at all.
     pub respect_forwarded_headers: bool,
 
     /// Additional headers sent in `Access-Control-Allow-Headers`.


### PR DESCRIPTION
## What

When `TusOptions::relative_location` is `false` and `canonical_origin` is `None`, the absolute `Location` header is built from the request's `Host` (and, when `respect_forwarded_headers` is set, `Forwarded` / `X-Forwarded-*`) headers — all client-controlled. That allows **Host-header injection** to poison the upload URL returned to clients.

Added `# Security` notes to the `canonical_origin` and `respect_forwarded_headers` fields explaining the risk and recommending a fixed, trusted `canonical_origin` (or a relative `Location`) in production. Docs only — no behavior change.

## Verification
- `cargo doc -p salvo-tus` with `-D rustdoc::broken_intra_doc_links` — clean (the `Self::` links resolve).
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)