### PR TITLE
Clarify that compression min_length only applies to sized bodies

### DIFF
--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -191,6 +191,12 @@ pub struct Compression {
     /// Content types to compress.
     pub content_types: Vec<Mime>,
     /// Minimum body size to compress; bodies smaller than this value are not compressed.
+    ///
+    /// This threshold only applies to bodies whose length is known up front
+    /// (in-memory `Once`/`Chunks` bodies). Streaming bodies (`Hyper`/`Stream`)
+    /// have no known length and are always compressed regardless of
+    /// `min_length`, so a tiny streamed body can still end up larger after
+    /// adding `Content-Encoding` and framing overhead.
     pub min_length: usize,
     /// Ignore the client's algorithm order in `Accept-Encoding` and always use the server's
     /// configured priority.
@@ -323,6 +329,9 @@ impl Compression {
 
     /// Sets minimum compression size, if body is less than this value, no compression.
     /// Default is 1kb.
+    ///
+    /// Only effective for bodies with a known length (`Once`/`Chunks`); streaming
+    /// bodies (`Hyper`/`Stream`) are always compressed regardless of this value.
     #[inline]
     #[must_use]
     pub fn min_length(mut self, size: usize) -> Self {


### PR DESCRIPTION
## What

`min_length` is only enforced for `ResBody::Once` and `ResBody::Chunks`, whose total length is known before compression. For streaming bodies (`ResBody::Hyper` / `ResBody::Stream`) the length is unknown, so they are compressed unconditionally — meaning a tiny streamed body can still end up *larger* once `Content-Encoding` and framing overhead are added.

This was undocumented and surprising. Added a note to both the `min_length` field and the `min_length(..)` setter explaining the limitation. Docs only — no behavior change (buffering a stream just to measure it would defeat streaming).

## Verification
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)