### PR TITLE
Compile the craft attribute regex once via LazyLock

### DIFF
--- a/crates/craft-macros/src/craft.rs
+++ b/crates/craft-macros/src/craft.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use regex::Regex;
@@ -33,10 +35,14 @@ pub(crate) fn generate(input: Item) -> syn::Result<TokenStream> {
 
 const REGEX_STR: &str = r#"(?s)#\s*\[\s*(::)?\s*([A-Za-z_][A-Za-z0-9_]*\s*::\s*)*\s*craft\s*\(\s*(?P<name>handler|endpoint)\s*(?P<content>\(.*\))?\s*\)\s*\]"#;
 
+/// Compiled once per process instead of per `#[craft]` method.
+static CRAFT_ATTR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(REGEX_STR).expect("regex compile should not fail"));
+
 fn take_method_macro(item_fn: &mut ImplItemFn) -> syn::Result<Option<Attribute>> {
     let mut index: Option<usize> = None;
     let mut new_attr: Option<Attribute> = None;
-    let re = Regex::new(REGEX_STR).expect("regex compile should not fail");
+    let re = &*CRAFT_ATTR_RE;
     for (idx, attr) in &mut item_fn.attrs.iter().enumerate() {
         if !(match attr.path().segments.last() {
             Some(segment) => segment.ident == "craft",


### PR DESCRIPTION
## What

`take_method_macro` called `Regex::new(REGEX_STR)` every time it processed a `#[craft]` method, recompiling the same attribute-matching regex repeatedly during macro expansion.

Hoisted it into a module-level `LazyLock<Regex>` (the same pattern `salvo-compression` already uses) so it is compiled once per proc-macro process. No behavior change.

## Verification
- `cargo test -p salvo-craft-macros` — passes.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)