### PR TITLE
Remove duplicate cfg attribute on the u32 schema-format arm

### DIFF
--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -443,7 +443,6 @@ impl TryToTokens for Type<'_> {
             #[cfg(feature="non-strict-integers")]
             "u16" => tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::UInt16) }),
             #[cfg(feature="non-strict-integers")]
-            #[cfg(feature="non-strict-integers")]
             "u32" => tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::UInt32) }),
             #[cfg(feature="non-strict-integers")]
             "u64" => tokens.extend(quote! { #oapi::oapi::SchemaFormat::KnownFormat(#oapi::oapi::KnownFormat::UInt64) }),


### PR DESCRIPTION
## What

In `schema_type.rs`, the `"u32"` match arm under the `non-strict-integers` feature had two identical `#[cfg(feature="non-strict-integers")]` attributes stacked on it:

```rust
#[cfg(feature="non-strict-integers")]
#[cfg(feature="non-strict-integers")]
"u32" => tokens.extend(...UInt32...),
```

Harmless (both must be true, so it's equivalent to one) but a stray copy-paste. Removed the duplicate. No behavior change.

## Verification
- `cargo build -p salvo-oapi-macros` (default) and `--features non-strict-integers` — both build.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)