### PR TITLE
Wrap JSON payload map in Arc to make Payload clones cheap

### DIFF
--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -95,7 +95,9 @@ where
 pub(crate) enum Payload<'a> {
     FormData(&'a FormData),
     JsonStr(&'a str),
-    JsonMap(HashMap<&'a str, &'a RawValue>),
+    // Behind an `Arc` so cloning a `Payload` (e.g. once per flattened field) is a
+    // refcount bump instead of rebuilding the whole map.
+    JsonMap(Arc<HashMap<&'a str, &'a RawValue>>),
 }
 impl Payload<'_> {
     #[allow(dead_code)]
@@ -149,7 +151,7 @@ impl<'de> RequestDeserializer<'de> {
                     {
                         // https://github.com/serde-rs/json/issues/903
                         payload = match serde_json::from_slice::<HashMap<&str, &RawValue>>(data) {
-                            Ok(map) => Some(Payload::JsonMap(map)),
+                            Ok(map) => Some(Payload::JsonMap(Arc::new(map))),
                             Err(e) => {
                                 tracing::warn!(error = ?e, "`RequestDeserializer` serde parse json payload failed");
                                 Some(Payload::JsonStr(std::str::from_utf8(data)?))


### PR DESCRIPTION
## What

On the request-deserialization path, `RequestDeserializer` clones its `Payload` for each flattened field (the nested deserializer gets a copy). The `JsonMap` variant held an **owned** `HashMap<&str, &RawValue>`:

```rust
JsonMap(HashMap<&'a str, &'a RawValue>),
```

so every clone rebuilt the entire map. Wrapped it in `Arc`:

```rust
JsonMap(Arc<HashMap<&'a str, &'a RawValue>>),
```

Now cloning a `Payload` is a refcount bump instead of a re-hash of all entries. The map is read-only after construction and all lookups go through `Deref`, so call sites are unchanged. The entries still borrow the request body (`&'a`), so no data is copied or owned differently.

## Verification
- `cargo test -p salvo_core --all-features --lib serde::request` — all 22 deserialization tests pass (they exercise `JsonMap` construction and lookup for json str/bool/vec/object bodies).
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)