### PR TITLE
Wake graceful-shutdown wait on force-stop to avoid hangs

### DIFF
--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -390,7 +390,17 @@ impl<A: Acceptor + Send> Server<A> {
                     "wait for {} connections to close.",
                     alive_connections.load(Ordering::Acquire)
                 );
-                notify.notified().await;
+                // Re-check in a loop and also wake on a force-stop: a connection that
+                // ignores `force_stop_token` would otherwise never decrement the count,
+                // so a single `notify.notified().await` could hang shutdown forever.
+                while !force_stop_token.is_cancelled()
+                    && alive_connections.load(Ordering::Acquire) > 0
+                {
+                    tokio::select! {
+                        _ = notify.notified() => {}
+                        _ = force_stop_token.cancelled() => break,
+                    }
+                }
             }
 
             tracing::info!("server stopped");


### PR DESCRIPTION
## Problem

After initiating shutdown, the server's final wait was:

```rust
if !force_stop_token.is_cancelled() && alive_connections.load(Acquire) > 0 {
    notify.notified().await;
}
```

`notify` is only fired when the **last** connection closes (count reaches 0). If a connection ignores `force_stop_token` — stuck in user code, a slow body, etc. — the count never reaches zero, the notify never fires, and shutdown **hangs indefinitely**, even though a force-stop (graceful timeout elapsed, or an explicit force command) was requested. The single `await` had no way to observe the force-stop.

## Fix

Wait in a loop that re-checks the condition and also selects on `force_stop_token.cancelled()`, so a force-stop reliably ends the wait regardless of lingering connections:

```rust
while !force_stop_token.is_cancelled() && alive_connections.load(Acquire) > 0 {
    tokio::select! {
        _ = notify.notified() => {}
        _ = force_stop_token.cancelled() => break,
    }
}
```

Normal graceful shutdown (all connections close on their own) behaves exactly as before — the loop exits when the count reaches zero.

## Verification
- `cargo build -p salvo_core --features "server http1"` — compiles.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)