### PR TITLE
Return Cow from RenameRule::apply_to_field to skip no-op allocations

### DIFF
--- a/crates/core/src/extract/case.rs
+++ b/crates/core/src/extract/case.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use self::RenameRule::{
@@ -78,11 +79,14 @@ impl RenameRule {
     }
 
     /// Apply a renaming rule to a struct field, returning the version expected in the source.
+    ///
+    /// Returns `Cow::Borrowed` for the no-op rules (`snake_case`/`lowercase`),
+    /// avoiding an allocation on that hot path; the other rules allocate.
     #[must_use]
-    pub fn apply_to_field(self, field: &str) -> String {
+    pub fn apply_to_field(self, field: &str) -> Cow<'_, str> {
         match self {
-            LowerCase | SnakeCase => field.to_owned(),
-            UpperCase | ScreamingSnakeCase => field.to_ascii_uppercase(),
+            LowerCase | SnakeCase => Cow::Borrowed(field),
+            UpperCase | ScreamingSnakeCase => Cow::Owned(field.to_ascii_uppercase()),
             PascalCase => {
                 let mut pascal = String::new();
                 let mut capitalize = true;
@@ -96,14 +100,13 @@ impl RenameRule {
                         pascal.push(ch);
                     }
                 }
-                pascal
+                Cow::Owned(pascal)
             }
-            CamelCase => {
-                let pascal = PascalCase.apply_to_field(field);
-                lowercase_first_char(&pascal)
+            CamelCase => Cow::Owned(lowercase_first_char(&PascalCase.apply_to_field(field))),
+            KebabCase => Cow::Owned(field.replace('_', "-")),
+            ScreamingKebabCase => {
+                Cow::Owned(ScreamingSnakeCase.apply_to_field(field).replace('_', "-"))
             }
-            KebabCase => field.replace('_', "-"),
-            ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
         }
     }
 }

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -482,7 +482,7 @@ impl<'de> RequestDeserializer<'de> {
             if self.fill_value(field) {
                 return field.serde_rename.map(Cow::from).or_else(|| {
                     if let Some(serde_rename_all) = self.metadata.serde_rename_all {
-                        Some(Cow::Owned(serde_rename_all.apply_to_field(field.decl_name)))
+                        Some(serde_rename_all.apply_to_field(field.decl_name))
                     } else {
                         Some(Cow::from(field.decl_name))
                     }


### PR DESCRIPTION
## What

`RenameRule::apply_to_field` always returned an owned `String`. For the `snake_case`/`lowercase` rules the field name is unchanged, yet the old code still did `field.to_owned()`. The request deserializer calls this **per renamed field** when `rename_all` is configured, so those no-op rules allocated needlessly on the hot path.

Changed the return type to `Cow<'_, str>`: `snake_case`/`lowercase` now return `Cow::Borrowed(field)` (zero allocation); every other rule returns `Cow::Owned` exactly as before.

## Breaking change (0.94)

`extract::RenameRule` is publicly re-exported, so the return-type change is breaking for external callers. Migration is mechanical:
- need an owned `String`? → `.into_owned()`
- `&*x`, `x.to_string()`, deref-coercion to `&str` → unchanged

The only in-tree callers are core's request deserializer, updated here. (The macros use a separate `serde-util` `RenameRule`, unaffected.)

## Verification
- `cargo test -p salvo_core --all-features --lib extract::case` and `serde::request` — pass.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)