### PR TITLE
Generate craft handle types via split_for_impl for generic impls

### DIFF
--- a/crates/craft-macros/src/craft.rs
+++ b/crates/craft-macros/src/craft.rs
@@ -5,8 +5,7 @@ use quote::{ToTokens, quote};
 use regex::Regex;
 use syn::parse::Parser;
 use syn::{
-    AngleBracketedGenericArguments, Attribute, FnArg, Generics, Ident, ImplItem, ImplItemFn, Item,
-    PathArguments, Token, Type, TypePath, parse_quote,
+    Attribute, FnArg, Generics, Ident, ImplItem, ImplItemFn, Item, Token, Type, parse_quote,
 };
 
 use crate::utils::salvo_crate;
@@ -118,7 +117,7 @@ impl FnReceiver {
 }
 
 fn rewrite_method(
-    mut impl_generics: Generics,
+    impl_generics: Generics,
     self_ty: &Type,
     method: &mut ImplItemFn,
 ) -> syn::Result<()> {
@@ -170,20 +169,19 @@ fn rewrite_method(
                 .collect();
             method.sig.inputs[0] = FnArg::Receiver(parse_quote!(&self));
             method.sig.ident = Ident::new("handle", Span::call_site());
-            let where_clause = impl_generics.make_where_clause().clone();
-            let mut angle_bracketed: Option<AngleBracketedGenericArguments> = None;
-            if let Type::Path(TypePath { path, .. }) = self_ty
-                && let Some(last_segment) = path.segments.last()
-                && let PathArguments::AngleBracketed(_angle_bracketed) = &last_segment.arguments
-            {
-                angle_bracketed = Some(_angle_bracketed.clone());
-            }
+            // Use `split_for_impl` so the generated `handle` struct is referred to
+            // with its *type* generics (`handle<T>`) in impl headers, while the
+            // `impl` keeps the bounded `impl<T: Bound>` form and the where-clause.
+            // The previous code derived the type arguments from `self_ty`, which is
+            // wrong whenever they differ from the impl's parameters (e.g.
+            // `impl<T> Foo<Wrapper<T>>` would emit `handle<Wrapper<T>>`).
+            let (impl_g, ty_g, where_c) = impl_generics.split_for_impl();
             parse_quote! {
                 #vis fn #method_name(#receiver) -> impl #handler {
                     #[allow(non_camel_case_types)]
-                    pub struct handle #impl_generics(::std::sync::Arc<#self_ty>) #where_clause;
+                    pub struct handle #impl_g(::std::sync::Arc<#self_ty>) #where_c;
                     use ::std::ops::Deref;
-                    impl #impl_generics Deref for handle #angle_bracketed #where_clause{
+                    impl #impl_g Deref for handle #ty_g #where_c {
                         type Target = #self_ty;
 
                         fn deref(&self) -> &Self::Target {
@@ -194,7 +192,7 @@ fn rewrite_method(
                     use ::std::ops::Deref as _;
                     #(#forwarded_attrs)*
                     #macro_attr
-                    impl #impl_generics handle #angle_bracketed #where_clause{
+                    impl #impl_g handle #ty_g #where_c {
                         #method
                     }
                     handle(#output)

--- a/crates/craft/tests/craft_smoke.rs
+++ b/crates/craft/tests/craft_smoke.rs
@@ -32,3 +32,35 @@ async fn crafted_handler_can_be_registered_on_a_router() {
 
     assert_eq!(body, "hello world");
 }
+
+#[derive(Clone, Debug)]
+pub struct Pair<A, B> {
+    a: A,
+    b: B,
+}
+
+// `impl<T> Pair<T, T>` is the regression case: the self type's arguments
+// (`<T, T>`) differ from the impl's parameters (`<T>`), so generating the
+// `handle` struct's impl headers from `self_ty` would emit `handle<T, T>` and
+// fail to compile. `split_for_impl` yields the correct `handle<T>`.
+#[craft]
+impl<T: Clone + Send + Sync + std::fmt::Display + 'static> Pair<T, T> {
+    #[craft(handler)]
+    fn show(&self) -> String {
+        format!("{}+{}", self.a, self.b)
+    }
+}
+
+#[tokio::test]
+async fn crafted_handler_supports_generic_impl_with_repeated_type_args() {
+    let router = Router::new().get(Pair { a: "x", b: "y" }.show());
+
+    let body = TestClient::get("http://127.0.0.1:5801")
+        .send(router)
+        .await
+        .take_string()
+        .await
+        .unwrap();
+
+    assert_eq!(body, "x+y");
+}


### PR DESCRIPTION
## Problem

The `#[craft]` macro generates a private `handle` struct parameterized by the **impl's** generics, then references it in impl headers. It derived the type arguments for those references from `self_ty`:

```rust
// angle_bracketed taken from self_ty
impl #impl_generics Deref for handle #angle_bracketed #where_clause { ... }
impl #impl_generics handle #angle_bracketed #where_clause { #method }
```

`self_ty`'s arguments are not the same as the `handle` struct's parameters whenever they differ from the impl's generic params. For `impl<T> Pair<T, T>`, `self_ty = Pair<T, T>` so it emitted `handle<T, T>` — but `handle` has a single parameter `<T>`, so the generated code failed to compile.

## Fix

Use `Generics::split_for_impl()`:
- `impl_g` for the `impl<T: Bound>` headers (and the struct definition),
- `ty_g` for type references (`handle<T>`),
- `where_c` for the where-clause.

This drops the manual `self_ty`-argument extraction and the redundant `make_where_clause`. Non-generic and simple-generic impls are unaffected; the broken cross-arg cases now compile.

## Tests
- New `crafted_handler_supports_generic_impl_with_repeated_type_args` in `craft_smoke.rs` exercises `impl<T> Pair<T, T>`, which fails to compile under the old codegen and passes now.
- Existing craft smoke / oapi-doc tests still pass.

## Verification
- `cargo test -p salvo-craft` — all pass.
- clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)