### PR TITLE
Clarify that dropping certon's maintenance handle detaches, not cancels

### DIFF
--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -402,7 +402,10 @@ where
         let tls_acceptor = TlsAcceptor::from(server_config.clone());
         let inner = inner.try_bind().await?;
 
-        // Start certon's background maintenance for renewal + OCSP.
+        // Start certon's background maintenance for renewal + OCSP. Dropping the
+        // returned `JoinHandle` *detaches* the spawned task rather than cancelling
+        // it (per certon's docs), so the renewal/OCSP loop keeps running for the
+        // lifetime of the process even though we don't hold the handle.
         let _maintenance_handle = certon::start_maintenance(&certon_config);
 
         let acceptor = AcmeAcceptor::new(acme_config, server_config, inner, tls_acceptor);


### PR DESCRIPTION
## What

`AcmeListener::try_bind` discards the handle from `certon::start_maintenance`:

```rust
let _maintenance_handle = certon::start_maintenance(&certon_config);
```

This looks like a lifetime bug ("the background renewal task gets cancelled when the handle drops"), but `start_maintenance` returns a `tokio::task::JoinHandle`, and certon's own docs state that **dropping the handle detaches the task rather than cancelling it** (`CertCache::stop` is the way to request shutdown). So the renewal/OCSP loop keeps running for the process lifetime.

Added a comment at the call site documenting this so the intentional drop isn't repeatedly re-flagged as a bug. No behavior change.

## Verification
- `cargo build -p salvo-acme` — compiles.
- `cargo +nightly fmt --all -- --check` + `typos` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)