### PR TITLE
Default Proxy to the standards-compliant host header getter

### DIFF
--- a/crates/proxy/README.md
+++ b/crates/proxy/README.md
@@ -93,9 +93,10 @@ only prevents common proxy/backend path interpretation mismatches.
 
 ### Forwarded headers
 
-The default host header getter forwards only the upstream host name. Configure
-`standard_host_header_getter` when the upstream `Host` header should include a
-non-default port, for example `example.com:8080`.
+The default host header getter (`standard_host_header_getter`) forwards the
+upstream host and includes a non-default port, for example `example.com:8080`
+(per RFC 7230 / RFC 9110). Configure `default_host_header_getter` if you want to
+forward only the bare host name without the port.
 
 Client IP forwarding overwrites any inbound `X-Forwarded-For` value with the
 direct client IP from the connection. This avoids trusting a client-supplied

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -373,8 +373,9 @@ where
 {
     /// Creates a new `Proxy` with an upstream list.
     ///
-    /// The default host header getter forwards only the upstream host name. To include
-    /// non-default upstream ports, configure [`standard_host_header_getter`] with
+    /// The default host header getter is [`standard_host_header_getter`], which forwards the
+    /// upstream host and includes a non-default port (RFC 7230 / RFC 9110). To forward only
+    /// the bare host name, configure [`default_host_header_getter`] via
     /// [`Self::host_header_getter`].
     #[must_use]
     pub fn new(upstreams: U, client: C) -> Self {
@@ -383,7 +384,7 @@ where
             client,
             url_path_getter: Box::new(default_url_path_getter),
             url_query_getter: Box::new(default_url_query_getter),
-            host_header_getter: Box::new(default_host_header_getter),
+            host_header_getter: Box::new(standard_host_header_getter),
             client_ip_forwarding_enabled: false,
             strict_path_normalization_enabled: true,
             strip_authorization_header_enabled: false,
@@ -400,7 +401,7 @@ where
             client,
             url_path_getter: Box::new(default_url_path_getter),
             url_query_getter: Box::new(default_url_query_getter),
-            host_header_getter: Box::new(default_host_header_getter),
+            host_header_getter: Box::new(standard_host_header_getter),
             client_ip_forwarding_enabled: true,
             strict_path_normalization_enabled: true,
             strip_authorization_header_enabled: false,
@@ -924,6 +925,21 @@ mod tests {
         assert_eq!(
             preserve_original_host_header_getter(&uri, &req, &depot),
             Some("test.host.tld".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_proxy_default_host_header_getter_includes_port() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        // `Proxy::new` now defaults to the standards-compliant getter, which keeps
+        // a non-default upstream port in the forwarded `Host`.
+        let proxy = Proxy::new(vec!["http://host.tld:8080"], HyperClient::default());
+        let uri = Uri::from_str("http://host.tld:8080/test").unwrap();
+        let req = Request::new();
+        let depot = Depot::new();
+        assert_eq!(
+            (proxy.host_header_getter)(&uri, &req, &depot),
+            Some("host.tld:8080".to_owned())
         );
     }
 


### PR DESCRIPTION
## What

`Proxy::new` and `Proxy::with_client_ip_forwarding` defaulted to `default_host_header_getter`, which forwards only the bare upstream host and **drops a non-default port** — `http://upstream:8080` becomes `Host: upstream`. Upstreams that route/virtual-host by `Host:port` get the wrong `Host`.

Switched the default to `standard_host_header_getter`, which includes the port when it isn't the scheme default, per RFC 7230 / RFC 9110. The previous behavior stays available via `default_host_header_getter` configured through `Proxy::host_header_getter`.

## Behavior change (0.94)

For upstreams with a non-default port, the forwarded `Host` now includes the port. Most servers accept this; deployments that relied on the bare-host behavior can opt back in with `default_host_header_getter`.

## Tests
- New `test_proxy_default_host_header_getter_includes_port` asserts `Proxy::new(...)`'s default getter keeps `host.tld:8080`.
- Existing `test_host_header_handling` (both getters) and all 31 proxy tests pass.

## Verification
- `cargo test -p salvo-proxy --all-features` — pass.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)