### PR TITLE
Bound the protocol-detection read to mitigate idle-connection leaks

### DIFF
--- a/crates/core/src/conn/proto.rs
+++ b/crates/core/src/conn/proto.rs
@@ -39,6 +39,11 @@ const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 /// immediately — and only bounds this one initial read, not established connections.
 /// Configure a [`fuse_factory`](crate::Server::fuse_factory) for finer-grained
 /// handshake/idle timeouts.
+///
+/// This relies on the Tokio **time driver**, so the server must run on a runtime
+/// built with timers enabled (`#[tokio::main]` and `Runtime::new()` enable them;
+/// a hand-built runtime needs `enable_time()` / `enable_all()`). That matches the
+/// rest of the server (graceful-shutdown and fuse timeouts already use timers).
 #[cfg(all(feature = "http1", feature = "http2"))]
 const PROTOCOL_DETECT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 

--- a/crates/core/src/conn/proto.rs
+++ b/crates/core/src/conn/proto.rs
@@ -32,6 +32,16 @@ use crate::rt::tokio::TokioExecutor;
 
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
+/// Fallback timeout for the initial protocol-detection read when no fusewire is
+/// configured. A connection that opens but never sends bytes would otherwise keep
+/// the detection read pending forever (Slowloris-style connection leak). The value
+/// is intentionally generous — real clients send the request line / HTTP/2 preface
+/// immediately — and only bounds this one initial read, not established connections.
+/// Configure a [`fuse_factory`](crate::Server::fuse_factory) for finer-grained
+/// handshake/idle timeouts.
+#[cfg(all(feature = "http1", feature = "http2"))]
+const PROTOCOL_DETECT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[doc(hidden)]
 pub struct HttpBuilder {
     #[cfg(feature = "http1")]
@@ -95,7 +105,15 @@ impl HttpBuilder {
                 },
             }
         } else {
-            read_version(socket).await?
+            // No fusewire: still bound the protocol-detection read so a connection
+            // that never sends bytes can't leak a task indefinitely.
+            match tokio::time::timeout(PROTOCOL_DETECT_READ_TIMEOUT, read_version(socket)).await {
+                Ok(result) => result?,
+                Err(_) => {
+                    tracing::info!("closing connection: protocol-detection read timed out");
+                    return Ok(());
+                }
+            }
         };
         #[cfg(all(not(feature = "http1"), not(feature = "http2")))]
         let version = Version::HTTP_11; // Just make the compiler happy.


### PR DESCRIPTION
## Problem

`serve_connection` detects HTTP/1 vs HTTP/2 by reading the first bytes (`read_version`). On the `http1 + http2` path:

```rust
if let Some(fusewire) = &fusewire {
    tokio::select! { result = read_version(socket) => ..., _ = fusewire.fused() => return }
} else {
    read_version(socket).await?   // <-- no timeout
}
```

With a fusewire the read is bounded by the fuse, but **fusewire is `None` by default**, so the bare `read_version(socket).await` has no timeout. A client that opens a TCP connection and never sends a byte keeps that detection read pending forever — a Slowloris-style way to leak server tasks / exhaust connections.

## Fix

Wrap the no-fusewire detection read in a generous default timeout (`30s`); on elapse the connection is closed. This:
- bounds only the **initial** protocol-detection read (real clients send the request line / HTTP/2 preface immediately), not established or keep-alive connections;
- leaves the fusewire path unchanged (it already times out via its `select!`);
- points users at `Server::fuse_factory` for finer-grained handshake/idle timeouts.

## Behavior change

A connection that opens and sends nothing for 30s is now closed rather than held indefinitely.

## Verification
- Builds with `http1+http2`, and with `http1`-only (the const is `cfg`-gated to the both-features path).
- `cargo test -p salvo_core --features "server http1 http2 test" --lib conn` — passes (clients in tests send promptly, well within 30s).
- fmt clean. (No fast unit test for the 30s path; the change is a localized `tokio::time::timeout` wrapper.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)