### PR TITLE
salvo-core: Improve preformance for `FlowCtrl`

### DIFF
--- a/crates/core/src/conn/proto.rs
+++ b/crates/core/src/conn/proto.rs
@@ -112,12 +112,13 @@ impl HttpBuilder {
         } else {
             // No fusewire: still bound the protocol-detection read so a connection
             // that never sends bytes can't leak a task indefinitely.
-            match tokio::time::timeout(PROTOCOL_DETECT_READ_TIMEOUT, read_version(socket)).await {
-                Ok(result) => result?,
-                Err(_) => {
-                    tracing::info!("closing connection: protocol-detection read timed out");
-                    return Ok(());
-                }
+            if let Ok(result) =
+                tokio::time::timeout(PROTOCOL_DETECT_READ_TIMEOUT, read_version(socket)).await
+            {
+                result?
+            } else {
+                tracing::info!("closing connection: protocol-detection read timed out");
+                return Ok(());
             }
         };
         #[cfg(all(not(feature = "http1"), not(feature = "http2")))]

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -395,14 +395,13 @@ impl Handler for HoopedHandler {
     ) {
         let inner: Arc<dyn Handler> = self.inner.clone();
         let right = ctrl.handlers.split_off(ctrl.cursor);
-        ctrl.handlers.append(
-            &mut self
-                .hoops
+        ctrl.handlers.extend(
+            self.hoops
                 .iter()
                 .cloned()
                 .chain([inner])
-                .chain(right)
-                .collect(),
+                .map(Some)
+                .chain(right.into_iter()),
         );
         ctrl.call_next(req, depot, res).await;
     }

--- a/crates/core/src/handler.rs
+++ b/crates/core/src/handler.rs
@@ -401,7 +401,7 @@ impl Handler for HoopedHandler {
                 .cloned()
                 .chain([inner])
                 .map(Some)
-                .chain(right.into_iter()),
+                .chain(right),
         );
         ctrl.call_next(req, depot, res).await;
     }

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -114,8 +114,6 @@ impl FlowCtrl {
                     self.skip_rest();
                     return true;
                 }
-            } else {
-                continue;
             }
         }
         self.cursor > start

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -45,7 +45,7 @@ pub struct FlowCtrl {
     catching: Option<bool>,
     is_ceased: bool,
     pub(crate) cursor: usize,
-    pub(crate) handlers: Vec<Arc<dyn Handler>>,
+    pub(crate) handlers: Vec<Option<Arc<dyn Handler>>>,
 }
 
 impl Debug for FlowCtrl {
@@ -67,14 +67,14 @@ impl FlowCtrl {
             catching: None,
             is_ceased: false,
             cursor: 0,
-            handlers,
+            handlers: handlers.into_iter().map(Some).collect(),
         }
     }
     /// Returns whether there is another handler in the chain.
     #[inline]
     #[must_use]
     pub fn has_next(&self) -> bool {
-        self.cursor < self.handlers.len() // && !self.handlers.is_empty()
+        self.cursor < self.handlers.len()
     }
 
     /// Runs the next handler in the chain.
@@ -104,22 +104,21 @@ impl FlowCtrl {
             self.skip_rest();
             return false;
         }
-        let mut handler = self.handlers.get(self.cursor).cloned();
-        if handler.is_none() {
-            false
-        } else {
-            while let Some(h) = handler.take() {
-                self.cursor += 1;
-                h.handle(req, depot, res, self).await;
+        let start = self.cursor;
+        while self.cursor < self.handlers.len() {
+            let handler = self.handlers[self.cursor].take();
+            self.cursor += 1;
+            if let Some(handler) = handler {
+                handler.handle(req, depot, res, self).await;
                 if !self.catching.unwrap_or_default() && res.is_stamped() {
                     self.skip_rest();
                     return true;
-                } else if self.has_next() {
-                    handler = self.handlers.get(self.cursor).cloned();
                 }
+            } else {
+                continue;
             }
-            true
         }
+        self.cursor > start
     }
 
     /// Skip all remaining handlers.

--- a/crates/core/src/routing/flow_ctrl.rs
+++ b/crates/core/src/routing/flow_ctrl.rs
@@ -147,3 +147,75 @@ impl FlowCtrl {
         self.is_ceased = true;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::prelude::*;
+    use crate::routing::FlowCtrl;
+    use crate::{Depot, Handler, Request, Response};
+
+    #[tokio::test]
+    async fn test_reentrant_call_next() {
+        #[handler]
+        async fn around_a(
+            req: &mut Request,
+            depot: &mut Depot,
+            res: &mut Response,
+            ctrl: &mut FlowCtrl,
+        ) {
+            depot.get_typed_mut::<Vec<&str>>().unwrap().push("enter_a");
+            assert!(ctrl.call_next(req, depot, res).await);
+            depot.get_typed_mut::<Vec<&str>>().unwrap().push("exit_a");
+        }
+
+        #[handler]
+        async fn around_b(
+            req: &mut Request,
+            depot: &mut Depot,
+            res: &mut Response,
+            ctrl: &mut FlowCtrl,
+        ) {
+            depot.get_typed_mut::<Vec<&str>>().unwrap().push("enter_b");
+            assert!(ctrl.call_next(req, depot, res).await);
+            depot.get_typed_mut::<Vec<&str>>().unwrap().push("exit_b");
+        }
+
+        #[handler]
+        async fn goal(res: &mut Response, depot: &mut Depot) {
+            depot.get_typed_mut::<Vec<&str>>().unwrap().push("goal");
+            res.status_code(StatusCode::OK);
+        }
+
+        let order: Vec<&str> = Vec::new();
+        let handlers: Vec<Arc<dyn Handler>> =
+            vec![Arc::new(around_a), Arc::new(around_b), Arc::new(goal)];
+
+        let mut req = Request::new();
+        let mut depot = Depot::new();
+        depot.insert_typed(order);
+        let mut res = Response::new();
+        let mut ctrl = FlowCtrl::new(handlers);
+        let ran = ctrl.call_next(&mut req, &mut depot, &mut res).await;
+
+        assert!(ran);
+        assert_eq!(res.status_code, Some(StatusCode::OK));
+        assert!(!ctrl.has_next());
+        assert_eq!(
+            depot.get_typed::<Vec<&str>>().unwrap(),
+            &["enter_a", "enter_b", "goal", "exit_b", "exit_a"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_empty_handler_chain() {
+        let handlers: Vec<Arc<dyn Handler>> = Vec::new();
+        let mut req = Request::new();
+        let mut depot = Depot::new();
+        let mut res = Response::new();
+        let mut ctrl = FlowCtrl::new(handlers);
+        assert!(!ctrl.call_next(&mut req, &mut depot, &mut res).await);
+        assert!(!ctrl.has_next());
+    }
+}

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -571,4 +571,39 @@ mod tests {
             .await;
         assert_eq!(res.status_code.unwrap(), StatusCode::NOT_FOUND);
     }
+
+    /// Regression test for [#925](https://github.com/salvo-rs/salvo/pull/925).
+    #[tokio::test]
+    async fn test_default_status_ok_visible_to_service_middleware() {
+        #[handler]
+        async fn goal(res: &mut Response) {
+            res.render("ok");
+        }
+
+        #[handler]
+        async fn check_status(
+            req: &mut Request,
+            depot: &mut Depot,
+            res: &mut Response,
+            ctrl: &mut FlowCtrl,
+        ) {
+            ctrl.call_next(req, depot, res).await;
+
+            assert_eq!(
+                res.status_code,
+                Some(StatusCode::OK),
+                "service middleware should observe implicit 200 after call_next"
+            );
+        }
+
+        let router = Router::new().goal(goal);
+
+        let service = Service::new(router).hoop(check_status);
+
+        let res = TestClient::get("http://127.0.0.1:5802/")
+            .send(&service)
+            .await;
+
+        assert_eq!(res.status_code, Some(StatusCode::OK));
+    }
 }


### PR DESCRIPTION
### Changes made in this PR                                                                                                                                                                                                                                                                                                                                                                                                                                       
- Remove redundant `DEFAULT_STATUS_OK_HANDLER` — It sets status to 200 OK after the goal handler, but the post-chain check (service.rs:285-288) already does the same. Saves one Arc clone and one Vec slot per request.                                                                                                                                                                                     
- Avoid per-request Arc clones in `FlowCtrl::call_next` — Replace `Vec<Arc<dyn Handler>>` with `Vec<Option<Arc<dyn Handler>>>` so handlers can be `.take()` out of the slot instead of `.cloned()`. This eliminates atomic refcount operations for every handler fetch in call_next, reducing total atomic ops.
