### PR TITLE
Reject #[serde(flatten)] on Extractible fields; document salvo flatten

### DIFF
--- a/crates/core/src/extract.rs
+++ b/crates/core/src/extract.rs
@@ -27,8 +27,10 @@
 //! }
 //! ```
 //!
-//! Extracted types can be nested. Use `#[salvo(extract(flatten))]` or
-//! `#[serde(flatten)]` when a nested type should be parsed from the same request:
+//! Extracted types can be nested. Use `#[salvo(extract(flatten))]` when a nested
+//! extractible type should be parsed from the same request. (`#[serde(flatten)]`
+//! is not supported on `#[derive(Extractible)]` fields — it conflicts with
+//! Salvo's extraction and is rejected at compile time; use the attribute below.)
 //!
 //! ```
 //! # use salvo_core::prelude::*;
@@ -44,7 +46,7 @@
 //!     last_name: String,
 //!     lovers: Vec<String>,
 //!     /// The nested field is parsed from the same request.
-//!     #[serde(flatten)]
+//!     #[salvo(extract(flatten))]
 //!     nested: Nested<'a>,
 //! }
 //!

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -1157,4 +1157,49 @@ mod tests {
             }
         );
     }
+
+    #[tokio::test]
+    async fn test_de_request_with_salvo_flatten() {
+        // `#[salvo(extract(flatten))]` flattens an extractible sub-struct: its
+        // fields are pulled from the same (flat) request sources as the parent.
+        #[derive(Deserialize, Extractible, Eq, PartialEq, Debug)]
+        #[salvo(extract(default_source(from = "body", parse = "json")))]
+        struct Inner {
+            name: String,
+            age: usize,
+        }
+        #[derive(Deserialize, Extractible, Eq, PartialEq, Debug)]
+        #[salvo(extract(default_source(from = "body", parse = "json")))]
+        struct RequestData {
+            id: u64,
+            #[salvo(extract(flatten))]
+            inner: Inner,
+        }
+        #[derive(Serialize)]
+        struct Body {
+            id: u64,
+            name: &'static str,
+            age: usize,
+        }
+
+        let mut req = TestClient::get("http://127.0.0.1:8698/test")
+            .json(&Body {
+                id: 7,
+                name: "chris",
+                age: 20,
+            })
+            .build();
+        let mut depot = Depot::new();
+        let data: RequestData = req.extract(&mut depot).await.unwrap();
+        assert_eq!(
+            data,
+            RequestData {
+                id: 7,
+                inner: Inner {
+                    name: "chris".to_owned(),
+                    age: 20,
+                },
+            }
+        );
+    }
 }

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -62,7 +62,19 @@ impl TryFrom<&Field> for FieldInfo {
         } else {
             (None, Vec::new(), false)
         };
-        let flatten = flatten.unwrap_or(serde_flatten);
+        // `#[serde(flatten)]` drives serde's own content-buffering flatten, which
+        // conflicts with Salvo's metadata-driven flattening (the two disagree on
+        // what the request map contains, producing spurious "missing field"
+        // errors). Reject it with a clear pointer to the supported attribute
+        // instead of failing at deserialization time.
+        if serde_flatten {
+            return Err(Error::new_spanned(
+                ident,
+                "`#[serde(flatten)]` is not supported on `#[derive(Extractible)]` fields; \
+                 use `#[salvo(extract(flatten))]` to flatten an extractible sub-struct",
+            ));
+        }
+        let flatten = flatten.unwrap_or(false);
         if flatten {
             if !sources.is_empty() {
                 return Err(Error::new_spanned(


### PR DESCRIPTION
## Problem

`#[serde(flatten)]` on a `#[derive(Extractible)]` field produced a runtime `missing field ...` error when extracting (e.g. `req.extract()`), even though the data was present.

**Root cause:** there are two flattening mechanisms and `#[serde(flatten)]` triggered both:
- **Salvo's** metadata-driven flatten: `RequestDeserializer`'s `MapAccess` yields the flatten field's key (`"inner"`) and sub-deserializes the nested struct from the same flat request sources.
- **serde's** derive flatten: buffers the whole map into `Content` and redistributes, expecting the leaf entries (`id`, `name`, `age`).

The Extractible derive enabled Salvo flatten from serde flatten (`flatten.unwrap_or(serde_flatten)`), so both ran and disagreed — serde received `{id, "inner": <already-built>}` instead of `{id, name, age}` and built the sub-struct from a remainder missing its fields.

## Fix (decouple + compile-time guard)

- Salvo flatten now comes **only** from `#[salvo(extract(flatten))]`.
- A field carrying `#[serde(flatten)]` under `#[derive(Extractible)]` is rejected **at compile time** with a message pointing at `#[salvo(extract(flatten))]`, instead of failing confusingly at request time.
- `#[salvo(extract(flatten))]` keeps working (verified) — its sub-struct is extracted from the same request sources as the parent.

No `#[serde(flatten)]` usage exists in-tree, so nothing breaks; `examples/extract-nested` (which uses `#[salvo(extract(flatten))]`) still builds.

## Tests
- New `test_de_request_with_salvo_flatten` covers the `#[salvo(extract(flatten))]` path (JSON body, nested extractible) — previously **zero** flatten coverage.

## Docs
Website guide (`guide/concepts/request.md`) updated in en / zh-hans / zh-hant to state that `#[serde(flatten)]` is unsupported on Extractible fields and to use `#[salvo(extract(flatten))]` (separate `salvo-rs/website` repo).

## Verification
- `cargo test -p salvo_core --all-features --lib serde` — 28 pass.
- `cargo build` of `examples/extract-nested` — ok; clippy + `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)