### PR TITLE
fix(core): roll back captured path params when a sibling route fails

### DIFF
--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -96,6 +96,7 @@ impl Router {
             }
             if !self.routers.is_empty() {
                 let original_cursor = path_state.cursor;
+                let original_params = path_state.params.clone();
                 #[cfg(feature = "matched-path")]
                 let original_matched_parts_len = path_state.matched_parts.len();
                 for child in &self.routers {
@@ -118,6 +119,7 @@ impl Router {
                             .matched_parts
                             .truncate(original_matched_parts_len);
                         path_state.cursor = original_cursor;
+                        path_state.params = original_params.clone();
                     }
                 }
             }
@@ -735,6 +737,34 @@ mod tests {
         let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_router_detect_method_mismatch_wildcard_sibling() {
+        // Regression test for https://github.com/salvo-rs/salvo/issues/1612
+        //
+        // When a sibling route matches the path (capturing a wildcard param) but
+        // fails a later filter such as the method filter, its captured params must
+        // be rolled back. Otherwise the next sibling's wildcard insertion panics
+        // with "only one wildcard param is allowed and it must be the last one".
+        let router = Router::new()
+            .push(Router::with_path("{foo|[a-f0-9]{4}}/{**subpath}").get(fake_handler))
+            .push(Router::with_path("{**subpath}").get(fake_handler));
+
+        // A HEAD request does not match the GET method filter of the first route.
+        let mut req = TestClient::head("http://local.host/b33f/subpath.txt").build();
+        let mut path_state = PathState::new(req.uri().path());
+        // Must not panic, and should fall through with no matched goal.
+        let matched = router.detect(&mut req, &mut path_state).await;
+        assert!(matched.is_none());
+
+        // A GET request still matches the first route as before.
+        let mut req = TestClient::get("http://local.host/b33f/subpath.txt").build();
+        let mut path_state = PathState::new(req.uri().path());
+        let matched = router.detect(&mut req, &mut path_state).await;
+        assert!(matched.is_some());
+        assert_eq!(path_state.params["foo"], "b33f");
+        assert_eq!(path_state.params["subpath"], "subpath.txt");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Fixes #1612 — a panic (`only one wildcard param is allowed and it must be the last one`) that occurs when a request fails a method filter on a route whose path pattern captures a wildcard param, and a sibling route also captures a wildcard.

## Reproduction

```rust
PathFilter::register_wisp_regex("foo", Regex::new(r"([a-f0-9]{4})").unwrap());
let router = Router::new()
    .push(Router::with_path("/{foo:foo}/{**subpath}").get(handler))
    .push(Router::with_path("/{**subpath}").get(handler));
```

`curl -I http://localhost:8000/b33f/subpath.txt` (a HEAD request) panics.

## Root cause

In `Router::detect`, when a child router matches the path (capturing params, including a wildcard which sets `PathParams::greedy = true`) but then fails a later filter such as the method filter, its `detect` returns `None`. The backtracking logic restored `cursor` and `matched_parts` on that failure but **not** `params`. The leaked `greedy` flag then caused the next sibling's wildcard insertion to panic in `PathParams::insert` (debug builds; in release the param state is silently corrupted).

## Fix

Snapshot `path_state.params` before iterating children and restore it whenever a child match fails, mirroring the existing `cursor` / `matched_parts` rollback so a failed match attempt leaves no side effects.

## Tests

- Added regression test `test_router_detect_method_mismatch_wildcard_sibling` covering the exact issue scenario (HEAD falls through without matching; GET still matches and captures params correctly).
- Verified the test panics without the fix and passes with it.
- Full `routing` test suite (66 tests) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)