### PR TITLE
fix(oapi): default ToParameters location to Query so required is honored

### DIFF
--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -494,6 +494,7 @@ mod tests {
                         salvo::oapi::Parameters(
                             [
                                 salvo::oapi::parameter::Parameter::new("name")
+                                    .location(salvo::oapi::parameter::ParameterIn::Query)
                                     .description("Name of pet")
                                     .required(salvo::oapi::Required::False)
                                     .schema(
@@ -501,6 +502,7 @@ mod tests {
                                             .schema_type(salvo::oapi::schema::SchemaType::basic(salvo::oapi::schema::BasicType::String))
                                     ),
                                 salvo::oapi::parameter::Parameter::new("age")
+                                    .location(salvo::oapi::parameter::ParameterIn::Query)
                                     .description("Age of pet")
                                     .required(salvo::oapi::Required::False)
                                     .schema(
@@ -511,6 +513,7 @@ mod tests {
                                             ))
                                     ),
                                 salvo::oapi::parameter::Parameter::new("kind")
+                                    .location(salvo::oapi::parameter::ParameterIn::Query)
                                     .description("Kind of pet")
                                     .required(salvo::oapi::Required::True)
                                     .schema(<PetKind as salvo::oapi::ComposeSchema>::compose(components, ::std::vec::Vec::new())),

--- a/crates/oapi-macros/src/parameter/derive.rs
+++ b/crates/oapi-macros/src/parameter/derive.rs
@@ -568,6 +568,12 @@ impl TryToTokens for Parameter<'_> {
             tokens.extend(quote! { .location(#parameter_in) });
         } else if let Some(parameter_in) = &self.container_attributes.default_parameter_in {
             tokens.extend(parameter_in.try_to_token_stream()?);
+        } else {
+            // `ToParameters` extracts from the query string by default (see `default_source_from`),
+            // so the OpenAPI parameter location must default to `Query` as well. Without this the
+            // location would fall back to `ParameterIn`'s `Path` default, which both mislabels the
+            // parameter and forces `required: true` regardless of the field type.
+            tokens.extend(quote! { .location(#oapi::oapi::parameter::ParameterIn::Query) });
         }
 
         if let Some(style) = param_features.pop_style_feature() {

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -1279,6 +1279,61 @@ mod tests {
     }
 
     #[test]
+    fn to_parameters_struct_defaults_to_query_with_required() {
+        // Regression test for https://github.com/salvo-rs/salvo/issues/1609
+        // A struct used directly as a handler argument extracts from the query string by
+        // default, so its parameters must be reported with `in: query`. Non-`Option` fields
+        // must be `required: true`, and `Option` fields `required: false`. Previously the
+        // parameter location fell back to `ParameterIn::Path`, which mislabeled the location
+        // and forced every field to `required: true`.
+        #[derive(Deserialize, crate::ToParameters)]
+        #[allow(dead_code)]
+        struct ListQuery {
+            page: i32,
+            #[serde(rename = "pageSize")]
+            page_size: i32,
+            name: String,
+            keyword: Option<String>,
+        }
+
+        #[salvo_oapi::endpoint]
+        async fn list(query: ListQuery) -> &'static str {
+            let _ = query;
+            "ok"
+        }
+
+        let router = Router::with_path("/list").get(list);
+        let doc = OpenApi::new("test api", "0.0.1").merge_router(&router);
+
+        let path_item = doc.paths.get("/list").expect("/list entry should exist");
+        let operation = path_item
+            .operations
+            .get(&PathItemType::Get)
+            .expect("get operation should exist");
+
+        let by_name = |name: &str| {
+            operation
+                .parameters
+                .0
+                .iter()
+                .find(|p| p.name == name)
+                .unwrap_or_else(|| panic!("parameter `{name}` should exist"))
+        };
+
+        for name in ["page", "pageSize", "name", "keyword"] {
+            assert_eq!(
+                by_name(name).parameter_in,
+                ParameterIn::Query,
+                "parameter `{name}` should be located in query"
+            );
+        }
+        assert_eq!(by_name("page").required, Required::True);
+        assert_eq!(by_name("pageSize").required, Required::True);
+        assert_eq!(by_name("name").required, Required::True);
+        assert_eq!(by_name("keyword").required, Required::False);
+    }
+
+    #[test]
     fn merge_router_skips_route_without_method_filter() {
         #[salvo_oapi::endpoint]
         async fn any_handler() -> &'static str {


### PR DESCRIPTION
## Problem

Closes #1609

When a struct is used directly as a handler argument via `#[derive(ToParameters)]`, the fields should be reported as **query** parameters and non-`Option` fields should be `required: true`. The user reported that `required` was not taking effect in the generated OpenAPI document.

## Root cause

`ToParameters` extracts from the query string by default (the `Extractible` `default_source_from` is `Query`), but when no explicit `parameter_in` was specified, the generated OpenAPI `Parameter` had **no** location set — so it fell back to `ParameterIn`'s `#[default]` value of `Path`.

This caused two problems:
1. The parameter was mislabeled as `in: path` instead of `in: query`.
2. Per the OpenAPI 3.1 spec, path parameters are forced to `required: true` (`Parameters::insert`), which overwrote and masked the correct per-field `required` computation.

## Fix

Emit `.location(ParameterIn::Query)` in the `ToParameters` derive when no field-level or container-level `parameter_in` is given. This matches the [documented default](crates/oapi/docs/derive_to_parameters.md) ("If this attribute is not supplied, then the default value is from query") and the default extraction source.

After the fix:

| field | `in` | `required` |
|-------|------|-----------|
| `page: i32` | query | true |
| `pageSize: i32` | query | true |
| `name: String` | query | true |
| `keyword: Option<String>` | query | false |

## Tests

- Added a regression test `to_parameters_struct_defaults_to_query_with_required` in `crates/oapi/src/openapi.rs` that drives the full endpoint + `merge_router` flow.
- Updated the `test_to_parameters` macro expansion snapshot to include the new `.location(ParameterIn::Query)` call.
- Full `salvo-oapi` and `salvo-oapi-macros` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)