### PR TITLE
fix(security): harden proxy IP trust, JWKS cache bounds, ACME and redirect fail-closed

### DIFF
--- a/crates/acme/src/config.rs
+++ b/crates/acme/src/config.rs
@@ -107,9 +107,17 @@ impl AcmeConfigBuilder {
     #[inline]
     #[must_use]
     pub fn directory(self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        let url = url.into();
+        if !url.starts_with("https://") {
+            tracing::warn!(
+                directory_url = %url,
+                "ACME directory URL is not HTTPS; the ACME exchange is not protected against \
+                 man-in-the-middle tampering. Use an https:// directory in production."
+            );
+        }
         Self {
             directory_name: name.into(),
-            directory_url: url.into(),
+            directory_url: url,
             ..self
         }
     }

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -181,7 +181,9 @@ impl Handler for ForceHttps {
             } else {
                 // Fail closed: a malformed redirect target must not fall through to
                 // serving the request over plaintext HTTP, which would defeat the
-                // purpose of this middleware.
+                // purpose of this middleware. Clear any body an earlier hoop may
+                // have written so it cannot be leaked alongside the 400 status.
+                res.body(ResBody::None);
                 res.status_code(StatusCode::BAD_REQUEST);
                 ctrl.skip_rest();
             }
@@ -239,6 +241,32 @@ mod tests {
     async fn hello() -> &'static str {
         "Hello World"
     }
+
+    #[handler]
+    async fn leak_plaintext(res: &mut Response) {
+        res.render("leaked plaintext");
+    }
+
+    #[tokio::test]
+    async fn test_fail_closed_clears_earlier_body() {
+        // An earlier hoop writes a body, then `ForceHttps` hits a malformed
+        // redirect target (`Host` with a space is not a valid authority) and
+        // fails closed. The 400 must not leak the earlier plaintext body.
+        let router = Router::with_hoop(leak_plaintext)
+            .hoop(ForceHttps::new().trust_host_header(true))
+            .goal(hello);
+        let mut response = TestClient::get("http://127.0.0.1:8698/")
+            .add_header(HOST, "bad host", true)
+            .send(router)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_ne!(
+            response.take_string().await.unwrap_or_default(),
+            "leaked plaintext"
+        );
+    }
+
     #[tokio::test]
     async fn test_redirect_handler() {
         let router =

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -190,11 +190,18 @@ impl Handler for ForceHttps {
 }
 
 fn redirect_host(host: &str, https_port: Option<u16>) -> Cow<'_, str> {
-    match (host.split_once(':'), https_port) {
-        (Some((host, _)), Some(port)) => Cow::Owned(format!("{host}:{port}")),
-        (None, Some(port)) => Cow::Owned(format!("{host}:{port}")),
-        (_, None) => Cow::Borrowed(host),
-    }
+    let Some(port) = https_port else {
+        return Cow::Borrowed(host);
+    };
+    // Strip any existing port before appending the configured one. IPv6 literals
+    // are bracketed (`[::1]` / `[::1]:8080`), so the port separator is the colon
+    // *after* the closing bracket — splitting on the first colon would land in
+    // the middle of the address and corrupt it (`[:PORT`).
+    let host_part = match host.rfind(']') {
+        Some(close) => &host[..=close],
+        None => host.split_once(':').map_or(host, |(h, _)| h),
+    };
+    Cow::Owned(format!("{host_part}:{port}"))
 }
 
 #[cfg(test)]
@@ -215,6 +222,17 @@ mod tests {
         assert_eq!(redirect_host("example.com", Some(1234)), "example.com:1234");
         assert_eq!(redirect_host("example.com:1234", None), "example.com:1234");
         assert_eq!(redirect_host("example.com", None), "example.com");
+
+        // IPv6 literals must keep the bracketed address intact and only swap the
+        // trailing port, instead of being split at the first colon.
+        assert_eq!(redirect_host("[::1]", Some(5443)), "[::1]:5443");
+        assert_eq!(redirect_host("[::1]:8698", Some(5443)), "[::1]:5443");
+        assert_eq!(
+            redirect_host("[2001:db8::1]:8698", Some(5443)),
+            "[2001:db8::1]:5443"
+        );
+        assert_eq!(redirect_host("[::1]:8698", None), "[::1]:8698");
+        assert_eq!(redirect_host("[::1]", None), "[::1]");
     }
 
     #[handler]

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -49,7 +49,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use salvo_core::handler::Skipper;
 use salvo_core::http::header;
 use salvo_core::http::uri::{Scheme, Uri};
-use salvo_core::http::{Request, ResBody, Response};
+use salvo_core::http::{Request, ResBody, Response, StatusCode};
 use salvo_core::writing::Redirect;
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 
@@ -177,6 +177,12 @@ impl Handler for ForceHttps {
             if let Ok(uri) = builder.build() {
                 res.body(ResBody::None);
                 res.render(Redirect::permanent(uri.to_string()));
+                ctrl.skip_rest();
+            } else {
+                // Fail closed: a malformed redirect target must not fall through to
+                // serving the request over plaintext HTTP, which would defeat the
+                // purpose of this middleware.
+                res.status_code(StatusCode::BAD_REQUEST);
                 ctrl.skip_rest();
             }
         }

--- a/crates/jwt-auth/src/oidc/cache.rs
+++ b/crates/jwt-auth/src/oidc/cache.rs
@@ -44,6 +44,11 @@ impl CachePolicy {
     }
 
     fn parse_str(&mut self, value: &str) {
+        // Upper bound for any cache directive (30 days). Without it, a malicious or
+        // misconfigured IdP returning a huge `max-age` could overflow the downstream
+        // `fetched + max_age` arithmetic (debug panic / release wrap) and pin a stale
+        // JWKS indefinitely.
+        const MAX_CACHE_AGE_SECS: u64 = 30 * 24 * 60 * 60;
         // Iterate over every token in the header value
         for token in value.split(',') {
             // split them into whitespace trimmed pairs
@@ -56,17 +61,21 @@ impl CachePolicy {
             match (key, directive_value) {
                 (Some("max-age"), Some(directive_value)) => {
                     if let Ok(secs) = directive_value.parse::<u64>() {
-                        self.max_age = Duration::from_secs(secs);
+                        // Keep at least 1s so `max-age=0` cannot make every request
+                        // revalidate and amplify load back onto the IdP.
+                        self.max_age = Duration::from_secs(secs.clamp(1, MAX_CACHE_AGE_SECS));
                     }
                 }
                 (Some("stale-while-revalidate"), Some(directive_value)) => {
                     if let Ok(secs) = directive_value.parse::<u64>() {
-                        self.stale_while_revalidate = Some(Duration::from_secs(secs));
+                        self.stale_while_revalidate =
+                            Some(Duration::from_secs(secs.min(MAX_CACHE_AGE_SECS)));
                     }
                 }
                 (Some("stale-if-error"), Some(directive_value)) => {
                     if let Ok(secs) = directive_value.parse::<u64>() {
-                        self.stale_if_error = Some(Duration::from_secs(secs));
+                        self.stale_if_error =
+                            Some(Duration::from_secs(secs.min(MAX_CACHE_AGE_SECS)));
                     }
                 }
                 _ => {},

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -311,12 +311,46 @@ impl RateIssuer for TrustedProxyIssuer {
         let remote_ip = req.remote_addr().ip();
         if let Some(remote_ip) = remote_ip
             && self.trusted_proxies.contains(&remote_ip)
-            && let Some(forwarded) = extract_forwarded_ip(req)
+            && let Some(forwarded) = extract_client_ip_via_trusted_proxies(req, &self.trusted_proxies)
         {
             return Some(forwarded);
         }
         remote_ip
     }
+}
+
+/// Determine the real client IP for a request that arrived through a trusted proxy.
+///
+/// `X-Forwarded-For` is appended left-to-right (`client, proxy1, proxy2`), so the
+/// untrusted client address is found by scanning **right-to-left** and returning the
+/// first entry that is not itself a trusted proxy. Taking the leftmost value (as the
+/// legacy [`ForwardedHeaderIssuer`] does) would let a client spoof its address by
+/// pre-populating the header before it reaches the trusted proxy.
+fn extract_client_ip_via_trusted_proxies(
+    req: &Request,
+    trusted: &HashSet<IpAddr>,
+) -> Option<IpAddr> {
+    if let Some(xff) = req.headers().get("x-forwarded-for")
+        && let Ok(xff_str) = xff.to_str()
+    {
+        for part in xff_str.rsplit(',') {
+            if let Ok(ip) = part.trim().parse::<IpAddr>()
+                && !trusted.contains(&ip)
+            {
+                return Some(ip);
+            }
+        }
+    }
+
+    // No usable forwarded address; fall back to `X-Real-IP` set by the trusted proxy.
+    if let Some(real_ip) = req.headers().get("x-real-ip")
+        && let Ok(real_ip_str) = real_ip.to_str()
+        && let Ok(ip) = real_ip_str.trim().parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    None
 }
 
 /// Parse the first usable IP out of `X-Forwarded-For` / `X-Real-IP`.
@@ -825,6 +859,33 @@ mod tests {
 
         let ip = issuer.issue(&mut req, &depot).await.expect("ip");
         assert_eq!(ip, "203.0.113.42".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_trusted_proxy_issuer_ignores_spoofed_leftmost_xff() {
+        // A client spoofs `X-Forwarded-For: 1.2.3.4` before reaching the trusted
+        // proxy, which appends the real peer address. The issuer must return the
+        // real client (rightmost non-trusted), not the spoofed leftmost value.
+        let issuer = TrustedProxyIssuer::new(["10.0.0.5".parse::<IpAddr>().unwrap()]);
+        let mut req = make_req_from_proxy("10.0.0.5", Some("1.2.3.4, 198.51.100.7"), None);
+        let depot = Depot::new();
+
+        let ip = issuer.issue(&mut req, &depot).await.expect("ip");
+        assert_eq!(ip, "198.51.100.7".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_trusted_proxy_issuer_skips_chained_trusted_proxies() {
+        // Two trusted proxies in the chain: both must be skipped right-to-left.
+        let issuer = TrustedProxyIssuer::new([
+            "10.0.0.5".parse::<IpAddr>().unwrap(),
+            "10.0.0.6".parse::<IpAddr>().unwrap(),
+        ]);
+        let mut req = make_req_from_proxy("10.0.0.6", Some("198.51.100.7, 10.0.0.5, 10.0.0.6"), None);
+        let depot = Depot::new();
+
+        let ip = issuer.issue(&mut req, &depot).await.expect("ip");
+        assert_eq!(ip, "198.51.100.7".parse::<IpAddr>().unwrap());
     }
 
     #[test]

--- a/crates/tus/src/utils.rs
+++ b/crates/tus/src/utils.rs
@@ -40,7 +40,9 @@ pub fn normalize_path(p: &str) -> String {
 /// This prevents path traversal attacks via malicious upload IDs.
 #[must_use]
 pub fn is_safe_upload_id(id: &str) -> bool {
-    if id.is_empty() {
+    // Reject empty or excessively long IDs. A length cap bounds the resulting file
+    // path length and limits abuse of the endpoint with attacker-chosen IDs.
+    if id.is_empty() || id.len() > 256 {
         return false;
     }
     // Only allow alphanumeric characters, dashes, and underscores


### PR DESCRIPTION
## Background

Part of a project-wide audit, this PR groups confirmed "security hardening" fixes. Each was verified by reading the source; the affected crates build and test cleanly.

## Fixes

### 1. rate-limiter: `TrustedProxyIssuer` could be bypassed with a spoofed IP (high severity)
`extract_forwarded_ip` took the **leftmost** `X-Forwarded-For` entry as the client IP. `X-Forwarded-For` is append-only, so the leftmost value is written by the client and fully attacker-controlled: an attacker could rotate forged IPs to bypass per-IP rate limiting — exactly what `TrustedProxyIssuer` is supposed to prevent.

It now scans the header **right-to-left**, skipping configured trusted proxies, and returns the first non-trusted address (the real client). Two regression tests are added: a spoofed leftmost value, and a chain of trusted proxies. The legacy `ForwardedHeaderIssuer` (documented as unconditionally trusting) is unchanged.

### 2. jwt-auth: JWKS/OIDC `Cache-Control` directives were unbounded
`max-age`/`stale-*` parsed from the IdP had no bounds: `max-age=0` forced revalidation on every request (amplifying load back to the IdP), and a huge value could overflow the downstream `fetched + max_age` arithmetic (debug panic / release wrap). `max-age` is now clamped to `[1s, 30d]`; `stale-*` are capped at 30d.

### 3. acme: directory URL had no scheme check
A misconfigured `http://` directory leaves the entire ACME exchange open to MITM tampering. A non-HTTPS directory URL now emits a `warn` (http is kept for test environments such as pebble).

### 4. force_https: fail-open on redirect build failure
When the redirect URI failed to build, the old code silently fell through and served the plaintext request, defeating the middleware. It now fails closed (returns 400 and `skip_rest`).

### 5. tus: `is_safe_upload_id` had no length cap
Adds a 256-byte cap to bound the resulting file-path length and limit abuse with attacker-chosen IDs.

## Testing
- `cargo test -p salvo-rate-limiter -p salvo-jwt-auth -p salvo_extra -p salvo-tus -p salvo-acme` — all pass (including the two new rate-limiter regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)