### PR TITLE
fix(core): correct conditional-request ordering, multi-range and IPv6 handling

### DIFF
--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -721,29 +721,9 @@ impl NamedFile {
             res.headers_mut()
                 .insert(CONTENT_ENCODING, content_encoding.clone());
         }
-        let mut offset = 0;
-
-        // check for range header
-        let range = req_headers.get(RANGE);
-        if let Some(range) = range {
-            if let Ok(range) = range.to_str() {
-                if let Ok(range) = HttpRange::parse(range, length)
-                    && !range.is_empty()
-                {
-                    length = range[0].length;
-                    offset = range[0].start;
-                } else {
-                    res.headers_mut()
-                        .typed_insert(ContentRange::unsatisfied_bytes(length));
-                    res.status_code(StatusCode::RANGE_NOT_SATISFIABLE);
-                    return;
-                };
-            } else {
-                res.status_code(StatusCode::BAD_REQUEST);
-                return;
-            };
-        }
-
+        // Conditional request handling must precede Range processing: per RFC 7232
+        // a `304 Not Modified` / `412 Precondition Failed` takes priority over the
+        // `206`/`416` produced by a Range request.
         if precondition_failed {
             res.status_code(StatusCode::PRECONDITION_FAILED);
             return;
@@ -752,10 +732,44 @@ impl NamedFile {
             return;
         }
 
-        if offset != 0 || length != self.metadata.len() || range.is_some() {
+        let file_size = self.metadata.len();
+        let mut offset = 0;
+        let mut is_partial = false;
+
+        // check for range header
+        if let Some(range) = req_headers.get(RANGE) {
+            let Ok(range) = range.to_str() else {
+                res.status_code(StatusCode::BAD_REQUEST);
+                return;
+            };
+            match HttpRange::parse(range, length) {
+                // A single range is served as `206 Partial Content`.
+                Ok(ranges) if ranges.len() == 1 => {
+                    offset = ranges[0].start;
+                    length = ranges[0].length;
+                    is_partial = true;
+                }
+                // Multiple ranges would require a `multipart/byteranges` body, which
+                // is not supported here. Per RFC 7233 the server may ignore the Range
+                // header and return the full `200 OK` representation instead.
+                Ok(ranges) if ranges.len() > 1 => {}
+                // Empty / unsatisfiable range.
+                _ => {
+                    res.headers_mut()
+                        .typed_insert(ContentRange::unsatisfied_bytes(length));
+                    res.status_code(StatusCode::RANGE_NOT_SATISFIABLE);
+                    return;
+                }
+            }
+        }
+
+        if is_partial {
             // Range request
             res.status_code(StatusCode::PARTIAL_CONTENT);
-            match ContentRange::bytes(offset..offset.saturating_add(length), self.metadata.len()) {
+            // Single source of truth for the byte count, clamped to the file so the
+            // `Content-Range`, `Content-Length` and the body always agree.
+            let total_size = length.min(file_size.saturating_sub(offset));
+            match ContentRange::bytes(offset..offset.saturating_add(total_size), file_size) {
                 Ok(content_range) => {
                     res.headers_mut().typed_insert(content_range);
                 }
@@ -763,12 +777,11 @@ impl NamedFile {
                     tracing::error!(error = ?e, "set file's content range failed");
                 }
             }
-            let total_size = cmp::min(length, self.metadata.len());
             res.headers_mut().typed_insert(ContentLength(total_size));
 
             // Fast path: slice from preread bytes if available
             if let Some(preread) = self.preread {
-                let end = cmp::min(offset.saturating_add(length) as usize, preread.len());
+                let end = cmp::min(offset.saturating_add(total_size) as usize, preread.len());
                 let start = cmp::min(offset as usize, end);
                 res.replace_body(ResBody::Once(preread.slice(start..end)));
             } else {

--- a/crates/core/src/http/range.rs
+++ b/crates/core/src/http/range.rs
@@ -25,7 +25,11 @@ impl HttpRange {
             return Err(ParseError::InvalidRange);
         };
 
-        let size_sig = size as i64;
+        // Clamp to `i64::MAX`: the signed arithmetic below would otherwise wrap a
+        // `size` above `i64::MAX` into a negative value and corrupt every bound.
+        // Files larger than 8 EiB are not addressable here and do not occur in
+        // practice.
+        let size_sig = size.min(i64::MAX as u64) as i64;
         let mut no_overlap = false;
 
         let all_ranges: Vec<Option<Self>> = ranges_header

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -119,6 +119,27 @@ impl HostFilter {
     }
 }
 
+/// Split an authority into its host and optional port.
+///
+/// Handles bracketed IPv6 literals such as `[::1]` and `[::1]:8080` correctly; a
+/// naive `rsplit_once(':')` would split inside the address.
+fn split_host_port(authority: &str) -> (&str, Option<&str>) {
+    if authority.starts_with('[') {
+        // IPv6 literal: the host ends at the closing bracket.
+        if let Some(close) = authority.find(']') {
+            let host = &authority[..=close];
+            let port = authority[close + 1..]
+                .strip_prefix(':')
+                .filter(|p| !p.is_empty());
+            return (host, port);
+        }
+    }
+    match authority.rsplit_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (authority, None),
+    }
+}
+
 #[async_trait]
 impl Filter for HostFilter {
     #[inline]
@@ -133,17 +154,8 @@ impl Filter for HostFilter {
                 .get(crate::http::header::HOST)
                 .and_then(|h| h.to_str().ok())
         });
-        host.map(|h| {
-            if h.contains(':') {
-                h.rsplit_once(':')
-                    .expect("rsplit_once by ':' should not return `None`")
-                    .0
-            } else {
-                h
-            }
-        })
-        .map(|h| h == self.host)
-        .unwrap_or(self.fallback)
+        host.map(|h| split_host_port(h).0 == self.host)
+            .unwrap_or(self.fallback)
     }
     #[inline]
     fn info(&self) -> FilterInfo {
@@ -205,18 +217,10 @@ impl Filter for PortFilter {
                 .get(crate::http::header::HOST)
                 .and_then(|h| h.to_str().ok())
         });
-        host.map(|h| {
-            if h.contains(':') {
-                h.rsplit_once(':')
-                    .expect("rsplit_once by ':' should not return `None`")
-                    .1
-            } else {
-                h
-            }
-        })
-        .and_then(|p| p.parse::<u16>().ok())
-        .map(|p| p == self.port)
-        .unwrap_or(self.fallback)
+        host.and_then(|h| split_host_port(h).1)
+            .and_then(|p| p.parse::<u16>().ok())
+            .map(|p| p == self.port)
+            .unwrap_or(self.fallback)
     }
     #[inline]
     fn info(&self) -> FilterInfo {
@@ -233,6 +237,22 @@ impl Debug for PortFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_host_port_handles_ipv4_and_ipv6() {
+        assert_eq!(split_host_port("example.com"), ("example.com", None));
+        assert_eq!(
+            split_host_port("example.com:8080"),
+            ("example.com", Some("8080"))
+        );
+        // IPv6 literals must not be split inside the address.
+        assert_eq!(split_host_port("[::1]"), ("[::1]", None));
+        assert_eq!(split_host_port("[::1]:8080"), ("[::1]", Some("8080")));
+        assert_eq!(
+            split_host_port("[2001:db8::1]:443"),
+            ("[2001:db8::1]", Some("443"))
+        );
+    }
 
     #[tokio::test]
     async fn fallback_sets_scheme_filter_result_when_scheme_is_absent() {

--- a/crates/core/src/writing/seek.rs
+++ b/crates/core/src/writing/seek.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::io::SeekFrom;
 use std::time::SystemTime;
 
@@ -98,29 +97,9 @@ where
         }
         res.headers_mut().typed_insert(AcceptRanges::bytes());
 
-        let mut offset = 0;
-        let mut length = self.length;
-        // check for range header
-        let range = req_headers.get(RANGE);
-        if let Some(range) = range {
-            if let Ok(range) = range.to_str() {
-                if let Ok(range) = HttpRange::parse(range, length)
-                    && !range.is_empty()
-                {
-                    length = range[0].length;
-                    offset = range[0].start;
-                } else {
-                    res.headers_mut()
-                        .typed_insert(ContentRange::unsatisfied_bytes(length));
-                    res.status_code(StatusCode::RANGE_NOT_SATISFIABLE);
-                    return;
-                };
-            } else {
-                res.status_code(StatusCode::BAD_REQUEST);
-                return;
-            };
-        }
-
+        // Conditional request handling must precede Range processing: per RFC 7232
+        // a `304 Not Modified` / `412 Precondition Failed` takes priority over the
+        // `206`/`416` produced by a Range request.
         if precondition_failed {
             res.status_code(StatusCode::PRECONDITION_FAILED);
             return;
@@ -129,9 +108,43 @@ where
             return;
         }
 
-        if offset != 0 || length != self.length || range.is_some() {
+        let mut offset = 0;
+        let mut length = self.length;
+        let mut is_partial = false;
+        // check for range header
+        if let Some(range) = req_headers.get(RANGE) {
+            let Ok(range) = range.to_str() else {
+                res.status_code(StatusCode::BAD_REQUEST);
+                return;
+            };
+            match HttpRange::parse(range, length) {
+                // A single range is served as `206 Partial Content`.
+                Ok(ranges) if ranges.len() == 1 => {
+                    offset = ranges[0].start;
+                    length = ranges[0].length;
+                    is_partial = true;
+                }
+                // Multiple ranges would require a `multipart/byteranges` body, which
+                // is not supported here. Per RFC 7233 the server may ignore the Range
+                // header and return the full `200 OK` representation instead.
+                Ok(ranges) if ranges.len() > 1 => {}
+                // Empty / unsatisfiable range.
+                _ => {
+                    res.headers_mut()
+                        .typed_insert(ContentRange::unsatisfied_bytes(length));
+                    res.status_code(StatusCode::RANGE_NOT_SATISFIABLE);
+                    return;
+                }
+            }
+        }
+
+        if is_partial {
             res.status_code(StatusCode::PARTIAL_CONTENT);
-            match ContentRange::bytes(offset..offset.saturating_add(length), self.length) {
+            // Derive the byte count from a single source and clamp defensively so the
+            // declared `Content-Range`, `Content-Length` and the streamed body always
+            // agree on the number of bytes.
+            let content_length = length.min(self.length.saturating_sub(offset));
+            match ContentRange::bytes(offset..offset.saturating_add(content_length), self.length) {
                 Ok(content_range) => {
                     res.headers_mut().typed_insert(content_range);
                 }
@@ -144,9 +157,6 @@ where
                 res.render(StatusError::bad_request().brief("seek file failed"));
                 return;
             }
-            // Only stream the requested range, not the rest of the reader. The
-            // declared `Content-Length` must match the number of bytes written.
-            let content_length = cmp::min(length, self.length);
             res.headers_mut()
                 .typed_insert(ContentLength(content_length));
             res.stream(ReaderStream::new(self.reader.take(content_length)));


### PR DESCRIPTION
## Background

Part of a project-wide audit, this PR groups confirmed "HTTP protocol correctness" fixes. All changes pass `cargo test -p salvo_core` (including a new IPv6 unit test).

## Fixes

### 1. Conditional-request ordering (RFC 7232)
`ReadSeeker::send` (writing/seek.rs) and `NamedFile::send` (fs/named_file.rs) parsed the `Range` header **before** evaluating preconditions. A request with both `If-None-Match` and an unsatisfiable `Range` returned `416` instead of `304`. The 304/412 checks are now performed before Range processing.

### 2. Multi-range requests
`HttpRange::parse` returns a list of ranges, but the old code used only `range[0]` while still returning `206` — multiple ranges semantically require a `multipart/byteranges` body. The handling is now explicit:
- single range → `206 Partial Content`
- multiple ranges → unsupported multipart, so per RFC 7233 the `Range` is ignored and the full `200 OK` representation is returned
- empty / unsatisfiable → `416`

The streamed byte count is also derived from a single, file-clamped source so `Content-Range`, `Content-Length` and the body length always agree (removing the `saturating_add` inconsistency).

### 3. `HttpRange::parse` i64 overflow
`size as i64` wraps a `size` above `i64::MAX` into a negative value, corrupting every bound. `size` is now clamped with `size.min(i64::MAX as u64)` first (files above 8 EiB are not addressable here and do not occur in practice).

### 4. IPv6 host/port parsing
`HostFilter`/`PortFilter` split the authority with `rsplit_once(':')`, which splits inside IPv6 literals (`[::1]`, `[::1]:8080`). A bracket-aware `split_host_port` helper is introduced, with a unit test covering IPv4/IPv6 with and without a port.

## Testing
- `cargo test -p salvo_core` — 205+ tests pass, plus the new `split_host_port_handles_ipv4_and_ipv6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)