### PR TITLE
fix: harden routing param insertion, path parser and websocket upgrade

### DIFF
--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -691,7 +691,9 @@ impl PathParser {
     }
     #[inline]
     fn next(&mut self, skip_blanks: bool) -> Option<char> {
-        if self.offset < self.path.len() - 1 {
+        // `offset + 1 < len` rather than `offset < len - 1`: the latter underflows
+        // to `usize::MAX` when `path` is empty (e.g. the root path `/`).
+        if self.offset + 1 < self.path.len() {
             self.offset += 1;
             if skip_blanks {
                 self.skip_blanks();
@@ -704,7 +706,7 @@ impl PathParser {
     }
     #[inline]
     fn peek(&self, skip_blanks: bool) -> Option<char> {
-        if self.offset < self.path.len() - 1 {
+        if self.offset + 1 < self.path.len() {
             if skip_blanks {
                 let mut offset = self.offset + 1;
                 let mut ch = self.path[offset];

--- a/crates/core/src/routing/path_params.rs
+++ b/crates/core/src/routing/path_params.rs
@@ -40,11 +40,21 @@ impl PathParams {
 
     /// Insert new param.
     pub fn insert(&mut self, name: &str, value: String) {
-        #[cfg(debug_assertions)]
-        {
-            if self.greedy {
-                panic!("only one wildcard param is allowed and it must be the last one");
-            }
+        if self.greedy {
+            // A wildcard param must be the last one. Reaching here means an earlier
+            // wildcard was not rolled back correctly. In debug builds this is a bug
+            // worth catching loudly; in release we must not silently corrupt the
+            // existing params (the previous code kept inserting), so drop the stray
+            // insert and log instead.
+            debug_assert!(
+                false,
+                "only one wildcard param is allowed and it must be the last one"
+            );
+            tracing::error!(
+                param = name,
+                "ignoring a param inserted after a wildcard param; this indicates a routing bug"
+            );
+            return;
         }
         if name.starts_with('*') {
             self.inner.insert(split_wild_name(name).1.to_owned(), value);

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -462,9 +462,16 @@ impl WebSocketUpgrade {
                         tracing::debug!("websocket upgrade complete");
                         WebSocket::from_raw_socket(upgraded, protocol::Role::Server, config).map(Ok)
                     })
-                    .await
-                    .expect("connection upgrade failed");
-                callback(socket).await;
+                    .await;
+                match socket {
+                    Ok(socket) => callback(socket).await,
+                    Err(error) => {
+                        // The client can drop the connection before the upgrade
+                        // completes; that is a normal network condition, not a bug,
+                        // so log it instead of panicking inside the spawned task.
+                        tracing::debug!(?error, "websocket connection upgrade failed");
+                    }
+                }
             });
             Ok(())
         } else {


### PR DESCRIPTION
## Background

Part of a project-wide audit, this PR groups confirmed robustness / panic-safety fixes.

## Fixes

### 1. `routing/path_params`: wildcard guard was debug-only
A wildcard param must be the last one. The duplicate-insert guard was wrapped in `#[cfg(debug_assertions)]`, so in release builds — if a sibling route was not rolled back correctly — it kept inserting and silently corrupted the params order and `tail()`. The guard now uses `debug_assert!` (still loud in debug) and, in release, drops the stray insert and logs an error instead of corrupting existing state.

### 2. `routing/filters/path`: `PathParser` integer underflow
`PathParser::next`/`peek` used `self.offset < self.path.len() - 1`, which underflows to `usize::MAX` when `path` is empty (e.g. the root path `/` after trimming). Switched to `self.offset + 1 < self.path.len()`, which is underflow-free.

### 3. `extra/websocket`: panic on aborted upgrade
The connection-upgrade future was unwrapped with `.expect("connection upgrade failed")` inside a spawned task. A client dropping the connection before the upgrade completes is a normal network condition, so this produced spurious panics. The error is now handled and logged instead.

## Testing
- `cargo build -p salvo_core -p salvo_extra` — clean.
- `cargo test -p salvo_core --lib routing` — 66 tests pass, including the wildcard-sibling rollback regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)