### PR TITLE
perf(core): single map lookup for depot value extraction

### DIFF
--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -221,6 +221,15 @@ impl Depot {
         }
     }
 
+    /// Borrow the type-erased value stored under `key` via [`Depot::insert`], if any.
+    ///
+    /// Lets a caller that probes many concrete types do a single map lookup and
+    /// then `downcast_ref` repeatedly, instead of one lookup per candidate type.
+    #[inline]
+    pub(crate) fn get_any(&self, key: &str) -> Option<&(dyn Any + Send + Sync)> {
+        self.named.get(key).map(|v| &**v as &(dyn Any + Send + Sync))
+    }
+
     /// Mutably borrows value from depot.
     ///
     /// Returns `Err(None)` if value is not present in depot.
@@ -231,10 +240,10 @@ impl Depot {
         key: &str,
     ) -> Result<&mut V, Option<&mut Box<dyn Any + Send + Sync>>> {
         if let Some(value) = self.named.get_mut(key) {
-            if value.downcast_mut::<V>().is_some() {
+            if value.is::<V>() {
                 Ok(value
                     .downcast_mut::<V>()
-                    .expect("downcast_mut should not be failed"))
+                    .expect("type checked by is::<V>() above"))
             } else {
                 Err(Some(value))
             }

--- a/crates/core/src/depot.rs
+++ b/crates/core/src/depot.rs
@@ -227,7 +227,9 @@ impl Depot {
     /// then `downcast_ref` repeatedly, instead of one lookup per candidate type.
     #[inline]
     pub(crate) fn get_any(&self, key: &str) -> Option<&(dyn Any + Send + Sync)> {
-        self.named.get(key).map(|v| &**v as &(dyn Any + Send + Sync))
+        self.named
+            .get(key)
+            .map(|v| &**v as &(dyn Any + Send + Sync))
     }
 
     /// Mutably borrows value from depot.

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -16,53 +16,36 @@ use crate::http::header::HeaderMap;
 use crate::serde::{CowValue, FlatValue, VecValue};
 use crate::{Depot, Request};
 
-/// Type alias for depot value extractor functions.
-/// Each extractor attempts to extract a specific type from the Depot and convert it to `Cow<str>`.
-type DepotExtractFn = for<'a> fn(&'a Depot, &str) -> Option<Cow<'a, str>>;
-
-/// Registry of depot value extractors.
-/// Extractors are tried in order until one succeeds.
-/// String types that can be borrowed are listed first for efficiency.
-static DEPOT_EXTRACTORS: &[DepotExtractFn] = &[
-    // Borrowable string types (most common, listed first)
-    |d, k| d.get::<String>(k).ok().map(|v| Cow::Borrowed(v.as_str())),
-    |d, k| d.get::<&'static str>(k).ok().map(|v| Cow::Borrowed(*v)),
-    |d, k| {
-        d.get::<Arc<String>>(k)
-            .ok()
-            .map(|v| Cow::Borrowed(v.as_str()))
-    },
-    |d, k| d.get::<Arc<str>>(k).ok().map(|v| Cow::Borrowed(&**v)),
-    // Signed integer types
-    |d, k| d.get::<i8>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<i16>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<i32>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<i64>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<i128>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<isize>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    // Unsigned integer types
-    |d, k| d.get::<u8>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<u16>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<u32>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<u64>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<u128>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<usize>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    // Floating point types
-    |d, k| d.get::<f32>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    |d, k| d.get::<f64>(k).ok().map(|v| Cow::Owned(v.to_string())),
-    // Boolean
-    |d, k| d.get::<bool>(k).ok().map(|v| Cow::Owned(v.to_string())),
-];
-
 /// Helper function to extract a value from Depot and convert it to a `Cow<str>`.
 /// Supports `String`, `&str`, `Arc<String>`, `Arc<str>`, and common primitive types (integers,
 /// floats, bool).
+///
+/// Does a single map lookup and then probes the candidate types with cheap
+/// `downcast_ref`s, rather than one map lookup per candidate type.
 fn get_depot_value<'a>(depot: &'a Depot, key: &str) -> Option<Cow<'a, str>> {
-    for extractor in DEPOT_EXTRACTORS {
-        if let Some(value) = extractor(depot, key) {
-            return Some(value);
-        }
+    let any = depot.get_any(key)?;
+    // Borrowable string types (most common, listed first).
+    if let Some(v) = any.downcast_ref::<String>() {
+        return Some(Cow::Borrowed(v.as_str()));
     }
+    if let Some(v) = any.downcast_ref::<&'static str>() {
+        return Some(Cow::Borrowed(*v));
+    }
+    if let Some(v) = any.downcast_ref::<Arc<String>>() {
+        return Some(Cow::Borrowed(v.as_str()));
+    }
+    if let Some(v) = any.downcast_ref::<Arc<str>>() {
+        return Some(Cow::Borrowed(&**v));
+    }
+    // Numeric and boolean types, rendered to an owned string.
+    macro_rules! try_display {
+        ($($t:ty),* $(,)?) => {$(
+            if let Some(v) = any.downcast_ref::<$t>() {
+                return Some(Cow::Owned(v.to_string()));
+            }
+        )*};
+    }
+    try_display!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64, bool);
     None
 }
 

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -45,7 +45,9 @@ fn get_depot_value<'a>(depot: &'a Depot, key: &str) -> Option<Cow<'a, str>> {
             }
         )*};
     }
-    try_display!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64, bool);
+    try_display!(
+        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64, bool
+    );
     None
 }
 


### PR DESCRIPTION
## Background

Part of a project-wide audit, this PR addresses a hot-path inefficiency in depot-based extraction.

## Changes

### 1. `get_depot_value`: 19 map lookups → 1
Extracting a field from the depot (`#[salvo(extract(source(from = "depot")))]`) previously iterated a table of 19 closures, each calling `depot.get::<T>(key)` — i.e. up to 19 `HashMap<String, _>` lookups (each hashing the key) per field.

A new `pub(crate) Depot::get_any` returns the type-erased value, so `get_depot_value` now does **one** lookup and then probes the candidate types with cheap `downcast_ref`s (a `TypeId` comparison). A boxed value has exactly one concrete type, so probe order does not affect the result — behaviour is unchanged.

### 2. `Depot::get_mut`: redundant downcast removed
`get_mut` called `downcast_mut::<V>()` twice (once to test, once to return). It now checks `is::<V>()` then downcasts once, consistent with `get_typed_mut`.

## Testing
- `cargo test -p salvo_core --lib` — 205 tests pass, no regression (depot + serde request deserializer covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)