### PR TITLE
fix(oapi-macros): turn user-triggerable panics into compile errors

### DIFF
--- a/crates/oapi-macros/src/endpoint.rs
+++ b/crates/oapi-macros/src/endpoint.rs
@@ -1,9 +1,13 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
-use syn::{Expr, Ident, ImplItem, Item, Pat, ReturnType, Signature, Type};
+use syn::spanned::Spanned;
+use syn::{Expr, Ident, ImplItem, Item, Lit, Pat, ReturnType, Signature, Type};
 
 use crate::doc_comment::CommentAttributes;
-use crate::{Array, DiagResult, InputType, Operation, omit_type_path_lifetimes, parse_input_type};
+use crate::{
+    Array, DiagLevel, DiagResult, Diagnostic, InputType, Operation, omit_type_path_lifetimes,
+    parse_input_type,
+};
 
 mod attr;
 pub(crate) use attr::EndpointAttr;
@@ -47,18 +51,43 @@ fn metadata(
     );
     let opt = Operation::new(attr);
     modifiers.append(opt.modifiers()?.as_mut());
-    let status_codes = Array::from_iter(attr.status_codes.iter().map(|expr| match expr {
-        Expr::Lit(lit) => {
-            quote! {
-                #salvo::http::StatusCode::from_u16(#lit).unwrap()
-            }
+    let mut status_code_tokens = Vec::with_capacity(attr.status_codes.len());
+    for expr in &attr.status_codes {
+        match expr {
+            Expr::Lit(expr_lit) => match &expr_lit.lit {
+                Lit::Int(lit_int) => {
+                    // Validate the literal at expansion time so an out-of-range value
+                    // produces a clear compile error instead of a runtime `unwrap`
+                    // panic during route registration.
+                    let code: u16 = lit_int.base10_parse().map_err(|e| {
+                        Diagnostic::spanned(lit_int.span(), DiagLevel::Error, e.to_string())
+                    })?;
+                    if !(100..=599).contains(&code) {
+                        return Err(Diagnostic::spanned(
+                            lit_int.span(),
+                            DiagLevel::Error,
+                            format!(
+                                "invalid HTTP status code `{code}`: must be in the range 100..=599"
+                            ),
+                        ));
+                    }
+                    status_code_tokens.push(quote! {
+                        #salvo::http::StatusCode::from_u16(#code)
+                            .expect("status code validated at compile time")
+                    });
+                }
+                _ => {
+                    return Err(Diagnostic::spanned(
+                        expr_lit.span(),
+                        DiagLevel::Error,
+                        "`status_codes` entries must be integer literals or `StatusCode` expressions",
+                    ));
+                }
+            },
+            _ => status_code_tokens.push(quote! { #expr }),
         }
-        _ => {
-            quote! {
-                #expr
-            }
-        }
-    }));
+    }
+    let status_codes = Array::from_iter(status_code_tokens);
     let modifiers = if modifiers.is_empty() {
         None
     } else {

--- a/crates/oapi-macros/src/response/derive.rs
+++ b/crates/oapi-macros/src/response/derive.rs
@@ -38,11 +38,13 @@ impl<'a> ToResponse<'a> {
                     ToResponseNamedStructResponse::new(attributes, ident, &fields.named)?.0
                 }
                 Fields::Unnamed(fields) => {
-                    let field = fields
-                        .unnamed
-                        .iter()
-                        .next()
-                        .expect("unnamed struct must have 1 field");
+                    let field = fields.unnamed.iter().next().ok_or_else(|| {
+                        Diagnostic::spanned(
+                            ident.span(),
+                            DiagLevel::Error,
+                            "`ToResponse` requires the tuple struct to have exactly one field",
+                        )
+                    })?;
                     ToResponseUnnamedStructResponse::new(attributes, &field.ty, &field.attrs)?.0
                 }
                 Fields::Unit => ToResponseUnitStructResponse::new(attributes)?.0,
@@ -114,11 +116,13 @@ impl TryToTokens for ToResponses<'_> {
                     Array::from_iter(iter::once(quote!((#status_code, #response))))
                 }
                 Fields::Unnamed(fields) => {
-                    let field = fields
-                        .unnamed
-                        .iter()
-                        .next()
-                        .expect("Unnamed struct must have 1 field");
+                    let field = fields.unnamed.iter().next().ok_or_else(|| {
+                        Diagnostic::spanned(
+                            self.ident.span(),
+                            DiagLevel::Error,
+                            "`ToResponses` requires the tuple struct to have exactly one field",
+                        )
+                    })?;
 
                     let response =
                         UnnamedStructResponse::new(self.attributes, &field.ty, &field.attrs)?.0;
@@ -144,11 +148,13 @@ impl TryToTokens for ToResponses<'_> {
                     )?
                     .0),
                     Fields::Unnamed(fields) => {
-                        let field = fields
-                            .unnamed
-                            .iter()
-                            .next()
-                            .expect("Unnamed enum variant must have 1 field");
+                        let field = fields.unnamed.iter().next().ok_or_else(|| {
+                            Diagnostic::spanned(
+                                variant.ident.span(),
+                                DiagLevel::Error,
+                                "`ToResponses` requires the tuple variant to have exactly one field",
+                            )
+                        })?;
                         Ok(UnnamedStructResponse::new(&variant.attrs, &field.ty, &field.attrs)?.0)
                     }
                     Fields::Unit => Ok(UnitStructResponse::new(&variant.attrs)?.0),
@@ -256,8 +262,13 @@ impl<'u> UnnamedStructResponse<'u> {
                 break;
             }
         }
-        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?
-            .expect("`ToResponses` must have `#[salvo(response(...))]` attribute");
+        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?.ok_or_else(|| {
+            Diagnostic::spanned(
+                Span::call_site(),
+                DiagLevel::Error,
+                "`ToResponses` requires a `#[salvo(response(...))]` attribute",
+            )
+        })?;
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
             parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
@@ -297,8 +308,13 @@ impl NamedStructResponse<'_> {
             return Err(diag);
         }
 
-        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?
-            .expect("`ToResponses` must have `#[salvo(response(...))]` attribute");
+        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?.ok_or_else(|| {
+            Diagnostic::spanned(
+                Span::call_site(),
+                DiagLevel::Error,
+                "`ToResponses` requires a `#[salvo(response(...))]` attribute",
+            )
+        })?;
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
             parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
@@ -347,8 +363,13 @@ impl UnitStructResponse<'_> {
             return Err(diagnostics);
         }
 
-        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?
-            .expect("`ToResponses` must have `#[salvo(response(...))]` attribute");
+        let mut derive_value = DeriveToResponsesValue::from_attributes(attributes)?.ok_or_else(|| {
+            Diagnostic::spanned(
+                Span::call_site(),
+                DiagLevel::Error,
+                "`ToResponses` requires a `#[salvo(response(...))]` attribute",
+            )
+        })?;
         let status_code = mem::take(&mut derive_value.status_code);
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();

--- a/crates/oapi-macros/src/schema/struct_schemas.rs
+++ b/crates/oapi-macros/src/schema/struct_schemas.rs
@@ -531,7 +531,13 @@ impl TryToTokens for UnnamedStructSchema<'_> {
     fn try_to_tokens(&self, tokens: &mut TokenStream) -> DiagResult<()> {
         let oapi = crate::oapi_crate();
         let fields_len = self.fields.len();
-        let first_field = self.fields.first().expect("fields should not be empty");
+        let first_field = self.fields.first().ok_or_else(|| {
+            Diagnostic::spanned(
+                self.fields.span(),
+                DiagLevel::Error,
+                "a tuple struct used as a schema must have at least one field",
+            )
+        })?;
         let first_part = &TypeTree::from_type(&first_field.ty)?;
 
         let all_fields_are_same = fields_len == 1

--- a/crates/oapi-macros/src/type_tree.rs
+++ b/crates/oapi-macros/src/type_tree.rs
@@ -83,8 +83,10 @@ impl<'t> TypeTree<'t> {
                 .iter()
                 .find_map(|bound| match &bound {
                     syn::TypeParamBound::Trait(trait_bound) => Some(&trait_bound.path),
-                    syn::TypeParamBound::Lifetime(_) | syn::TypeParamBound::Verbatim(_) => None,
-                    _ => panic!("TypeTree trait object found unrecognized TypeParamBound"),
+                    // `TypeParamBound` is `#[non_exhaustive]`; treat any other
+                    // (current or future) bound kind like a lifetime/verbatim bound
+                    // rather than panicking inside the proc-macro.
+                    _ => None,
                 })
                 .map(|path| vec![TypeTreeValue::Path(path)])
                 .unwrap_or_else(Vec::new),


### PR DESCRIPTION
## Background

Part of a project-wide audit. Several `salvo-oapi-macros` paths panicked on otherwise-valid user input. A proc-macro should emit a diagnostic, not panic (an `unwrap`/`expect`/`panic!` produces an opaque ICE-like message and no useful span).

## Fixes — each converted to a spanned compile error

- **`#[endpoint(status_codes(...))]`**: integer literals are validated at expansion time (must be an integer in `100..=599`). Previously `status_codes(1000)` compiled and then panicked at route-registration time via `StatusCode::from_u16(..).unwrap()`; a non-integer literal like `status_codes("200")` produced an opaque error. Both now give a clear, spanned message.
- **`#[derive(ToResponse)]` / `#[derive(ToResponses)]`**: an empty tuple struct / tuple variant (`struct Foo();`) and a missing `#[salvo(response(...))]` attribute now produce compile errors instead of `expect()` panics.
- **`#[derive(ToSchema)]`** on an empty tuple struct now produces a compile error instead of `expect("fields should not be empty")`.
- **type_tree**: an unrecognized (`#[non_exhaustive]`) `TypeParamBound` variant is now ignored like a lifetime/verbatim bound, rather than `panic!`.

## Testing
- `cargo build -p salvo-oapi-macros -p salvo-oapi` — clean.
- `cargo test -p salvo-oapi --lib` — 277 pass; the only 2 failures (`test_openapi_schema_work_with_generics`, `test_simple_document_with_security`) **also fail on `main`** and are unrelated to this PR (a `StatusError.code` `u16` now serializes as `format: uint16` while the test still expects `int32`). Flagged separately.

## Note
A `trybuild` UI-test suite asserting these new error messages would be a good follow-up; not included here to avoid brittle `.stderr` snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)