### PR TITLE
fix(security): swagger-ui XSS escaping, proxy body error propagation, Vary caching, tus id/expiration

### DIFF
--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -140,7 +140,10 @@ impl<T> AcmeListenerBuilder<T> {
                 Router::with_path(format!("{WELL_KNOWN_PATH}/{{token}}")).goal(handler),
             );
         } else {
-            panic!("`HTTP-01` challenge's key should not be none");
+            // `AcmeConfigBuilder::http01_challenge()` always populates
+            // `keys_for_http01`, so this branch is an internal invariant violation
+            // rather than a user-triggerable error.
+            unreachable!("`http01_challenge()` must populate `keys_for_http01`");
         }
         Self {
             config_builder,

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -153,10 +153,10 @@ where
 /// relevant headers into the key.
 ///
 /// Note that a `Vary` response header is **not** a fix here: the store never
-/// evaluates `Vary` at lookup time. With the default `cache_private(false)` a
-/// `Vary` response is simply not cached at all, and with `cache_private(true)`
-/// it is cached under the same key and replayed regardless of the request's
-/// negotiation headers.
+/// evaluates `Vary` at lookup time, so a `Vary` response is never cached (in
+/// either `cache_private` mode) — it would otherwise be replayed under the same
+/// key regardless of the request's negotiation headers. Fold the relevant headers
+/// into a custom [`CacheIssuer`] key instead.
 #[derive(Clone, Debug)]
 pub struct RequestIssuer {
     use_scheme: bool,
@@ -681,17 +681,23 @@ fn request_has_private_cache_headers(req: &Request) -> bool {
 }
 
 fn response_has_private_cache_headers(headers: &HeaderMap) -> bool {
-    headers.contains_key(SET_COOKIE)
-        || headers.contains_key(VARY)
-        || cache_control_contains(headers, "private")
+    headers.contains_key(SET_COOKIE) || cache_control_contains(headers, "private")
 }
 
-/// `Cache-Control` directives that forbid caching regardless of whether this is
-/// a shared or private cache. `no-store` bans storing the response anywhere;
-/// `no-cache` requires revalidation before reuse, which this middleware does not
-/// perform, so both are treated as non-cacheable rather than served blindly.
+/// Directives/headers that forbid caching regardless of whether this is a shared
+/// or private cache. `no-store` bans storing the response anywhere; `no-cache`
+/// requires revalidation before reuse, which this middleware does not perform, so
+/// both are treated as non-cacheable rather than served blindly.
+///
+/// `Vary` is also handled here: this middleware never folds the varied request
+/// headers into the cache key, so it cannot tell two representations apart. Caching
+/// a `Vary` response (even in private mode) would replay one client's representation
+/// (e.g. a `gzip` body, or a specific `Accept-Language`) to clients that negotiated
+/// differently, so such responses are not cached at all.
 fn response_disallows_caching(headers: &HeaderMap) -> bool {
-    cache_control_contains(headers, "no-store") || cache_control_contains(headers, "no-cache")
+    cache_control_contains(headers, "no-store")
+        || cache_control_contains(headers, "no-cache")
+        || headers.contains_key(VARY)
 }
 
 fn cache_control_contains(headers: &HeaderMap, directive: &str) -> bool {
@@ -1347,17 +1353,27 @@ mod tests {
     fn cached_response_skips_private_cache_headers_by_default() {
         // Privacy heuristics only restrict a *shared* cache; a private cache
         // (`cache_private(true)`) may still store these.
-        for (name, value) in [
-            (SET_COOKIE, "sid=abc"),
-            (VARY, "accept-language"),
-            (CACHE_CONTROL, "private"),
-        ] {
+        for (name, value) in [(SET_COOKIE, "sid=abc"), (CACHE_CONTROL, "private")] {
             let mut res = Response::new();
             res.body(ResBody::Once(Bytes::from_static(b"cached")));
             res.headers_mut().insert(name, value.parse().unwrap());
             assert!(cached_response(&res, &HeaderMap::new(), false).is_none());
             assert!(cached_response(&res, &HeaderMap::new(), true).is_some());
         }
+    }
+
+    #[test]
+    fn cached_response_never_stores_vary() {
+        // The store never folds the varied request headers into the key, so a
+        // `Vary` response cannot be told apart from another representation and is
+        // not cached in either mode (otherwise one client's representation would be
+        // replayed to clients that negotiated differently).
+        let mut res = Response::new();
+        res.body(ResBody::Once(Bytes::from_static(b"cached")));
+        res.headers_mut()
+            .insert(VARY, "accept-language".parse().unwrap());
+        assert!(cached_response(&res, &HeaderMap::new(), false).is_none());
+        assert!(cached_response(&res, &HeaderMap::new(), true).is_none());
     }
 
     #[test]

--- a/crates/oapi/src/html.rs
+++ b/crates/oapi/src/html.rs
@@ -14,9 +14,16 @@ pub(crate) fn escape_html(value: &str) -> String {
 }
 
 pub(crate) fn json_string(value: &str) -> String {
-    serde_json::to_string(value)
-        .unwrap_or_else(|_| "\"\"".to_owned())
-        .replace('<', "\\u003c")
+    script_safe_json(serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned()))
+}
+
+/// Escapes characters that could break out of a `<script>` context when serialized
+/// JSON is embedded directly into an inline script (`<`, `>`, `&`, U+2028, U+2029).
+///
+/// Use this for already-serialized JSON values (e.g. a whole config object); for a
+/// plain string that still needs quoting use [`json_string`] instead.
+pub(crate) fn script_safe_json(json: String) -> String {
+    json.replace('<', "\\u003c")
         .replace('>', "\\u003e")
         .replace('&', "\\u0026")
         .replace('\u{2028}', "\\u2028")

--- a/crates/oapi/src/swagger_ui.rs
+++ b/crates/oapi/src/swagger_ui.rs
@@ -16,7 +16,7 @@ use salvo_core::routing::redirect_to_dir_url;
 use salvo_core::{Depot, Error, FlowCtrl, Handler, Request, Response, Router, async_trait};
 use serde::Serialize;
 
-use crate::html::{description_meta, escape_html, keywords_meta};
+use crate::html::{description_meta, escape_html, keywords_meta, script_safe_json};
 
 #[derive(RustEmbed)]
 #[folder = "src/swagger_ui/v5.32.4"]
@@ -377,7 +377,9 @@ pub fn serve<'a>(
     };
 
     let bytes = if path == "index.html" {
-        let config_json = serde_json::to_string(&config)?;
+        // The config is embedded into an inline `<script>` block, so escape any
+        // characters that could break out of the script context (e.g. `</script>`).
+        let config_json = script_safe_json(serde_json::to_string(&config)?);
 
         // Replace {{config}} with pretty config json and remove the curly brackets `{ }` from beginning and the end.
         let mut index = INDEX_TMPL
@@ -387,7 +389,7 @@ pub fn serve<'a>(
             .replacen("{{title}}", &escape_html(title), 1);
 
         if let Some(oauth) = &config.oauth {
-            let oauth_json = serde_json::to_string(oauth)?;
+            let oauth_json = script_safe_json(serde_json::to_string(oauth)?);
             index = index.replace(
                 "//{{oauth}}",
                 &format!("window.ui.initOAuth({});", &oauth_json),
@@ -405,4 +407,27 @@ pub fn serve<'a>(
     });
 
     Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serve_index_escapes_config_for_script_context() {
+        // A url containing `</script>` must not be able to break out of the inline script.
+        let config = Config::new(["</script><script>alert(1)</script>"]);
+        let file = serve("index.html", "title", "", "", &config)
+            .expect("serve should succeed")
+            .expect("index.html should be served");
+        let html = String::from_utf8(file.bytes.into_owned()).expect("utf8");
+        assert!(
+            !html.contains("</script><script>alert(1)</script>"),
+            "raw script-breaking payload must not be present"
+        );
+        assert!(
+            html.contains("\\u003c/script\\u003e"),
+            "`<` must be escaped to \\u003c inside the config json"
+        );
+    }
 }

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -519,7 +519,14 @@ where
             return Err(Error::other("upstreams is empty"));
         }
 
-        let path = (self.url_path_getter)(req, depot).unwrap_or_default();
+        let path = (self.url_path_getter)(req, depot).unwrap_or_else(|| {
+            // A `None` from the path getter means "no extra path"; the request is
+            // forwarded to the upstream root. Log it so a misconfigured custom getter
+            // (one that fails to extract the intended segment) is observable instead
+            // of silently proxying to the upstream root.
+            tracing::debug!("url_path_getter returned None; forwarding to upstream root path");
+            String::new()
+        });
         if self.strict_path_normalization_enabled {
             if contains_ambiguous_path_escape(&path) {
                 return Err(Error::other("ambiguous percent-encoded path"));

--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -63,8 +63,15 @@ impl Client for ReqwestClient {
         let request_upgrade_type =
             crate::get_upgrade_type(proxied_request.headers()).map(|s| s.to_owned());
 
-        let proxied_request = proxied_request
-            .map(|s| reqwest::Body::wrap_stream(s.map_ok(|s| s.into_data().unwrap_or_default())));
+        let proxied_request = proxied_request.map(|body| {
+            // Forward only data frames; drop non-data frames (e.g. trailers, which
+            // reqwest cannot send anyway) instead of turning them into empty bytes,
+            // and propagate stream errors so a failed/aborted upstream body surfaces
+            // as an error rather than being silently truncated into a "successful" body.
+            reqwest::Body::wrap_stream(
+                body.try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok()))),
+            )
+        });
         let response = self
             .inner
             .execute(proxied_request.try_into().map_err(Error::other)?)

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -5,6 +5,7 @@ use salvo_core::{Depot, Request, Response, Router, handler};
 
 use crate::error::{ProtocolError, TusError};
 use crate::handlers::apply_common_headers;
+use crate::stores::Extension;
 use crate::utils::check_tus_version;
 use crate::{CancellationContext, H_TUS_RESUMABLE, H_TUS_VERSION, TUS_VERSION, Tus};
 
@@ -58,6 +59,22 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
                 return;
             }
         };
+
+        // An expired upload should report `410 Gone` instead of being served,
+        // consistent with the HEAD handler (per the tus expiration extension).
+        if store.has_extension(Extension::Expiration)
+            && let Some(expiration) = store.get_expiration()
+            && expiration > std::time::Duration::from_secs(0)
+            && !info.creation_date.is_empty()
+            && let Ok(created_at) = chrono::DateTime::parse_from_rfc3339(&info.creation_date)
+            && let Ok(delta) = chrono::Duration::from_std(expiration)
+        {
+            let expires = created_at.with_timezone(&chrono::Utc) + delta;
+            if chrono::Utc::now() > expires {
+                res.status_code = Some(TusError::FileNoLongerExists.status());
+                return;
+            }
+        }
 
         let Some(storage) = info.storage else {
             res.status_code =

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -261,13 +261,21 @@ impl TusOptions {
     }
 
     /// Extracts and validates the upload ID from the request path.
+    ///
+    /// Prefers the decoded `{id}` route parameter so the id matches exactly what
+    /// the router parsed (avoiding any divergence between the route decoding and a
+    /// separate regex over the raw URI). Falls back to scanning the raw URI path
+    /// for callers that invoke this without the upload routes mounted.
     pub fn extract_file_id_from_request(&self, req: &Request) -> TusResult<String> {
-        let path = req.uri().path();
-        let re = file_id_regex();
-
-        re.captures(path)
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_owned())
+        req.params()
+            .get("id")
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                file_id_regex()
+                    .captures(req.uri().path())
+                    .and_then(|caps| caps.get(1))
+                    .map(|m| m.as_str().to_owned())
+            })
             .filter(|id| is_safe_upload_id(id))
             .ok_or(TusError::FileIdError)
     }


### PR DESCRIPTION
Security-related fixes from the second-round audit.

## Changes

- **oapi / swagger-ui XSS (defense in depth)** — `serve()` embedded the config/oauth JSON straight into an inline `<script>` via `serde_json::to_string`, which does not escape `<` `>` `/`; a field containing `</script>` could break out of the script context. Reuse the same `\uXXXX` escaping redoc already applies, extracted into `html::script_safe_json`. Adds a regression test.
- **proxy / reqwest request body** — `into_data().unwrap_or_default()` turned trailer/error frames into empty bytes and kept sending, silently truncating a failed/aborted upstream body into a "successful" one. Forward only data frames and propagate stream errors instead.
- **proxy** — log (at debug) when the url path getter returns `None` (falls back to the upstream root) so a misconfigured custom getter is observable. Behavior unchanged.
- **cache / Vary** — the store never folds the varied request headers into the key, so a `Vary` response must not be cached in any mode. It was previously cached and replayed under one key with `cache_private(true)`, leaking one client's negotiated representation to others. Never cache `Vary` now; docs and tests updated.
- **tus** — `extract_file_id_from_request` prefers the decoded `{id}` route param (regex kept as fallback) to avoid diverging from route decoding; GET download returns `410 Gone` for expired uploads, consistent with HEAD.
- **acme** — replace a `panic!` on a public builder path with `unreachable!` documenting the internal invariant.

## Testing

`cargo test` passes: salvo-oapi (incl. new swagger XSS test), salvo-cache (70), salvo-tus (238), salvo-proxy (29); affected crates `cargo build` + `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)