### PR TITLE
fix(core): FlatParser offset, CombWisp wild capture, multipart predicate

### DIFF
--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -1251,7 +1251,7 @@ impl Request {
     #[inline]
     pub async fn form_data_max_size(&mut self, max_size: usize) -> ParseResult<&FormData> {
         if let Some(ctype) = self.content_type() {
-            if ctype.subtype() == mime::WWW_FORM_URLENCODED || ctype.type_() == mime::MULTIPART {
+            if is_form_content_type(&ctype) {
                 let body = self.take_body();
                 if body.is_none() {
                     let bytes = self.payload_with_max_size(max_size).await?.to_owned();
@@ -1435,7 +1435,7 @@ impl Request {
         T: Deserialize<'de>,
     {
         if let Some(ctype) = self.content_type()
-            && (ctype.subtype() == mime::WWW_FORM_URLENCODED || ctype.subtype() == mime::FORM_DATA)
+            && is_form_content_type(&ctype)
         {
             from_str_multi_map(self.form_data().await?.fields.iter_all())
                 .map_err(ParseError::Deserialize)
@@ -1478,7 +1478,7 @@ impl Request {
         T: Deserialize<'de>,
     {
         if let Some(ctype) = self.content_type() {
-            if ctype.subtype() == mime::WWW_FORM_URLENCODED || ctype.subtype() == mime::FORM_DATA {
+            if is_form_content_type(&ctype) {
                 return from_str_multi_map(
                     self.form_data_max_size(max_size).await?.fields.iter_all(),
                 )
@@ -1491,6 +1491,15 @@ impl Request {
         }
         Err(ParseError::InvalidContentType)
     }
+}
+
+/// Whether a content type denotes form data this request can parse, i.e.
+/// `application/x-www-form-urlencoded` or any `multipart/*` (the underlying
+/// [`FormData`] reader keys off the multipart boundary). Keeping the predicate in
+/// one place ensures `form_data*`, `parse_form` and `parse_body*` agree on what is
+/// accepted instead of diverging on exotic `multipart/*` subtypes.
+fn is_form_content_type(ctype: &Mime) -> bool {
+    ctype.subtype() == mime::WWW_FORM_URLENCODED || ctype.type_() == mime::MULTIPART
 }
 
 fn is_length_limit_error(error: &(dyn StdError + 'static)) -> bool {

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -544,18 +544,12 @@ impl Response {
                     "current body's kind is `ResBody::Channel`, it is not allowed to write bytes",
                 ));
             }
-            ResBody::Error(_) => {
-                // An error body usually accompanies a 4xx/5xx status set elsewhere;
-                // silently replacing it with plain bytes (leaving the status intact)
-                // would yield an inconsistent "error status + normal body" response.
-                tracing::error!(
-                    "current body's kind is `ResBody::Error`, it is not allowed to write bytes"
-                );
-                return Err(Error::other(
-                    "current body's kind is `ResBody::Error`, it is not allowed to write bytes",
-                ));
-            }
-            ResBody::None => {
+            // `ResBody::Error` is treated like `None` on purpose: the catcher
+            // (`write_error_default`) reads the `StatusError`, renders the negotiated
+            // error page, and then calls `write_body` to install it. Returning an
+            // error here would leave the body as `ResBody::Error` (which polls empty),
+            // dropping the error page.
+            ResBody::None | ResBody::Error(_) => {
                 self.body = ResBody::Once(data.into());
             }
         }

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -544,7 +544,18 @@ impl Response {
                     "current body's kind is `ResBody::Channel`, it is not allowed to write bytes",
                 ));
             }
-            ResBody::None | ResBody::Error(_) => {
+            ResBody::Error(_) => {
+                // An error body usually accompanies a 4xx/5xx status set elsewhere;
+                // silently replacing it with plain bytes (leaving the status intact)
+                // would yield an inconsistent "error status + normal body" response.
+                tracing::error!(
+                    "current body's kind is `ResBody::Error`, it is not allowed to write bytes"
+                );
+                return Err(Error::other(
+                    "current body's kind is `ResBody::Error`, it is not allowed to write bytes",
+                ));
+            }
+            ResBody::None => {
                 self.body = ResBody::Once(data.into());
             }
         }

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -433,12 +433,6 @@ impl PathWisp for CombWisp {
         let Some(picked) = state.pick().map(|s| s.to_owned()) else {
             return false;
         };
-        let wild_path_buf = if self.wild_regex.is_some() {
-            state.all_rest().unwrap_or_default().into_owned()
-        } else {
-            String::new()
-        };
-        let mut wild_path: &str = &wild_path_buf;
         let caps = self.comb_regex.captures(&picked);
         if let Some(caps) = caps {
             let take_count = if self.wild_regex.is_some() {
@@ -453,13 +447,6 @@ impl PathWisp for CombWisp {
             for name in self.names.iter().take(take_count) {
                 if let Some(value) = caps.name(name) {
                     state.params.insert(name, value.as_str().to_owned());
-                    if self.wild_regex.is_some() {
-                        // Strip the captured value exactly once. `trim_start_matches`
-                        // removes every leading repetition (e.g. a value of "a"
-                        // would strip all of "aaa…"), corrupting the remaining wild
-                        // path.
-                        wild_path = wild_path.strip_prefix(value.as_str()).unwrap_or(wild_path);
-                    }
                     #[cfg(feature = "matched-path")]
                     {
                         if value.start() > start {
@@ -504,6 +491,11 @@ impl PathWisp for CombWisp {
             self.wild_regex.as_ref(),
             self.wild_start.as_ref(),
         ) {
+            // Read the remaining path *after* the comb part has been consumed by
+            // `state.forward(len)` above, so the wild capture sees only the tail
+            // (e.g. `.ext` for `/first{id}world{**rest}` vs `first123world.ext`).
+            let wild_path_buf = state.all_rest().unwrap_or_default().into_owned();
+            let wild_path: &str = &wild_path_buf;
             if wild_start.starts_with("*?")
                 && wild_path
                     .trim_start_matches('/')
@@ -1347,6 +1339,9 @@ mod tests {
         let filter = PathFilter::new("/first{id}world{**rest}");
         let mut state = PathState::new("first123world.ext");
         assert!(filter.detect(&mut state));
+        // The wild capture must be the tail only, not include the comb prefix.
+        assert_eq!(state.params.get("id").map(String::as_str), Some("123"));
+        assert_eq!(state.params.get("rest").map(String::as_str), Some(".ext"));
     }
 
     #[test]
@@ -1374,9 +1369,14 @@ mod tests {
     #[test]
     fn test_parse_comb_5() {
         let filter = PathFilter::new(r"/abc/t{**rest|\d+}");
+        // After the literal `t` is consumed, the remaining `11` matches `\d+`, so
+        // this is a match with `rest = "11"` (the wild regex is checked against the
+        // tail, not the already-consumed `t` prefix).
         let mut state = PathState::new("abc/t11");
-        assert!(!filter.detect(&mut state));
+        assert!(filter.detect(&mut state));
+        assert_eq!(state.params.get("rest").map(String::as_str), Some("11"));
 
+        // `lo1` / `11a` tails are not all digits, so `\d+` rejects them.
         let mut state = PathState::new("abc/tlo1");
         assert!(!filter.detect(&mut state));
         let mut state = PathState::new("abc/t11a");

--- a/crates/core/src/serde/flat_value.rs
+++ b/crates/core/src/serde/flat_value.rs
@@ -209,7 +209,13 @@ struct FlatParser<'de> {
 }
 impl<'de> FlatParser<'de> {
     fn new(input: Cow<'de, str>) -> Self {
-        Self { input, start: 1 }
+        // `looks_like_list` only checks the *trimmed* value, so the raw input may
+        // have leading whitespace (or otherwise not start with `[`). Locate the
+        // opening `[` instead of assuming it is byte 0 — a hardcoded `start = 1`
+        // would otherwise scan from the wrong offset (or land inside a multi-byte
+        // char and silently yield nothing).
+        let start = input.find('[').map_or(0, |index| index + 1);
+        Self { input, start }
     }
 }
 impl<'de> Iterator for FlatParser<'de> {
@@ -293,6 +299,18 @@ mod tests {
         let mut iter = parser.into_iter();
         assert_eq!(iter.next().unwrap().0, "\u{4E2D}\u{6587}");
         assert_eq!(iter.next().unwrap().0, "\u{1F600}");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_flat_parser_leading_whitespace() {
+        // A list value may arrive with leading whitespace; the parser must locate
+        // the `[` rather than assume it is byte 0.
+        let parser = super::FlatParser::new("  [1,2,3]".into());
+        let mut iter = parser.into_iter();
+        assert_eq!(iter.next().unwrap().0, "1");
+        assert_eq!(iter.next().unwrap().0, "2");
+        assert_eq!(iter.next().unwrap().0, "3");
         assert!(iter.next().is_none());
     }
 }


### PR DESCRIPTION
Extraction / serde / HTTP correctness fixes in core from the second-round audit.

## Changes

- **serde `FlatParser` offset** — `FlatParser::new` hardcoded `start = 1`, assuming byte 0 is `[`. But `looks_like_list` only checks the *trimmed* value, so a list value with leading whitespace (`?x=  [1,2,3]`) scanned from the wrong offset, and a multi-byte char before `[` made `get(1..)` land mid-codepoint and silently yield an empty sequence. Locate the actual `[`. Adds a leading-whitespace test.
- **routing `CombWisp` wild capture** — the wild remaining path was snapshotted via `all_rest()` *before* `forward()` consumed the comb part, then a `strip_prefix` hack tried to remove the captured values (which were not a prefix). `{**rest}` (and a constrained `{**rest|\d+}`) captured/validated the still-consumed prefix (e.g. `first123world.ext` instead of `.ext`). Read `all_rest()` *after* `forward()`. Tests now assert the captured values, not just that `detect()` is true.
- **multipart content-type predicate** — `form_data*` accepted any `multipart/*` while `parse_form`/`parse_body*` only accepted `multipart/form-data`, so two equivalent APIs diverged on exotic `multipart/*` subtypes. Unify behind `is_form_content_type`.

(An earlier `write_body` change was reverted after review — the catcher deliberately relies on `ResBody::Error` being overwritten by `write_body` to render error pages.)

## Testing

`cargo test -p salvo_core --lib` (207) passes; path tests pass under `matched-path`; new/strengthened FlatParser and CombWisp tests; `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)