### PR TITLE
fix(extra): basic-auth multi-header fallthrough, request-id consistency, logging path/addr

### DIFF
--- a/crates/extra/src/basic_auth.rs
+++ b/crates/extra/src/basic_auth.rs
@@ -163,35 +163,46 @@ pub fn parse_credentials(
     req: &Request,
     header_names: &[HeaderName],
 ) -> Result<(String, String), Error> {
-    let mut authorization = "";
+    // Try every configured header for Basic credentials. A non-Basic (or empty)
+    // value on one header must not shadow valid Basic credentials on a later one,
+    // e.g. `Authorization: Bearer ..` alongside `Proxy-Authorization: Basic ..`.
     for header_name in header_names {
         if let Some(header_value) = req.headers().get(header_name) {
-            authorization = header_value.to_str().unwrap_or_default();
-            if !authorization.is_empty() {
-                break;
+            let authorization = header_value.to_str().unwrap_or_default();
+            if let Some(credentials) = parse_basic_authorization(authorization)? {
+                return Ok(credentials);
             }
         }
     }
-
-    if let Some((scheme, auth)) = authorization.split_once(' ')
-        && scheme.eq_ignore_ascii_case("Basic")
-    {
-        let auth = auth.trim_start();
-        if auth.is_empty() {
-            return Err(Error::other("`authorization` has bad format"));
-        }
-        let auth_bytes = general_purpose::STANDARD
-            .decode(auth)
-            .map_err(Error::other)?;
-        let auth = String::from_utf8(auth_bytes)
-            .map_err(|_| Error::other("credentials contain invalid UTF-8"))?;
-        return if let Some((username, password)) = auth.split_once(':') {
-            Ok((username.to_owned(), password.to_owned()))
-        } else {
-            Err(Error::other("`authorization` has bad format"))
-        };
-    }
     Err(Error::other("parse http header failed"))
+}
+
+/// Parses a single `Authorization`-style header value as Basic credentials.
+///
+/// Returns `Ok(None)` when the value is not a Basic challenge (so the caller can
+/// try the next header), `Ok(Some(..))` on success, and `Err(..)` when the value
+/// is a Basic challenge but malformed.
+fn parse_basic_authorization(authorization: &str) -> Result<Option<(String, String)>, Error> {
+    let Some((scheme, auth)) = authorization.split_once(' ') else {
+        return Ok(None);
+    };
+    if !scheme.eq_ignore_ascii_case("Basic") {
+        return Ok(None);
+    }
+    let auth = auth.trim_start();
+    if auth.is_empty() {
+        return Err(Error::other("`authorization` has bad format"));
+    }
+    let auth_bytes = general_purpose::STANDARD
+        .decode(auth)
+        .map_err(Error::other)?;
+    let auth = String::from_utf8(auth_bytes)
+        .map_err(|_| Error::other("credentials contain invalid UTF-8"))?;
+    if let Some((username, password)) = auth.split_once(':') {
+        Ok(Some((username.to_owned(), password.to_owned())))
+    } else {
+        Err(Error::other("`authorization` has bad format"))
+    }
 }
 
 #[async_trait]
@@ -302,6 +313,23 @@ mod tests {
         let (username, password) = result.unwrap();
         assert_eq!(username, "用户");
         assert_eq!(password, "密码");
+    }
+
+    #[test]
+    fn test_parse_credentials_falls_through_non_basic_header() {
+        // A non-Basic value on the first header must not shadow valid Basic
+        // credentials on a later one.
+        let mut req = Request::new();
+        req.headers_mut()
+            .insert(AUTHORIZATION, "Bearer sometoken".parse().unwrap());
+        req.headers_mut()
+            .insert(PROXY_AUTHORIZATION, "Basic cm9vdDpwd2Q=".parse().unwrap());
+
+        let result = parse_credentials(&req, &[AUTHORIZATION, PROXY_AUTHORIZATION]);
+        assert!(result.is_ok());
+        let (username, password) = result.unwrap();
+        assert_eq!(username, "root");
+        assert_eq!(password, "pwd");
     }
 
     #[test]

--- a/crates/extra/src/logging.rs
+++ b/crates/extra/src/logging.rs
@@ -72,10 +72,13 @@ impl Handler for Logger {
         let span = tracing::span!(
             Level::INFO,
             "Request",
-            remote_addr = %req.remote_addr().to_string(),
+            remote_addr = %req.remote_addr(),
             version = ?req.version(),
             method = %req.method(),
-            path = %req.uri(),
+            // Log only the path, not the full URI: the query string can carry
+            // secrets (`?token=`, `?api_key=`, signed URLs) that should not land
+            // in logs by default.
+            path = %req.uri().path(),
         );
 
         async move {

--- a/crates/extra/src/request_id.rs
+++ b/crates/extra/src/request_id.rs
@@ -178,7 +178,11 @@ impl Handler for RequestId {
             }
         };
 
-        let _ = req.add_header(self.header_name.clone(), &request_id, false);
+        // Overwrite (not append) so the request carries exactly the resolved id:
+        // appending left a client-supplied id in place when `overwrite` generated a
+        // new one (downstream `req.header(..)` then read the stale value), and
+        // duplicated the header in the pass-through case.
+        let _ = req.add_header(self.header_name.clone(), &request_id, true);
 
         let span = tracing::info_span!("request", ?request_id);
         res.headers_mut()


### PR DESCRIPTION
Extra middleware fixes from the second-round audit.

## Changes

- **basic_auth multi-header** — credential parsing locked onto the first non-empty header value then stopped; a non-Basic value (`Authorization: Bearer xxx`) shadowed valid Basic credentials on a later header (`Proxy-Authorization: Basic ...`). Try each configured header for Basic credentials and return on the first success. Adds a test.
- **request_id consistency** — the request header was set with `add_header(.., false)` (append), so with `overwrite = true` the client-supplied id stayed in place (downstream `req.header(..)` read the stale value, diverging from the response header / depot / span), and the pass-through case duplicated the header. Overwrite (insert) so req/res/depot/span agree.
- **logging** — drop the redundant `remote_addr().to_string()` (`SocketAddr` implements `Display`); log `req.uri().path()` instead of the full URI so query-string secrets (`?token=`, signed URLs) do not land in logs by default.

## Testing

`cargo test -p salvo_extra` basic_auth/logging/request_id (14, incl. the new fallthrough test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)