### PR TITLE
fix(oapi): Number Eq soundness, macro error span, drop unused regex, doc fixes

### DIFF
--- a/crates/oapi-macros/Cargo.toml
+++ b/crates/oapi-macros/Cargo.toml
@@ -39,7 +39,6 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 proc-macro-crate = { workspace = true }
 proc-macro2-diagnostics = { workspace = true }
-regex = { workspace = true }
 salvo-serde-util = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
 salvo_core = { workspace = true }

--- a/crates/oapi-macros/src/endpoint.rs
+++ b/crates/oapi-macros/src/endpoint.rs
@@ -242,7 +242,7 @@ pub(crate) fn generate(mut attr: EndpointAttr, input: Item) -> syn::Result<Token
         }
         _ => Err(syn::Error::new_spanned(
             input,
-            "#[handler] must added to `impl` or `fn`",
+            "#[endpoint] must be added to `impl` or `fn`",
         )),
     }
 }

--- a/crates/oapi-macros/src/response.rs
+++ b/crates/oapi-macros/src/response.rs
@@ -651,8 +651,11 @@ impl Parse for ResponseStatusCode {
                 .and_then(|lit_str| {
                     let value = lit_str.value();
                     if !VALID_STATUS_RANGES.contains(&value.as_str()) {
+                        // Point at the string literal, not call-site: `value` is a
+                        // `String`, and `String::span()` (via `quote`'s `ToTokens`)
+                        // resolves to `Span::call_site()`, mislocating the error.
                         Err(Error::new(
-                            value.span(),
+                            lit_str.span(),
                             format!(
                                 "Invalid status code range, expected one of: {}",
                                 VALID_STATUS_RANGES.join(", "),

--- a/crates/oapi/src/extract/payload/form.rs
+++ b/crates/oapi/src/extract/payload/form.rs
@@ -36,13 +36,17 @@ where
     T: Deserialize<'de> + ToSchema,
 {
     fn to_request_body(components: &mut Components) -> RequestBody {
+        // Build (and register) the schema once and reuse it for both media types.
+        let schema = T::to_schema(components);
         RequestBody::new()
             .description("Extract form format data from request.")
             .add_content(
                 "application/x-www-form-urlencoded",
-                Content::new(T::to_schema(components)),
+                Content::new(schema.clone()),
             )
-            .add_content("multipart/*", Content::new(T::to_schema(components)))
+            // `multipart/*` is not a valid OpenAPI media-type key; the concrete
+            // `multipart/form-data` is what form submissions use.
+            .add_content("multipart/form-data", Content::new(schema))
     }
 }
 
@@ -102,8 +106,9 @@ where
     T: Deserialize<'de> + ToSchema,
 {
     fn register(components: &mut Components, operation: &mut Operation, _arg: &str) {
+        // `to_request_body` already builds and registers the schema; no extra
+        // `to_schema` call is needed here.
         let request_body = Self::to_request_body(components);
-        let _ = <T as ToSchema>::to_schema(components);
         operation.request_body = Some(request_body);
     }
 }
@@ -150,7 +155,7 @@ mod tests {
                             "type": "string"
                         }
                     },
-                    "multipart/*": {
+                    "multipart/form-data": {
                         "schema": {
                             "type": "string"
                         }
@@ -206,7 +211,7 @@ mod tests {
                                 "type": "string"
                             }
                         },
-                        "multipart/*": {
+                        "multipart/form-data": {
                             "schema": {
                                 "type": "string"
                             }

--- a/crates/oapi/src/extract/payload/form.rs
+++ b/crates/oapi/src/extract/payload/form.rs
@@ -44,9 +44,13 @@ where
                 "application/x-www-form-urlencoded",
                 Content::new(schema.clone()),
             )
-            // `multipart/*` is not a valid OpenAPI media-type key; the concrete
-            // `multipart/form-data` is what form submissions use.
-            .add_content("multipart/form-data", Content::new(schema))
+            // NOTE: `multipart/*` is not a strictly valid OpenAPI media-type key, but
+            // keeping it distinct from `multipart/form-data` avoids clobbering the
+            // file schema that `FormFile`/`FormFiles` register under
+            // `multipart/form-data` when both are used on the same endpoint. Properly
+            // emitting `multipart/form-data` requires merging the form and file
+            // schemas; left as follow-up.
+            .add_content("multipart/*", Content::new(schema))
     }
 }
 
@@ -155,7 +159,7 @@ mod tests {
                             "type": "string"
                         }
                     },
-                    "multipart/form-data": {
+                    "multipart/*": {
                         "schema": {
                             "type": "string"
                         }
@@ -211,7 +215,7 @@ mod tests {
                                 "type": "string"
                             }
                         },
-                        "multipart/form-data": {
+                        "multipart/*": {
                             "schema": {
                                 "type": "string"
                             }

--- a/crates/oapi/src/openapi/path.rs
+++ b/crates/oapi/src/openapi/path.rs
@@ -61,8 +61,10 @@ impl Paths {
     }
     /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
-    /// If a key from `other` is already present in `self`, the respective
-    /// value from `self` will be overwritten with the respective value from `other`.
+    /// If a key from `other` is already present in `self`, the two [`PathItem`]s are
+    /// merged field by field (see [`insert`](Self::insert)): `servers`, `parameters`
+    /// and `operations` are appended, while the scalar fields (`ref_location`,
+    /// `summary`, `description`) are overwritten by `other`'s non-empty values.
     pub fn append(&mut self, other: &mut Self) {
         let items = std::mem::take(&mut other.0);
         for item in items {

--- a/crates/oapi/src/openapi/schema.rs
+++ b/crates/oapi/src/openapi/schema.rs
@@ -151,7 +151,7 @@ pub enum Schema {
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object
     OneOf(OneOf),
 
-    /// Creates a _AnyOf_ type [composite Object][composite] schema.
+    /// Creates an _AllOf_ type [composite Object][composite] schema.
     ///
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object
     AllOf(AllOf),

--- a/crates/oapi/src/openapi/schema/number.rs
+++ b/crates/oapi/src/openapi/schema/number.rs
@@ -33,7 +33,13 @@ impl PartialEq for Number {
         match (self, other) {
             (Self::Int(left), Self::Int(right)) => left == right,
             (Self::UInt(left), Self::UInt(right)) => left == right,
-            (Self::Float(left), Self::Float(right)) => left == right,
+            // A float is equal when numerically equal (so `-0.0 == 0.0`) or when the
+            // bit patterns match, so `NaN == NaN`. Without the bit check, `Eq` would
+            // be unsound: a plain `f64 == f64` makes `Number::Float(NaN)` unequal to
+            // itself, violating the reflexivity `Eq` promises.
+            (Self::Float(left), Self::Float(right)) => {
+                left == right || left.to_bits() == right.to_bits()
+            }
             _ => false,
         }
     }
@@ -207,5 +213,15 @@ mod tests {
         assert_eq!(Number::UInt(1), Number::UInt(1));
         assert_eq!(Number::Float(1.5), Number::Float(1.5));
         assert_ne!(Number::Int(1), Number::UInt(1));
+    }
+
+    #[test]
+    fn test_eq_is_reflexive_for_nan() {
+        // `Eq` requires `a == a`; the bit-pattern comparison must hold for NaN even
+        // though `f64::NAN != f64::NAN`.
+        let nan = Number::Float(f64::NAN);
+        assert_eq!(nan, nan);
+        // `-0.0` and `0.0` remain equal (numerically equal).
+        assert_eq!(Number::Float(-0.0), Number::Float(0.0));
     }
 }


### PR DESCRIPTION
OpenAPI and proc-macro fixes from the second-round audit.

## Changes

- **`schema::Number` unsound `Eq`** — `Float` compared with `f64 == f64`, so `Number::Float(NaN)` was unequal to itself, violating the reflexivity `Eq` requires. Compare floats as "numerically equal OR same bit pattern" so `NaN == NaN` holds and `-0.0 == 0.0` still holds. Adds a test. (Cross-variant distinctness `Int(1) != UInt(1)` is kept — there is an existing test for it.)
- **oapi-macros error span** — the invalid-status-range error used `value.span()` where `value` is a `String`; `String::span()` resolves to `Span::call_site()`, mislocating the diagnostic to the macro call site. Use `lit_str.span()`.
- **oapi-macros message** — the `#[endpoint]` fallback error read `#[handler] must added ...`; corrected to `#[endpoint] must be added ...`.
- **drop unused `regex` dependency** — the lifetime-omission pass was rewritten to a `syn` visitor; no `regex` use remains in oapi-macros.
- **docs** — `Schema::AllOf` said "AnyOf"; `Paths::append` claimed whole-value overwrite while `insert` merges field by field — both corrected.

(An earlier change aligning the form body media type to `multipart/form-data` was reverted after review — it collided with `FormFile`/`FormFiles::register`, clobbering the form-field schema; kept as `multipart/*`. Proper `multipart/form-data` needs schema merging — left as follow-up. The form `to_schema` is still built once and reused.)

## Testing

`cargo test -p salvo-oapi --lib` and `cargo test -p salvo-oapi-macros` pass (new Number NaN-reflexivity test). Note: salvo-oapi has 2 pre-existing failing tests on main (`test_openapi_schema_work_with_generics`, `test_simple_document_with_security`, `uint16` vs `int32`) unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)