### PR TITLE
fix(jwt-auth, flash): OIDC h2 negotiation, clock-skew panic, panic-free flash accessors

### DIFF
--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -277,10 +277,20 @@ pub trait FlashDepotExt {
     fn incoming_flash(&mut self) -> Option<&Flash>;
     /// Get outgoing flash, or `None` if no [`FlashHandler`] is installed on the
     /// route (so the outgoing flash was never initialized).
-    fn try_outgoing_flash(&self) -> Option<&Flash>;
+    ///
+    /// Defaulted so that adding it is not a breaking change for existing
+    /// implementors of this trait; [`Depot`] overrides it with the real lookup.
+    fn try_outgoing_flash(&self) -> Option<&Flash> {
+        None
+    }
     /// Get mutable outgoing flash, or `None` if no [`FlashHandler`] is installed on
     /// the route.
-    fn try_outgoing_flash_mut(&mut self) -> Option<&mut Flash>;
+    ///
+    /// Defaulted so that adding it is not a breaking change for existing
+    /// implementors of this trait; [`Depot`] overrides it with the real lookup.
+    fn try_outgoing_flash_mut(&mut self) -> Option<&mut Flash> {
+        None
+    }
     /// Get outgoing flash.
     ///
     /// # Panics

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -275,9 +275,27 @@ pub trait FlashStore: Debug + Send + Sync + 'static {
 pub trait FlashDepotExt {
     /// Get incoming flash.
     fn incoming_flash(&mut self) -> Option<&Flash>;
+    /// Get outgoing flash, or `None` if no [`FlashHandler`] is installed on the
+    /// route (so the outgoing flash was never initialized).
+    fn try_outgoing_flash(&self) -> Option<&Flash>;
+    /// Get mutable outgoing flash, or `None` if no [`FlashHandler`] is installed on
+    /// the route.
+    fn try_outgoing_flash_mut(&mut self) -> Option<&mut Flash>;
     /// Get outgoing flash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no [`FlashHandler`] is installed on the route. Use
+    /// [`try_outgoing_flash`](Self::try_outgoing_flash) to handle that case without
+    /// panicking.
     fn outgoing_flash(&self) -> &Flash;
     /// Get mutable outgoing flash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no [`FlashHandler`] is installed on the route. Use
+    /// [`try_outgoing_flash_mut`](Self::try_outgoing_flash_mut) to handle that case
+    /// without panicking.
     fn outgoing_flash_mut(&mut self) -> &mut Flash;
 }
 
@@ -288,15 +306,25 @@ impl FlashDepotExt for Depot {
     }
 
     #[inline]
+    fn try_outgoing_flash(&self) -> Option<&Flash> {
+        self.get::<Flash>(OUTGOING_FLASH_KEY).ok()
+    }
+
+    #[inline]
+    fn try_outgoing_flash_mut(&mut self) -> Option<&mut Flash> {
+        self.get_mut::<Flash>(OUTGOING_FLASH_KEY).ok()
+    }
+
+    #[inline]
     fn outgoing_flash(&self) -> &Flash {
-        self.get::<Flash>(OUTGOING_FLASH_KEY)
-            .expect("Flash should be initialized")
+        self.try_outgoing_flash()
+            .expect("`FlashHandler` must be installed to use the outgoing flash")
     }
 
     #[inline]
     fn outgoing_flash_mut(&mut self) -> &mut Flash {
-        self.get_mut::<Flash>(OUTGOING_FLASH_KEY)
-            .expect("Flash should be initialized")
+        self.try_outgoing_flash_mut()
+            .expect("`FlashHandler` must be installed to use the outgoing flash")
     }
 }
 

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -39,6 +39,7 @@ http-body-util = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, optional = true, features = [
     "native-tokio",
     "http1",
+    "http2",
     "rustls-native-certs",
     "tls12",
     "logging",

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -39,6 +39,9 @@ fn default_http_client() -> Result<HyperClient, JwtAuthError> {
         .map_err(|error| JwtAuthError::NativeRootCerts(error.to_string()))?
         .https_only()
         .enable_http1()
+        // Also negotiate HTTP/2: some IdP discovery/JWKS endpoints (often behind a
+        // CDN) prefer or require h2 via ALPN, and http1-only would fail the handshake.
+        .enable_http2()
         .build();
     Ok(Client::builder(TokioExecutor::new()).build(https))
 }
@@ -559,9 +562,11 @@ fn b64_decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, base64::DecodeError> 
 }
 
 pub(crate) fn current_time() -> u64 {
+    // Called on the token-validation hot path; treat a clock set before the epoch
+    // (NTP step / VM time travel) as `0` rather than panicking.
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time Went Backwards")
+        .unwrap_or_default()
         .as_secs()
 }
 


### PR DESCRIPTION
jwt-auth / flash fixes from the second-round audit.

## Changes

- **OIDC client HTTP/2** — the default discovery/JWKS client only `enable_http1()`; some IdP endpoints (often CDN-fronted) prefer/require h2 via ALPN, so an http1-only connector failed the handshake. Use `enable_http1().enable_http2()` and add the `http2` feature to hyper-rustls so the method is available.
- **`current_time()` clock-skew panic** — called on the token-validation hot path; a clock set before the epoch (NTP step / VM time travel) made `expect("Time Went Backwards")` panic. Fall back to `0` with `unwrap_or_default()`.
- **flash panic-free accessors** — add `try_outgoing_flash`/`try_outgoing_flash_mut` (returning `Option`) and document that `outgoing_flash`/`outgoing_flash_mut` panic when no `FlashHandler` is installed. The new trait methods have default bodies so adding them is not a breaking change for downstream implementors of `FlashDepotExt`.

## Testing

`cargo test -p salvo-flash --lib` (55) and `cargo test -p salvo-jwt-auth --features oidc --lib` (62) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)