### PR TITLE
build(deps): bump aead to 0.6, aes-gcm/chacha20poly1305 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ salvo-tus = { version = "0.93.0", path = "crates/tus", default-features = false 
 
 certon = "0.2"
 
-aead = "0.5"
-aes-gcm = "0.10"
+aead = "0.6"
+aes-gcm = "0.11"
 arc-swap = "1.9"
 anyhow = "1"
 async-trait = "0.1"
@@ -59,7 +59,7 @@ base64 = "0.22"
 bytes = "1"
 bcrypt = "0.19"
 cookie = "0.18"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 chardetng = "1.0"
 chrono = "0.4"
 compact_str = { version = "0.9", features = ["serde"] }

--- a/crates/csrf/src/aes_gcm_cipher.rs
+++ b/crates/csrf/src/aes_gcm_cipher.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
-use aead::generic_array::GenericArray;
-use aead::{Aead, KeyInit};
+use aead::array::Array;
+use aead::consts::U12;
+use aead::{Aead, Key, KeyInit};
 use aes_gcm::Aes256Gcm;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -38,7 +39,7 @@ impl AesGcmCipher {
 
     #[inline]
     fn aead(&self) -> Aes256Gcm {
-        let key = GenericArray::clone_from_slice(&self.aead_key);
+        let key = Key::<Aes256Gcm>::try_from(&self.aead_key[..]).expect("invalid key length");
         Aes256Gcm::new(&key)
     }
 }
@@ -52,9 +53,9 @@ impl CsrfCipher for AesGcmCipher {
             if token.len() < 8 || proof.len() < 20 {
                 false
             } else {
-                let nonce = GenericArray::from_slice(&proof[0..12]);
+                let nonce = Array::<u8, U12>::try_from(&proof[0..12]).expect("invalid nonce");
                 let aead = self.aead();
-                aead.decrypt(nonce, &proof[12..])
+                aead.decrypt(&nonce, &proof[12..])
                     .map(|p| {
                         // Compare lengths first, then use constant-time compare
                         // on the recovered plaintext vs. the client-supplied
@@ -72,10 +73,10 @@ impl CsrfCipher for AesGcmCipher {
         let token = self.random_bytes(self.token_size);
         let aead = self.aead();
         let mut proof = self.random_bytes(12);
-        let nonce = GenericArray::from_slice(&proof);
+        let nonce = Array::<u8, U12>::try_from(&proof[..]).expect("invalid nonce");
         proof.append(
             &mut aead
-                .encrypt(nonce, token.as_slice())
+                .encrypt(&nonce, token.as_slice())
                 .expect("encryption failed"),
         );
         (URL_SAFE_NO_PAD.encode(token), URL_SAFE_NO_PAD.encode(proof))

--- a/crates/csrf/src/ccp_cipher.rs
+++ b/crates/csrf/src/ccp_cipher.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
-use aead::generic_array::GenericArray;
-use aead::{Aead, KeyInit};
+use aead::array::Array;
+use aead::consts::U12;
+use aead::{Aead, Key, KeyInit};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chacha20poly1305::ChaCha20Poly1305;
@@ -38,7 +39,7 @@ impl CcpCipher {
 
     #[inline]
     fn aead(&self) -> ChaCha20Poly1305 {
-        let key = GenericArray::clone_from_slice(&self.aead_key);
+        let key = Key::<ChaCha20Poly1305>::try_from(&self.aead_key[..]).expect("invalid key length");
         ChaCha20Poly1305::new(&key)
     }
 }
@@ -52,9 +53,9 @@ impl CsrfCipher for CcpCipher {
             if token.len() < 8 || proof.len() < 20 {
                 false
             } else {
-                let nonce = GenericArray::from_slice(&proof[0..12]);
+                let nonce = Array::<u8, U12>::try_from(&proof[0..12]).expect("invalid nonce");
                 let aead = self.aead();
-                aead.decrypt(nonce, &proof[12..])
+                aead.decrypt(&nonce, &proof[12..])
                     .map(|p| {
                         // Compare lengths first, then use constant-time compare
                         // on the recovered plaintext vs. the client-supplied
@@ -72,10 +73,10 @@ impl CsrfCipher for CcpCipher {
         let token = self.random_bytes(self.token_size);
         let aead = self.aead();
         let mut proof = self.random_bytes(12);
-        let nonce = GenericArray::from_slice(&proof);
+        let nonce = Array::<u8, U12>::try_from(&proof[..]).expect("invalid nonce");
         proof.append(
             &mut aead
-                .encrypt(nonce, token.as_slice())
+                .encrypt(&nonce, token.as_slice())
                 .expect("encryption failed"),
         );
         (URL_SAFE_NO_PAD.encode(token), URL_SAFE_NO_PAD.encode(proof))


### PR DESCRIPTION
## What

Bumps the RustCrypto AEAD stack used by `salvo-csrf`:

- `aead` `0.5` → `0.6`
- `aes-gcm` `0.10` → `0.11`
- `chacha20poly1305` `0.10` → `0.11`

…and migrates the csrf ciphers to the new `aead 0.6` API.

## Why

These three are a **coupled** upgrade — `aes-gcm 0.11` and `chacha20poly1305 0.11` both require `aead 0.6`, so they cannot be bumped independently. This supersedes the individual dependabot PRs #1517, #1629 and #1630, none of which could pass CI on their own (each left the other crates on an incompatible major).

## Code changes

`aead 0.6` dropped the `generic_array` re-export in favor of `hybrid-array` (`aead::array`). Migrated `crates/csrf/src/aes_gcm_cipher.rs` and `crates/csrf/src/ccp_cipher.rs`:

- `aead::generic_array::GenericArray` → `aead::array::Array` + `aead::Key` + `aead::consts::U12`
- key built via `Key::<Cipher>::try_from(&key[..])`
- nonce built via `Array::<u8, U12>::try_from(..)`, passed as `&nonce` to `encrypt`/`decrypt`

The on-the-wire token/proof format is unchanged (12-byte nonce prefix + ciphertext), so existing tokens remain compatible.

## Reviewer notes

- `cargo clippy -p salvo-csrf --features full --all-targets` is clean; the full csrf test suite (40 tests) passes.
- `cookie 0.18` still depends transitively on `aes-gcm 0.10` / `aead 0.5`, so both versions will coexist in the tree until `cookie` migrates to `aead 0.6`. This is a duplication only, not a build/behavior issue.
- After merge, dependabot PRs #1517, #1629 and #1630 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)