### PR TITLE
fix(core)!: let each Scribe own its body semantics; Json render now replaces

### DIFF
--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -482,7 +482,10 @@ impl Response {
             }
             let before = committed_len(&self.body);
             scribe.render(self);
+            // `before > 0`: appending to an *empty* committed body yields exactly the
+            // new render's bytes, so nothing is corrupted and no warning is needed.
             if let (Some(before), Some(after)) = (before, committed_len(&self.body))
+                && before > 0
                 && after > before
             {
                 tracing::warn!(

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -446,6 +446,14 @@ impl Response {
     /// `Scribe` impl is responsible for converting the error into a `5xx` response
     /// instead of panicking or returning an error here.
     ///
+    /// **Note**: the built-in `Scribe` implementations write through
+    /// [`write_body`](Response::write_body), which *appends* to any body bytes
+    /// already present — it does not overwrite them. Calling `render` twice on the
+    /// same response therefore concatenates both outputs, which for `Json` produces
+    /// invalid JSON. Debug builds log a warning when this happens. To replace an
+    /// already-written body, set it explicitly via
+    /// [`replace_body`](Response::replace_body) or [`body`](Response::body) first.
+    ///
     /// # Example
     ///
     /// ```
@@ -458,17 +466,30 @@ impl Response {
     where
         P: Scribe,
     {
+        #[cfg(debug_assertions)]
+        if matches!(&self.body, ResBody::Once(_) | ResBody::Chunks(_)) {
+            tracing::warn!(
+                "`Response::render` called on a response that already contains body bytes; \
+                 the new content will be appended, not overwrite the old one. This is rarely \
+                 intended (e.g. rendering `Json` twice produces invalid JSON). To replace the \
+                 body, use `Response::replace_body` or `Response::body` first; to append on \
+                 purpose, call `Response::write_body` directly."
+            );
+        }
         scribe.render(self);
     }
 
     /// Sets the status code and renders content into this response.
+    ///
+    /// See [`render`](Response::render) for the append semantics when the response
+    /// already contains body bytes.
     #[inline]
     pub fn render_with_status<P>(&mut self, code: StatusCode, scribe: P)
     where
         P: Scribe,
     {
         self.status_code = Some(code);
-        scribe.render(self);
+        self.render(scribe);
     }
 
     /// Sets the status code and renders content into this response.
@@ -500,7 +521,14 @@ impl Response {
         }
     }
 
-    /// Write bytes data to body. If body is none, a new `ResBody` will created.
+    /// Write bytes data to body.
+    ///
+    /// This **appends**: if the body is [`ResBody::None`] (or an error placeholder) a
+    /// new [`ResBody::Once`] is created, but if the body already contains bytes
+    /// (`Once` or `Chunks`) the data is added after the existing content. Streaming
+    /// body kinds (`Hyper`, `Boxed`, `Stream`, `Channel`) cannot be written to and
+    /// return an error. To replace the body instead of appending, use
+    /// [`replace_body`](Response::replace_body) or [`body`](Response::body).
     pub fn write_body(&mut self, data: impl Into<Bytes>) -> crate::Result<()> {
         match self.body_mut() {
             ResBody::Once(bytes) => {

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -479,7 +479,7 @@ impl Response {
         P: Scribe,
     {
         self.status_code = Some(code);
-        self.render(scribe);
+        scribe.render(self);
     }
 
     /// Sets the status code and renders content into this response.

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -446,13 +446,13 @@ impl Response {
     /// `Scribe` impl is responsible for converting the error into a `5xx` response
     /// instead of panicking or returning an error here.
     ///
-    /// **Note**: the built-in `Scribe` implementations write through
-    /// [`write_body`](Response::write_body), which *appends* to any body bytes
-    /// already present — it does not overwrite them. Calling `render` twice on the
-    /// same response therefore concatenates both outputs, which for `Json` produces
-    /// invalid JSON. Debug builds log a warning when a render appends onto existing
-    /// body bytes. To replace an already-written body, set it explicitly via
-    /// [`replace_body`](Response::replace_body) or [`body`](Response::body) first.
+    /// **Note**: how a render interacts with body bytes that were already written
+    /// is defined by each `Scribe`, not by this method. Whole-document scribes like
+    /// [`Json`](crate::writing::Json) *replace* previously buffered bytes (two
+    /// concatenated JSON documents would be invalid); text-like scribes (`&str`,
+    /// `String`, [`Text`](crate::writing::Text)) *append* through
+    /// [`write_body`](Response::write_body), since concatenated text is still valid
+    /// text. See [`Scribe`] for how to pick semantics when implementing your own.
     ///
     /// # Example
     ///
@@ -466,45 +466,13 @@ impl Response {
     where
         P: Scribe,
     {
-        // In debug builds, detect a render that appends onto body bytes that were
-        // already committed — almost always an accidental double render (rendering
-        // `Json` twice produces invalid JSON). Comparing sizes after the fact (rather
-        // than warning whenever bytes pre-exist) avoids false positives for scribes
-        // that write nothing, e.g. the `()` rendered by `Ok(())`-returning handlers.
-        #[cfg(debug_assertions)]
-        {
-            fn committed_len(body: &ResBody) -> Option<usize> {
-                match body {
-                    ResBody::Once(bytes) => Some(bytes.len()),
-                    ResBody::Chunks(chunks) => Some(chunks.iter().map(Bytes::len).sum()),
-                    _ => None,
-                }
-            }
-            let before = committed_len(&self.body);
-            scribe.render(self);
-            // `before > 0`: appending to an *empty* committed body yields exactly the
-            // new render's bytes, so nothing is corrupted and no warning is needed.
-            if let (Some(before), Some(after)) = (before, committed_len(&self.body))
-                && before > 0
-                && after > before
-            {
-                tracing::warn!(
-                    "`Response::render` appended to a response that already contains body \
-                     bytes; the previous content is kept, not overwritten. This is rarely \
-                     intended (e.g. rendering `Json` twice produces invalid JSON). To replace \
-                     the body, use `Response::replace_body` or `Response::body` first; to \
-                     append on purpose, call `Response::write_body` directly."
-                );
-            }
-        }
-        #[cfg(not(debug_assertions))]
         scribe.render(self);
     }
 
     /// Sets the status code and renders content into this response.
     ///
-    /// See [`render`](Response::render) for the append semantics when the response
-    /// already contains body bytes.
+    /// See [`render`](Response::render) for how scribes interact with an
+    /// already-written body.
     #[inline]
     pub fn render_with_status<P>(&mut self, code: StatusCode, scribe: P)
     where

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -450,8 +450,8 @@ impl Response {
     /// [`write_body`](Response::write_body), which *appends* to any body bytes
     /// already present — it does not overwrite them. Calling `render` twice on the
     /// same response therefore concatenates both outputs, which for `Json` produces
-    /// invalid JSON. Debug builds log a warning when this happens. To replace an
-    /// already-written body, set it explicitly via
+    /// invalid JSON. Debug builds log a warning when a render appends onto existing
+    /// body bytes. To replace an already-written body, set it explicitly via
     /// [`replace_body`](Response::replace_body) or [`body`](Response::body) first.
     ///
     /// # Example
@@ -466,16 +466,35 @@ impl Response {
     where
         P: Scribe,
     {
+        // In debug builds, detect a render that appends onto body bytes that were
+        // already committed — almost always an accidental double render (rendering
+        // `Json` twice produces invalid JSON). Comparing sizes after the fact (rather
+        // than warning whenever bytes pre-exist) avoids false positives for scribes
+        // that write nothing, e.g. the `()` rendered by `Ok(())`-returning handlers.
         #[cfg(debug_assertions)]
-        if matches!(&self.body, ResBody::Once(_) | ResBody::Chunks(_)) {
-            tracing::warn!(
-                "`Response::render` called on a response that already contains body bytes; \
-                 the new content will be appended, not overwrite the old one. This is rarely \
-                 intended (e.g. rendering `Json` twice produces invalid JSON). To replace the \
-                 body, use `Response::replace_body` or `Response::body` first; to append on \
-                 purpose, call `Response::write_body` directly."
-            );
+        {
+            fn committed_len(body: &ResBody) -> Option<usize> {
+                match body {
+                    ResBody::Once(bytes) => Some(bytes.len()),
+                    ResBody::Chunks(chunks) => Some(chunks.iter().map(Bytes::len).sum()),
+                    _ => None,
+                }
+            }
+            let before = committed_len(&self.body);
+            scribe.render(self);
+            if let (Some(before), Some(after)) = (before, committed_len(&self.body))
+                && after > before
+            {
+                tracing::warn!(
+                    "`Response::render` appended to a response that already contains body \
+                     bytes; the previous content is kept, not overwritten. This is rarely \
+                     intended (e.g. rendering `Json` twice produces invalid JSON). To replace \
+                     the body, use `Response::replace_body` or `Response::body` first; to \
+                     append on purpose, call `Response::write_body` directly."
+                );
+            }
         }
+        #[cfg(not(debug_assertions))]
         scribe.render(self);
     }
 

--- a/crates/core/src/writing.rs
+++ b/crates/core/src/writing.rs
@@ -33,6 +33,24 @@ pub trait Writer {
 /// Depot and Request.
 ///
 /// There are several built-in implementations of the `Scribe` trait.
+///
+/// # Body semantics: replace or append?
+///
+/// Each `Scribe` decides for itself how to interact with body bytes that were
+/// already written to the response — the framework does not impose one rule:
+///
+/// - **Whole-document scribes replace.** [`Json`] emits one complete JSON
+///   document; two concatenated documents would be invalid, so rendering `Json`
+///   replaces any previously buffered body bytes.
+/// - **Incremental scribes append.** A scribe that adds a footer to a page, or
+///   emits one NDJSON record per call, should append via
+///   [`Response::write_body`] — concatenation *is* its output format. The
+///   text-like scribes (`&str`, `String`, [`Text`]) append for this reason.
+///
+/// When implementing your own `Scribe`, pick the semantics that make the final
+/// body valid in your format: use [`Response::write_body`] to append, or replace
+/// the buffered body (see how [`Json`] does it) when your output is a complete
+/// document.
 pub trait Scribe {
     /// Render data to [`Response`].
     fn render(self, res: &mut Response);
@@ -44,10 +62,7 @@ where
 {
     #[inline]
     async fn write(self, _req: &mut Request, _depot: &mut Depot, res: &mut Response) {
-        // Route through `Response::render` (not `Scribe::render` directly) so a
-        // handler that already wrote body bytes and then *returns* a `Scribe`
-        // still triggers the double-render diagnostic in debug builds.
-        res.render(self);
+        self.render(res)
     }
 }
 
@@ -59,7 +74,7 @@ where
     #[inline]
     async fn write(self, _req: &mut Request, _depot: &mut Depot, res: &mut Response) {
         match self {
-            Some(v) => res.render(v),
+            Some(v) => v.render(res),
             None => {
                 res.status_code(StatusCode::NOT_FOUND);
             }

--- a/crates/core/src/writing.rs
+++ b/crates/core/src/writing.rs
@@ -44,7 +44,10 @@ where
 {
     #[inline]
     async fn write(self, _req: &mut Request, _depot: &mut Depot, res: &mut Response) {
-        self.render(res)
+        // Route through `Response::render` (not `Scribe::render` directly) so a
+        // handler that already wrote body bytes and then *returns* a `Scribe`
+        // still triggers the double-render diagnostic in debug builds.
+        res.render(self);
     }
 }
 
@@ -56,7 +59,7 @@ where
     #[inline]
     async fn write(self, _req: &mut Request, _depot: &mut Depot, res: &mut Response) {
         match self {
-            Some(v) => v.render(res),
+            Some(v) => res.render(v),
             None => {
                 res.status_code(StatusCode::NOT_FOUND);
             }

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -1,9 +1,11 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use serde::Serialize;
 
 use super::{Scribe, try_set_header};
+use crate::http::body::ResBody;
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
 use crate::http::{Response, StatusError};
 
@@ -11,6 +13,16 @@ use crate::http::{Response, StatusError};
 ///
 /// `Json<T>` sets `content-type` to `application/json; charset=utf-8` and
 /// serializes the wrapped value with `serde_json`.
+///
+/// # Body semantics
+///
+/// A JSON body is one complete document, so rendering `Json` **replaces** any
+/// body bytes previously buffered on the response (appending would produce
+/// invalid JSON); debug builds log a warning when non-empty content is
+/// discarded this way. Streaming bodies cannot be replaced and are reported as
+/// an error, like [`Response::write_body`]. To emit multiple JSON records
+/// (e.g. NDJSON), serialize each record and append it via
+/// [`Response::write_body`] instead.
 ///
 /// # Examples
 ///
@@ -68,7 +80,38 @@ where
                     CONTENT_TYPE,
                     HeaderValue::from_static("application/json; charset=utf-8"),
                 );
-                let _ = res.write_body(bytes);
+                // A JSON body is one complete document: replace previously
+                // buffered bytes instead of appending, which would concatenate
+                // two documents into invalid JSON.
+                match &res.body {
+                    ResBody::None | ResBody::Error(_) | ResBody::Once(_) | ResBody::Chunks(_) => {
+                        #[cfg(debug_assertions)]
+                        {
+                            let discarded = match &res.body {
+                                ResBody::Once(prev) => prev.len(),
+                                ResBody::Chunks(chunks) => chunks.iter().map(Bytes::len).sum(),
+                                _ => 0,
+                            };
+                            if discarded > 0 {
+                                tracing::warn!(
+                                    discarded_bytes = discarded,
+                                    "rendering `Json` replaced body bytes that were already \
+                                     written; a JSON body is one complete document. To emit \
+                                     multiple JSON records (NDJSON), serialize each record and \
+                                     append it via `Response::write_body` instead."
+                                );
+                            }
+                        }
+                        res.body(ResBody::Once(Bytes::from(bytes)));
+                    }
+                    _ => {
+                        // Streaming kinds cannot be replaced silently; mirror the
+                        // `write_body` error behavior.
+                        tracing::error!(
+                            "current body kind cannot be written or replaced by `Json`"
+                        );
+                    }
+                }
             }
             Err(e) => {
                 tracing::error!(error = ?e, "JSON serialize error");
@@ -116,5 +159,41 @@ mod tests {
             res.headers().get("content-type").unwrap(),
             "application/json; charset=utf-8"
         );
+    }
+
+    #[tokio::test]
+    async fn test_json_render_replaces_previous_body() {
+        // A JSON body is one complete document: a second render (or a render
+        // after other body bytes were written) must replace, not concatenate
+        // into invalid JSON.
+        #[handler]
+        async fn test(res: &mut Response) {
+            res.render(Json(serde_json::json!({"first": true})));
+            res.render(Json(serde_json::json!({"second": true})));
+        }
+
+        let router = Router::new().push(Router::with_path("test").get(test));
+        let mut res = TestClient::get("http://127.0.0.1:8698/test")
+            .send(router)
+            .await;
+        let body = res.take_string().await.unwrap();
+        assert_eq!(body, r#"{"second":true}"#);
+        // The body must be valid JSON — the old append behavior produced two
+        // concatenated documents here.
+        serde_json::from_str::<serde_json::Value>(&body).expect("body must be valid JSON");
+    }
+
+    #[tokio::test]
+    async fn test_json_render_does_not_clobber_stream_body() {
+        use futures_util::stream;
+
+        use crate::http::body::ResBody;
+
+        // Streaming bodies cannot be replaced silently; `Json` must leave them
+        // untouched (mirroring `write_body`'s error behavior).
+        let mut res = Response::new();
+        res.stream(stream::iter(vec![Ok::<_, crate::BoxedError>("chunk")]));
+        Json(serde_json::json!({"x": 1})).render(&mut res);
+        assert!(matches!(res.body, ResBody::Stream(_)));
     }
 }


### PR DESCRIPTION
## Design principle (from maintainer review)

Whether a render **replaces** or **appends** is not a global property of `Response::render` — it belongs to each `Scribe`:

- A footer writer appends by nature — clearing the body would be wrong.
- An NDJSON emitter appends one record per call — append *is* its format.
- A JSON document must replace — two concatenated documents are invalid JSON.

Earlier iterations of this PR added a global debug warning whenever a render appended onto existing bytes. That approach contradicts the principle above: it would false-positive on legitimately appending scribes. It has been removed.

## What this PR now does

1. **`Json::render` replaces** previously buffered body bytes (`None`/`Error`/`Once`/`Chunks`) instead of appending invalid output. Debug builds log a warning when non-empty content is discarded — that usually indicates a missing early-`return` after an error render, and with replace semantics the earlier content would otherwise vanish silently. Streaming body kinds are left untouched with an error log, mirroring `write_body`'s behavior.
2. **Text-like scribes keep append semantics** (`&str`, `String`, `Text`): concatenated text is valid text, and incremental writing is a legitimate pattern.
3. **`Scribe` trait docs** state the design rule ("pick the semantics that make the final body valid in your format") with the footer/NDJSON/JSON examples; `Response::render` and `write_body` docs updated to match. `Response::render` itself is pure delegation again; the `Writer` blanket impls are back to calling `Scribe::render` directly (zero diff from `main` in `writing.rs` apart from docs).

## Breaking change

Rendering `Json` after other body bytes were written now **replaces** them (previously: concatenated). Since concatenated JSON was invalid output, any code affected by this was already producing broken responses.

## Verification

- New tests: `test_json_render_replaces_previous_body` (double render yields the last, valid document), `test_json_render_does_not_clobber_stream_body`.
- All 209 `salvo_core` lib tests pass; clippy clean.
- Downstream: `salvo-flash` (55), `salvo-cache` (70), `salvo-csrf` (30) all green. (`salvo-oapi` has 2 pre-existing failures reproducible on `main`; `salvo_extra` hits a pre-existing `rustls`/`aws_lc_rs` feature-combination compile issue in `conn/rustls/config.rs`, unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)