### PR TITLE
docs: fix stale pre-brace path syntax in doc examples

### DIFF
--- a/crates/craft/src/lib.rs
+++ b/crates/craft/src/lib.rs
@@ -36,7 +36,7 @@
 //! let service = UserService { prefix: "hello" };
 //! let _router = Router::new()
 //!     .push(Router::with_path("users").get(service.list_users()))
-//!     .push(Router::with_path("users/<id>").get(service.get_user()));
+//!     .push(Router::with_path("users/{id}").get(service.get_user()));
 //! ```
 //!
 //! # Usage

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -153,7 +153,7 @@ where
 /// use salvo_serve_static::StaticDir;
 ///
 /// let router = Router::new().push(
-///     Router::with_path("static/<**>").get(
+///     Router::with_path("static/{**}").get(
 ///         StaticDir::new(["assets", "static"])
 ///             .defaults("index.html")
 ///             .auto_list(true),


### PR DESCRIPTION
Two doc examples still used the old angle-bracket path syntax. The current parser has no support for it (`<id>` / `<**>` become literal path segments), so the routers shown in these examples compile but can never match a real request:

- [craft/src/lib.rs:39](https://github.com/salvo-rs/salvo/blob/main/crates/craft/src/lib.rs#L39): `users/<id>` → `users/{id}`
- [serve-static/src/dir.rs:156](https://github.com/salvo-rs/salvo/blob/main/crates/serve-static/src/dir.rs#L156): `static/<**>` → `static/{**}` (matches the form used in `examples/db-sea-orm`)

Swept the rest of `crates/*/src` for `path("...<` — no other occurrences. Doctests for both crates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)