### PR TITLE
fix(examples): pin sea-orm to rc.40 to unblock CI

### DIFF
--- a/examples/db-postgres-sea-orm/Cargo.toml
+++ b/examples/db-postgres-sea-orm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 migration = { path = "migration" }
 anyhow.workspace = true
-sea-orm = { version = "2.0.0-rc", features = ["with-chrono", "sqlx-postgres", "macros", "with-uuid", "with-time", "runtime-tokio", "runtime-tokio-native-tls", "runtime-tokio-rustls", "schema-sync", "entity-registry"] }
+sea-orm = { version = "=2.0.0-rc.40", features = ["with-chrono", "sqlx-postgres", "macros", "with-uuid", "with-time", "runtime-tokio", "runtime-tokio-native-tls", "runtime-tokio-rustls", "schema-sync", "entity-registry"] }
 dotenvy.workspace = true
 salvo = { workspace = true, features = ["oapi", "affix-state", "anyhow", "jwt-auth", "test", "cors"] }
 salvo-oapi = { workspace = true, features = ["swagger-ui"] }

--- a/examples/db-postgres-sea-orm/migration/Cargo.toml
+++ b/examples/db-postgres-sea-orm/migration/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
 [dependencies.sea-orm-migration]
-version = "2.0.0-rc.20"
+version = "=2.0.0-rc.40"
 features = [
   # Enable at least one `ASYNC_RUNTIME` and `DATABASE_DRIVER` feature if you want to run migration via CLI.
   # View the list of supported features at https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime.


### PR DESCRIPTION
## Why

`sea-orm 2.0.0-rc.41` (published today) fails to compile — its `sea_schema_shim` implements trait methods whose returned futures lack the required `Send` bound (`E0053`, in `sea-orm-2.0.0-rc.41/src/database/sea_schema_shim.rs`). The `db-postgres-sea-orm` example uses the floating requirement `"2.0.0-rc"`, so every fresh **check examples** CI run now resolves the broken release and fails — currently breaking CI on all open PRs (e.g. #1637, #1638 both hit it with identical errors, while earlier runs today passed on rc.40).

## What

Pin the example to `=2.0.0-rc.40`. Verified locally: `cargo check -p salvo-postgres-seaorm` compiles clean against rc.40.

Revert to a floating requirement once upstream ships a fixed rc (tracked upstream in SeaQL/sea-orm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)