### PR TITLE
[codex] clear request body cache on replacement

### DIFF
--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -92,9 +92,9 @@ impl Handler for SecureMaxSize {
 ///   internally. Subsequent calls return the cached bytes.
 /// - [`form_data()`](Request::form_data) parses form data and caches the result. If the body has
 ///   already been consumed by `payload()`, it will use the cached bytes to parse the form.
-/// - [`replace_body()`](Request::replace_body) preserves those cached values for compatibility. Use
-///   [`replace_body_and_clear_cache()`](Request::replace_body_and_clear_cache) when replacing the
-///   body should also invalidate cached payload and form data.
+/// - [`replace_body()`](Request::replace_body), [`take_body()`](Request::take_body), and
+///   [`body_mut()`](Request::body_mut) invalidate cached payload and form data so cached data never
+///   describes an old body after the body is changed.
 ///
 /// # Size Limits
 ///
@@ -555,11 +555,11 @@ impl Request {
     ///
     /// # Note
     ///
-    /// Modifying the body directly may interfere with methods like
-    /// [`payload()`](Request::payload) and [`form_data()`](Request::form_data).
+    /// This clears cached payload and form data before exposing mutable body access.
     /// Use with caution.
     #[inline]
     pub fn body_mut(&mut self) -> &mut ReqBody {
+        self.clear_body_cache();
         &mut self.body
     }
 
@@ -567,26 +567,19 @@ impl Request {
     ///
     /// This is useful when you need to transform or wrap the request body.
     ///
-    /// # Note
-    ///
-    /// Replacing the body does not clear the cached payload or form data.
-    /// If you've already called [`payload()`](Request::payload), those cached
-    /// values will still be returned on subsequent calls.
+    /// This clears cached payload and form data so subsequent calls to
+    /// [`payload()`](Request::payload) and [`form_data()`](Request::form_data)
+    /// read from the new body.
     #[inline]
     pub fn replace_body(&mut self, body: ReqBody) -> ReqBody {
-        std::mem::replace(&mut self.body, body)
-    }
-
-    /// Replaces the body with a new value, clears cached payload and form data, and returns the
-    /// old body.
-    ///
-    /// This is useful for middleware that transforms the request body and wants subsequent calls to
-    /// [`payload()`](Request::payload) or [`form_data()`](Request::form_data) to read the new body.
-    #[inline]
-    pub fn replace_body_and_clear_cache(&mut self, body: ReqBody) -> ReqBody {
-        let old_body = self.replace_body(body);
+        let old_body = self.replace_body_preserving_cache(body);
         self.clear_body_cache();
         old_body
+    }
+
+    #[inline]
+    fn replace_body_preserving_cache(&mut self, body: ReqBody) -> ReqBody {
+        std::mem::replace(&mut self.body, body)
     }
 
     #[inline]
@@ -597,8 +590,8 @@ impl Request {
 
     /// Takes the body from the request, leaving [`ReqBody::None`] in its place.
     ///
-    /// This consumes the body, making it unavailable for subsequent reads unless
-    /// it was already cached via [`payload()`](Request::payload).
+    /// This consumes the body and clears cached payload and form data so later
+    /// reads cannot observe data from the old body.
     ///
     /// # When to Use
     ///
@@ -609,11 +602,15 @@ impl Request {
     /// # Note
     ///
     /// Methods like [`payload()`](Request::payload) and [`form_data()`](Request::form_data)
-    /// call this internally. If those methods have already been called successfully,
-    /// the data is cached and can still be accessed.
+    /// manage their own internal body consumption while building fresh cache entries.
     #[inline]
     pub fn take_body(&mut self) -> ReqBody {
         self.replace_body(ReqBody::None)
+    }
+
+    #[inline]
+    fn take_body_preserving_cache(&mut self) -> ReqBody {
+        self.replace_body_preserving_cache(ReqBody::None)
     }
 
     /// Returns a reference to the associated extensions.
@@ -1162,20 +1159,27 @@ impl Request {
     /// ```
     #[inline]
     pub async fn payload_with_max_size(&mut self, max_size: usize) -> ParseResult<&Bytes> {
-        let body = self.take_body();
-        self.payload
-            .get_or_try_init(|| async {
-                let limited = Limited::new(body, max_size);
-                let collected = limited.collect().await.map_err(|e| {
-                    if is_length_limit_error(e.as_ref()) {
-                        ParseError::PayloadTooLarge
-                    } else {
-                        ParseError::other(e)
-                    }
-                })?;
-                Ok(collected.to_bytes())
-            })
-            .await
+        if self.payload.get().is_none() {
+            let body = self.take_body_preserving_cache();
+            self.payload
+                .get_or_try_init(|| async {
+                    let limited = Limited::new(body, max_size);
+                    let collected = limited.collect().await.map_err(|e| {
+                        if is_length_limit_error(e.as_ref()) {
+                            ParseError::PayloadTooLarge
+                        } else {
+                            ParseError::other(e)
+                        }
+                    })?;
+                    Ok(collected.to_bytes())
+                })
+                .await
+        } else {
+            Ok(self
+                .payload
+                .get()
+                .expect("payload cache should be initialized"))
+        }
     }
 
     /// Get [`FormData`] reference from request with the default size limit.
@@ -1250,9 +1254,15 @@ impl Request {
     /// ```
     #[inline]
     pub async fn form_data_max_size(&mut self, max_size: usize) -> ParseResult<&FormData> {
+        if self.form_data.get().is_some() {
+            return Ok(self
+                .form_data
+                .get()
+                .expect("form data cache should be initialized"));
+        }
         if let Some(ctype) = self.content_type() {
             if is_form_content_type(&ctype) {
-                let body = self.take_body();
+                let body = self.take_body_preserving_cache();
                 if body.is_none() {
                     let bytes = self.payload_with_max_size(max_size).await?.to_owned();
                     let headers = self.headers();
@@ -1717,7 +1727,7 @@ Hello World\r\n\
     }
 
     #[tokio::test]
-    async fn test_replace_body_preserves_cached_payload() {
+    async fn test_replace_body_refreshes_payload() {
         let mut req = TestClient::post("http://127.0.0.1:8698/form")
             .add_header("content-type", "application/x-www-form-urlencoded", true)
             .raw_form("username=first")
@@ -1729,27 +1739,11 @@ Hello World\r\n\
         req.replace_body(ReqBody::from("username=second"));
 
         let payload = req.payload().await.unwrap();
-        assert_eq!(payload.as_ref(), b"username=first");
-    }
-
-    #[tokio::test]
-    async fn test_replace_body_and_clear_cache_refreshes_payload() {
-        let mut req = TestClient::post("http://127.0.0.1:8698/form")
-            .add_header("content-type", "application/x-www-form-urlencoded", true)
-            .raw_form("username=first")
-            .build();
-
-        let payload = req.payload().await.unwrap().clone();
-        assert_eq!(payload.as_ref(), b"username=first");
-
-        req.replace_body_and_clear_cache(ReqBody::from("username=second"));
-
-        let payload = req.payload().await.unwrap();
         assert_eq!(payload.as_ref(), b"username=second");
     }
 
     #[tokio::test]
-    async fn test_replace_body_and_clear_cache_refreshes_form_data() {
+    async fn test_replace_body_refreshes_form_data() {
         let mut req = TestClient::post("http://127.0.0.1:8698/form")
             .add_header("content-type", "application/x-www-form-urlencoded", true)
             .raw_form("username=first")
@@ -1758,10 +1752,43 @@ Hello World\r\n\
         let form_data = req.form_data().await.unwrap();
         assert_eq!(form_data.fields.get("username").unwrap(), "first");
 
-        req.replace_body_and_clear_cache(ReqBody::from("username=second"));
+        req.replace_body(ReqBody::from("username=second"));
 
         let form_data = req.form_data().await.unwrap();
         assert_eq!(form_data.fields.get("username").unwrap(), "second");
+    }
+
+    #[tokio::test]
+    async fn test_take_body_clears_cached_payload() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/form")
+            .add_header("content-type", "application/x-www-form-urlencoded", true)
+            .raw_form("username=first")
+            .build();
+
+        let payload = req.payload().await.unwrap().clone();
+        assert_eq!(payload.as_ref(), b"username=first");
+
+        let old_body = req.take_body();
+        assert!(old_body.is_none());
+
+        let payload = req.payload().await.unwrap();
+        assert!(payload.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_body_mut_clears_cached_payload() {
+        let mut req = TestClient::post("http://127.0.0.1:8698/form")
+            .add_header("content-type", "application/x-www-form-urlencoded", true)
+            .raw_form("username=first")
+            .build();
+
+        let payload = req.payload().await.unwrap().clone();
+        assert_eq!(payload.as_ref(), b"username=first");
+
+        *req.body_mut() = ReqBody::from("username=second");
+
+        let payload = req.payload().await.unwrap();
+        assert_eq!(payload.as_ref(), b"username=second");
     }
 
     #[tokio::test]

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -559,8 +559,7 @@ impl Request {
     /// Use with caution.
     #[inline]
     pub fn body_mut(&mut self) -> &mut ReqBody {
-        self.payload = tokio::sync::OnceCell::new();
-        self.form_data = tokio::sync::OnceCell::new();
+        self.clear_body_cache();
         &mut self.body
     }
 
@@ -574,9 +573,14 @@ impl Request {
     #[inline]
     pub fn replace_body(&mut self, body: ReqBody) -> ReqBody {
         let old_body = std::mem::replace(&mut self.body, body);
+        self.clear_body_cache();
+        old_body
+    }
+
+    #[inline]
+    fn clear_body_cache(&mut self) {
         self.payload = tokio::sync::OnceCell::new();
         self.form_data = tokio::sync::OnceCell::new();
-        old_body
     }
 
     /// Takes the body from the request, leaving [`ReqBody::None`] in its place.
@@ -597,8 +601,7 @@ impl Request {
     #[inline]
     pub fn take_body(&mut self) -> ReqBody {
         let old_body = std::mem::replace(&mut self.body, ReqBody::None);
-        self.payload = tokio::sync::OnceCell::new();
-        self.form_data = tokio::sync::OnceCell::new();
+        self.clear_body_cache();
         old_body
     }
 

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -559,7 +559,8 @@ impl Request {
     /// Use with caution.
     #[inline]
     pub fn body_mut(&mut self) -> &mut ReqBody {
-        self.clear_body_cache();
+        self.payload = tokio::sync::OnceCell::new();
+        self.form_data = tokio::sync::OnceCell::new();
         &mut self.body
     }
 
@@ -572,20 +573,10 @@ impl Request {
     /// read from the new body.
     #[inline]
     pub fn replace_body(&mut self, body: ReqBody) -> ReqBody {
-        let old_body = self.replace_body_preserving_cache(body);
-        self.clear_body_cache();
-        old_body
-    }
-
-    #[inline]
-    fn replace_body_preserving_cache(&mut self, body: ReqBody) -> ReqBody {
-        std::mem::replace(&mut self.body, body)
-    }
-
-    #[inline]
-    fn clear_body_cache(&mut self) {
+        let old_body = std::mem::replace(&mut self.body, body);
         self.payload = tokio::sync::OnceCell::new();
         self.form_data = tokio::sync::OnceCell::new();
+        old_body
     }
 
     /// Takes the body from the request, leaving [`ReqBody::None`] in its place.
@@ -605,12 +596,10 @@ impl Request {
     /// manage their own internal body consumption while building fresh cache entries.
     #[inline]
     pub fn take_body(&mut self) -> ReqBody {
-        self.replace_body(ReqBody::None)
-    }
-
-    #[inline]
-    fn take_body_preserving_cache(&mut self) -> ReqBody {
-        self.replace_body_preserving_cache(ReqBody::None)
+        let old_body = std::mem::replace(&mut self.body, ReqBody::None);
+        self.payload = tokio::sync::OnceCell::new();
+        self.form_data = tokio::sync::OnceCell::new();
+        old_body
     }
 
     /// Returns a reference to the associated extensions.
@@ -1160,7 +1149,7 @@ impl Request {
     #[inline]
     pub async fn payload_with_max_size(&mut self, max_size: usize) -> ParseResult<&Bytes> {
         if self.payload.get().is_none() {
-            let body = self.take_body_preserving_cache();
+            let body = std::mem::replace(&mut self.body, ReqBody::None);
             self.payload
                 .get_or_try_init(|| async {
                     let limited = Limited::new(body, max_size);
@@ -1262,7 +1251,7 @@ impl Request {
         }
         if let Some(ctype) = self.content_type() {
             if is_form_content_type(&ctype) {
-                let body = self.take_body_preserving_cache();
+                let body = std::mem::replace(&mut self.body, ReqBody::None);
                 if body.is_none() {
                     let bytes = self.payload_with_max_size(max_size).await?.to_owned();
                     let headers = self.headers();

--- a/examples/db-postgres-sea-orm/Cargo.toml
+++ b/examples/db-postgres-sea-orm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 migration = { path = "migration" }
 anyhow.workspace = true
-sea-orm = { version = "=2.0.0-rc.40", features = ["with-chrono", "sqlx-postgres", "macros", "with-uuid", "with-time", "runtime-tokio", "runtime-tokio-native-tls", "runtime-tokio-rustls", "schema-sync", "entity-registry"] }
+sea-orm = { version = "=2.0.0-rc.42", features = ["with-chrono", "sqlx-postgres", "macros", "with-uuid", "with-time", "runtime-tokio", "runtime-tokio-native-tls", "runtime-tokio-rustls", "schema-sync", "entity-registry"] }
 dotenvy.workspace = true
 salvo = { workspace = true, features = ["oapi", "affix-state", "anyhow", "jwt-auth", "test", "cors"] }
 salvo-oapi = { workspace = true, features = ["swagger-ui"] }
@@ -27,5 +27,4 @@ chrono = { workspace = true, features = ["serde"] }
 [[bin]]
 name = "salvo_postgres_seaorm"
 path = "src/main.rs"
-
 

--- a/examples/db-postgres-sea-orm/Dockerfile
+++ b/examples/db-postgres-sea-orm/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:1.92 AS builder
+FROM rust:1.94 AS builder
 
 WORKDIR /app
 
 COPY . .
 
 # Install Sea-orm CLI
-RUN cargo install sea-orm-cli@^2.0.0-rc
+RUN cargo install sea-orm-cli --version 2.0.0-rc.42
 
 RUN cargo build --release --target-dir target
 

--- a/examples/db-postgres-sea-orm/migration/Cargo.toml
+++ b/examples/db-postgres-sea-orm/migration/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
 [dependencies.sea-orm-migration]
-version = "=2.0.0-rc.40"
+version = "=2.0.0-rc.42"
 features = [
   # Enable at least one `ASYNC_RUNTIME` and `DATABASE_DRIVER` feature if you want to run migration via CLI.
   # View the list of supported features at https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime.


### PR DESCRIPTION
## What changed

- Changed `Request::replace_body()` to clear cached payload and form data before subsequent reads.
- Removed the public `replace_body_and_clear_cache()` API so callers no longer have two body-replacement paths with different cache semantics.
- Made public `Request::take_body()` and `Request::body_mut()` also invalidate body-derived caches.
- Kept cache-preserving body extraction as a private implementation detail for `payload()` / `form_data()` while they build fresh cache entries.

## Why

The old `replace_body()` preserved cached payload/form data, which could leave `Request` in a state where cached data described a previous body. Middleware that transformed a body then had to know to call the longer `replace_body_and_clear_cache()` method. This change makes the safe behavior the only public replacement behavior.

## Impact

This is an intentional API behavior change: after replacing, taking, or mutably accessing the request body, later `payload()` / `form_data()` reads observe the current body state rather than stale cached data.

## Validation

- `cargo test -p salvo_core replace_body`
- `cargo test -p salvo_core clears_cached_payload`
- `cargo test -p salvo_core`
- `cargo test -p salvo-proxy -p salvo-tus`
- `git diff --check`