### PR TITLE
fix(core): warn when Router::goal replaces an existing handler

### DIFF
--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -288,9 +288,22 @@ impl Router {
     }
 
     /// Sets current router's handler.
+    ///
+    /// Calling `goal` on a router that already has one **replaces** the previous
+    /// handler (a warning is logged, since this usually indicates route-building
+    /// code overwriting itself by accident). Note that the method helpers
+    /// ([`get`](Router::get), [`post`](Router::post), ...) do not set this
+    /// router's goal — each pushes a filtered child router with its own goal.
     #[inline]
     #[must_use]
     pub fn goal<H: Handler>(mut self, goal: H) -> Self {
+        if self.goal.is_some() {
+            tracing::warn!(
+                "`Router::goal` called on a router that already has a goal handler; \
+                 the previous handler is replaced. If you meant to serve multiple \
+                 methods or paths, push child routers instead."
+            );
+        }
         self.goal = Some(Arc::new(goal));
         self
     }
@@ -354,6 +367,14 @@ impl Router {
     /// Creates a new child router with [`MethodFilter`] to filter GET method and set this child
     /// router's handler.
     ///
+    /// Each method helper (`get`, `post`, ...) pushes a filtered **child** router;
+    /// it does not set the goal of `self`. Two consequences worth knowing:
+    ///
+    /// - `Router::with_path("x").get(a).post(b)` builds one path router with two
+    ///   method children — the usual pattern.
+    /// - `.get(a).get(b)` registers two **sibling** GET routes rather than
+    ///   replacing `a`; the first match wins, so `b` is unreachable.
+    ///
     /// [`MethodFilter`]: super::filters::MethodFilter
     #[inline]
     #[must_use]
@@ -363,6 +384,8 @@ impl Router {
 
     /// Create a new child router with [`MethodFilter`] to filter post method and set this child
     /// router's handler.
+    ///
+    /// See [`get`](Router::get) for how method helpers compose as child routers.
     ///
     /// [`MethodFilter`]: super::filters::MethodFilter
     #[inline]


### PR DESCRIPTION
Two related route-building footguns (H3 from the API-ergonomics review):

1. **`.goal(a).goal(b)` silently dropped `a`.** Now logs a `tracing::warn!` when a goal replaces an existing one. This runs at route-building time — once at startup, never on the request path — so it is not gated to debug builds: a production log line is exactly what reveals a misconfigured router. Replacement behavior itself is unchanged (it can be intentional in dynamic route construction).

2. **`.get(a).get(b)` registers two competing routes, not a replacement.** The method helpers push a filtered *child* router rather than setting `self`'s goal — correct, but the mental model differs from axum's `route("/x", get(h).post(h))` and was undocumented at the call site. `get()` now explains the composition model (including why `b` is unreachable after `.get(a).get(b)`), `post()` cross-references it, and `goal()` clarifies its relationship to the helpers.

215 lib tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)