### PR TITLE
fix(serve-static): entity-escape listing text and drop render-path panics

### DIFF
--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -665,7 +665,7 @@ fn list_xml(current: &CurrentInfo) -> String {
                 xml,
                 "<dir><name>{}</name><modified>{}</modified><link>{}</link></dir>",
                 xml_escape(&dir.name),
-                dir.modified.format(&format).expect("format time failed"),
+                dir.modified.format(&format).unwrap_or_else(|_| "-".into()),
                 encode_url_path(&dir.name),
             );
         }
@@ -674,7 +674,7 @@ fn list_xml(current: &CurrentInfo) -> String {
                 xml,
                 "<file><name>{}</name><modified>{}</modified><size>{}</size><link>{}</link></file>",
                 xml_escape(&file.name),
-                file.modified.format(&format).expect("format time failed"),
+                file.modified.format(&format).unwrap_or_else(|_| "-".into()),
                 file.size,
                 encode_url_path(&file.name),
             );
@@ -692,6 +692,9 @@ fn is_safe_relative_path(path: &str) -> bool {
             .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
 }
 
+/// Escape the five XML special characters. Also used for HTML text nodes and
+/// the page title in the directory listing: the escape set is identical, and
+/// unlike percent-encoding it is an actual markup escaper.
 fn xml_escape(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
@@ -733,10 +736,12 @@ fn list_html(current: &CurrentInfo) -> String {
             .trim_end_matches('/')
             .split('/')
         {
-            let encoded = encode_url_path(seg);
+            // URL-encode the href, but entity-escape the visible text: percent
+            // encoding is a URL escaper, not an HTML one, and it also renders
+            // non-ASCII names as unreadable `%xx` runs.
             link.push('/');
-            link.push_str(&encoded);
-            let _ = write!(out, r#"/<a href="{link}">{encoded}</a>"#);
+            link.push_str(&encode_url_path(seg));
+            let _ = write!(out, r#"/<a href="{link}">{}</a>"#, xml_escape(seg));
         }
     }
     let mut html = format!(
@@ -745,7 +750,7 @@ fn list_html(current: &CurrentInfo) -> String {
         <meta name="viewport" content="width=device-width">
         <title>{}</title>
         <style>{}</style></head><body><header><h3>Index of: "#,
-        encode_url_path(&current.path),
+        xml_escape(&current.path),
         HTML_STYLE,
     );
     header_link(&mut html, &current.path);
@@ -763,25 +768,23 @@ fn list_html(current: &CurrentInfo) -> String {
         );
         let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
         for dir in &current.dirs {
-            let encoded = encode_url_path(&dir.name);
             let _ = write!(
                 html,
                 r#"<tr><td>{}</td><td><a href="./{}/">{}</a></td><td>{}</td><td></td></tr>"#,
                 DIR_ICON,
-                encoded,
-                encoded,
-                dir.modified.format(&format).expect("format time failed"),
+                encode_url_path(&dir.name),
+                xml_escape(&dir.name),
+                dir.modified.format(&format).unwrap_or_else(|_| "-".into()),
             );
         }
         for file in &current.files {
-            let encoded = encode_url_path(&file.name);
             let _ = write!(
                 html,
                 r#"<tr><td>{}</td><td><a href="./{}">{}</a></td><td>{}</td><td>{}</td></tr>"#,
                 FILE_ICON,
-                encoded,
-                encoded,
-                file.modified.format(&format).expect("format time failed"),
+                encode_url_path(&file.name),
+                xml_escape(&file.name),
+                file.modified.format(&format).unwrap_or_else(|_| "-".into()),
                 human_size(file.size)
             );
         }
@@ -801,7 +804,7 @@ fn list_text(current: &CurrentInfo) -> String {
         let _ = writeln!(
             txt,
             "[DIR]  {}  {}",
-            dir.modified.format(&format).expect("format time failed"),
+            dir.modified.format(&format).unwrap_or_else(|_| "-".into()),
             dir.name,
         );
     }
@@ -810,7 +813,7 @@ fn list_text(current: &CurrentInfo) -> String {
             txt,
             "{:>10}  {}  {}",
             human_size(file.size),
-            file.modified.format(&format).expect("format time failed"),
+            file.modified.format(&format).unwrap_or_else(|_| "-".into()),
             file.name,
         );
     }
@@ -856,7 +859,33 @@ const HOME_ICON: &str = r#"<svg aria-hidden="true" data-icon="home" viewBox="0 0
 
 #[cfg(test)]
 mod tests {
-    use crate::dir::{human_size, is_safe_relative_path, xml_escape};
+    use crate::dir::{
+        CurrentInfo, DirInfo, FileInfo, human_size, is_safe_relative_path, list_html, xml_escape,
+    };
+
+    #[test]
+    fn test_list_html_escapes_visible_names() {
+        // Names in the listing are attacker-influenced only when the served
+        // directory is writable by untrusted parties, but the text nodes must be
+        // entity-escaped regardless — percent-encoding is a URL escaper, not an
+        // HTML one. (Names here need not be creatable on every filesystem; the
+        // renderer takes them as plain strings.)
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let file = temp.path().join("probe");
+        std::fs::write(&file, b"x").expect("write file");
+        let metadata = std::fs::metadata(&file).expect("metadata");
+
+        let files = vec![FileInfo::new("a&b'<c>.txt".to_owned(), &metadata)];
+        let dirs = vec![DirInfo::new(r#"d"ir&"#.to_owned(), &metadata)];
+        let html = list_html(&CurrentInfo::new("pa&th".to_owned(), files, dirs));
+
+        // Visible text is entity-escaped...
+        assert!(html.contains("a&amp;b&apos;&lt;c&gt;.txt"));
+        assert!(html.contains("d&quot;ir&amp;"));
+        assert!(html.contains("<title>pa&amp;th</title>"));
+        // ...and the raw markup-significant name never appears anywhere.
+        assert!(!html.contains("<c>.txt"));
+    }
 
     #[tokio::test]
     async fn test_convert_bytes_to_units() {


### PR DESCRIPTION
Two hygiene fixes in the auto directory listing (`auto_list`, off by default) — the two Low items from the security review:

1. **Visible text nodes were percent-encoded, not HTML-escaped.** File/dir names, breadcrumb segments, and the page title went through `encode_url_path`. Its encode set happens to cover `<>&"'` today, so this was not an exploitable XSS — but the safety property was incidental (a future tweak to `HTML_ENCODE_SET` would silently change it), and non-ASCII filenames rendered as unreadable `%xx` runs. Text nodes now use the entity escaper (`xml_escape` — its escape set is exactly the five markup-significant characters); hrefs keep percent-encoding, which is the correct escaper there. Bonus: 中文/emoji filenames now display readably in listings.

2. **Six `.expect("format time failed")` calls on the serving path** now degrade to a `"-"` placeholder. The `OffsetDateTime` values come from filesystem metadata (not request input), so the panics were not attacker-triggerable — but a panic has no place in a request handler.

New test `test_list_html_escapes_visible_names` locks the escaping: `a&b'<c>.txt` renders as `a&amp;b&apos;&lt;c&gt;.txt` and the raw name never appears in the markup.

All `salvo-serve-static` tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)