### PR TITLE
chore(core): add criterion benchmarks for routing and dispatch hot paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ cookie = "0.18"
 chacha20poly1305 = "0.11"
 chardetng = "1.0"
 chrono = "0.4"
+criterion = "0.7"
 compact_str = { version = "0.9", features = ["serde"] }
 content_inspector = "0.2"
 encoding_rs = "0.8"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -147,8 +147,18 @@ zstd = { workspace = true, optional = true, features = ["default"] }
 nix = { workspace = true, optional = true, features = ["fs", "user"] }
 
 [dev-dependencies]
+criterion = { workspace = true }
 fastrand = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "router_detect"
+harness = false
+
+[[bench]]
+name = "service_dispatch"
+harness = false

--- a/crates/core/benches/router_detect.rs
+++ b/crates/core/benches/router_detect.rs
@@ -1,0 +1,133 @@
+#![allow(missing_docs)]
+//! Benchmarks for the routing hot path: `Router::detect`.
+//!
+//! Scenarios cover the shapes that stress different parts of the matcher:
+//! flat static routes, dynamic params, deep nesting, wide sibling fan-out
+//! (worst case for the linear scan), and wildcard tails. Run with
+//! `cargo bench -p salvo_core --bench router_detect`.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use salvo_core::Router;
+use salvo_core::handler;
+use salvo_core::routing::PathState;
+use salvo_core::test::TestClient;
+
+#[handler]
+async fn goal() -> &'static str {
+    "ok"
+}
+
+fn bench_detect(c: &mut Criterion, name: &str, router: &Router, url: &str) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build runtime");
+    let mut req = TestClient::get(url).build();
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let mut state = PathState::new(req.uri().path());
+            let matched = rt.block_on(router.detect(&mut req, &mut state));
+            assert!(matched.is_some(), "route must match in benchmark");
+            black_box(state);
+        });
+    });
+}
+
+fn static_shallow(c: &mut Criterion) {
+    let router = Router::new()
+        .push(Router::with_path("users").goal(goal))
+        .push(Router::with_path("articles").goal(goal))
+        .push(Router::with_path("health").goal(goal));
+    bench_detect(c, "detect/static_shallow", &router, "http://t.dev/health");
+}
+
+fn dynamic_params(c: &mut Criterion) {
+    let router = Router::new().push(
+        Router::with_path("users").push(
+            Router::with_path("{id}")
+                .push(Router::with_path("articles").push(Router::with_path("{aid}").goal(goal))),
+        ),
+    );
+    bench_detect(
+        c,
+        "detect/dynamic_params",
+        &router,
+        "http://t.dev/users/12345/articles/67890",
+    );
+}
+
+fn deep_tree(c: &mut Criterion) {
+    // Eight nested levels alternating static and param segments.
+    let mut leaf = Router::with_path("leaf").goal(goal);
+    for level in (0..8).rev() {
+        let seg = if level % 2 == 0 {
+            format!("level{level}")
+        } else {
+            format!("{{p{level}}}")
+        };
+        leaf = Router::with_path(seg).push(leaf);
+    }
+    let router = Router::new().push(leaf);
+    bench_detect(
+        c,
+        "detect/deep_tree",
+        &router,
+        "http://t.dev/level0/v1/level2/v3/level4/v5/level6/v7/leaf",
+    );
+}
+
+fn wide_siblings(c: &mut Criterion) {
+    // 100 sibling routes under one parent; the request matches the last one,
+    // which is the worst case for the linear sibling scan.
+    let mut parent = Router::with_path("api");
+    for i in 0..100 {
+        parent = parent.push(Router::with_path(format!("res{i:03}")).goal(goal));
+    }
+    let router = Router::new().push(parent);
+    bench_detect(
+        c,
+        "detect/wide_siblings_last",
+        &router,
+        "http://t.dev/api/res099",
+    );
+}
+
+fn wildcard_tail(c: &mut Criterion) {
+    let router = Router::new().push(Router::with_path("assets/{**rest}").goal(goal));
+    bench_detect(
+        c,
+        "detect/wildcard_tail",
+        &router,
+        "http://t.dev/assets/css/site/theme/main.css",
+    );
+}
+
+fn sibling_param_backtrack(c: &mut Criterion) {
+    // Earlier siblings capture params and then fail on a deeper segment,
+    // exercising the snapshot/rollback path before the last sibling matches.
+    let router = Router::new().push(
+        Router::with_path("users")
+            .push(Router::with_path("{id}/profile").goal(goal))
+            .push(Router::with_path("{id}/settings").goal(goal))
+            .push(Router::with_path("{name}").goal(goal)),
+    );
+    bench_detect(
+        c,
+        "detect/sibling_param_backtrack",
+        &router,
+        "http://t.dev/users/alice",
+    );
+}
+
+fn benches(c: &mut Criterion) {
+    static_shallow(c);
+    dynamic_params(c);
+    deep_tree(c);
+    wide_siblings(c);
+    wildcard_tail(c);
+    sibling_param_backtrack(c);
+}
+
+criterion_group!(router_detect, benches);
+criterion_main!(router_detect);

--- a/crates/core/benches/service_dispatch.rs
+++ b/crates/core/benches/service_dispatch.rs
@@ -1,0 +1,73 @@
+#![allow(missing_docs)]
+//! Benchmarks for full request dispatch through `Service`.
+//!
+//! Unlike `router_detect`, these cover the whole per-request pipeline:
+//! routing, hoop-chain assembly, `FlowCtrl` execution, and response
+//! rendering. Run with `cargo bench -p salvo_core --bench service_dispatch`.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use salvo_core::prelude::*;
+use salvo_core::test::TestClient;
+
+#[handler]
+async fn hello() -> &'static str {
+    "hello"
+}
+
+#[handler]
+async fn noop_hoop() {}
+
+fn bench_dispatch(c: &mut Criterion, name: &str, service: &Service, url: &str) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build runtime");
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let res = rt.block_on(async { TestClient::get(url).send(service).await });
+            assert_eq!(res.status_code, Some(StatusCode::OK));
+            black_box(res);
+        });
+    });
+}
+
+fn plain(c: &mut Criterion) {
+    let service = Service::new(Router::new().push(Router::with_path("hello").get(hello)));
+    bench_dispatch(c, "dispatch/plain", &service, "http://t.dev/hello");
+}
+
+fn hoop_chain(c: &mut Criterion) {
+    // Eight no-op middleware on the matched branch: measures hoop-chain
+    // assembly and FlowCtrl traversal overhead.
+    let mut router = Router::with_path("hello");
+    for _ in 0..8 {
+        router = router.hoop(noop_hoop);
+    }
+    let service = Service::new(Router::new().push(router.get(hello)));
+    bench_dispatch(c, "dispatch/hoops8", &service, "http://t.dev/hello");
+}
+
+fn dynamic_path(c: &mut Criterion) {
+    let service = Service::new(Router::new().push(
+        Router::with_path("users").push(
+            Router::with_path("{id}")
+                .push(Router::with_path("articles").push(Router::with_path("{aid}").get(hello))),
+        ),
+    ));
+    bench_dispatch(
+        c,
+        "dispatch/dynamic_path",
+        &service,
+        "http://t.dev/users/12345/articles/67890",
+    );
+}
+
+fn benches(c: &mut Criterion) {
+    plain(c);
+    hoop_chain(c);
+    dynamic_path(c);
+}
+
+criterion_group!(service_dispatch, benches);
+criterion_main!(service_dispatch);


### PR DESCRIPTION
## Why

The repository has no local benchmark suite (`benches/` does not exist anywhere; no criterion dev-dependency) — README links an external leaderboard, but performance PRs cannot be quantified locally or protected against regressions. Recent examples where numbers would have settled the discussion immediately: the params-clone rollback (#1632), the Depot hasher (#1633), and the closed serve-static/compression micro-optimizations (#1634/#1637).

## What

Two criterion bench targets in `salvo_core` (dev-dependency only, zero impact on the shipped library):

**`benches/router_detect.rs`** — `Router::detect` in isolation:
- `static_shallow` — flat static routes
- `dynamic_params` — `/users/{id}/articles/{aid}`
- `deep_tree` — 8 nested levels alternating static/param segments
- `wide_siblings_last` — 100 siblings, request matches the last (linear-scan worst case; the P3 radix-tree ceiling)
- `wildcard_tail` — `{**rest}`
- `sibling_param_backtrack` — failed siblings capture params before the winner (exercises the #1632 snapshot/rollback path)

**`benches/service_dispatch.rs`** — full pipeline via `TestClient` → `Service`:
- `dispatch/plain`, `dispatch/hoops8` (8 no-op middleware), `dispatch/dynamic_path`

## Sample numbers (Windows, current-thread runtime, quick smoke settings)

```
detect/static_shallow      ~1.9 µs
detect/dynamic_params      ~3.1 µs
detect/deep_tree           ~8.8 µs
detect/wide_siblings_last  ~21.9 µs   <- linear sibling scan cost is clearly visible
detect/wildcard_tail       ~2.8 µs
dispatch/plain             ~3.5 µs
dispatch/hoops8            ~6.5 µs
dispatch/dynamic_path      ~7.4 µs
```

Run with `cargo bench -p salvo_core --bench router_detect` / `--bench service_dispatch`.

This gives the pending structural optimizations (sync matching core, Cow path segments, radix tree, precomputed hoop chains) a measurable baseline before any of them is attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)