### PR TITLE
docs: expand macro rustdoc

### DIFF
--- a/crates/craft-macros/src/lib.rs
+++ b/crates/craft-macros/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
-//! [`Salvo`](https://github.com/salvo-rs/salvo) `Handler` modular craft macros.
+//! Procedural macros for building Salvo handlers from service methods.
+//!
+//! This crate is normally used through `salvo_craft::craft`. The macro keeps
+//! related handlers inside an `impl` block and generates small callable handler
+//! values for the methods marked with `#[craft(handler)]` or
+//! `#[craft(endpoint(...))]`.
 
 mod craft;
 mod utils;
@@ -7,7 +12,28 @@ mod utils;
 use proc_macro::TokenStream;
 use syn::{Item, parse_macro_input};
 
-/// `#[craft]` is an attribute macro that converts methods in an `impl` block into [`Salvo`'s `Handler`](https://github.com/salvo-rs/salvo) implementations.
+/// Converts selected methods in an `impl` block into Salvo handlers.
+///
+/// Apply `#[craft]` to an `impl` block, then mark individual methods with:
+///
+/// - `#[craft(handler)]` for a regular Salvo handler.
+/// - `#[craft(endpoint(...))]` for a Salvo OpenAPI endpoint handler. The
+///   arguments are forwarded to `salvo_oapi::endpoint`.
+///
+/// Each marked method is rewritten into a handler factory with the same method
+/// name. Calling that method returns a handler value suitable for
+/// `Router::get`, `Router::post`, and other routing methods; the original
+/// method body is moved into the generated handler implementation.
+///
+/// Supported receivers:
+///
+/// - `&self`: clones the containing value into the generated handler, so the
+///   type must implement `Clone`.
+/// - `self: Arc<Self>`: reuses the existing `Arc`.
+/// - no receiver: generates a static handler constructor.
+///
+/// Handler parameters and return values follow the same rules as Salvo's
+/// `#[handler]` macro.
 ///
 /// ## Example
 /// ```

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,5 +1,10 @@
 //! Procedural macros for the Salvo web framework.
 //!
+//! This crate is normally used through the re-exports from `salvo` or
+//! `salvo_core::prelude`. It provides the `#[handler]` attribute for turning
+//! functions or `impl` blocks into Salvo handlers, and the `Extractible` derive
+//! for request extraction metadata.
+//!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
@@ -17,13 +22,50 @@ mod shared;
 pub(crate) use salvo_serde_util as serde_util;
 use shared::*;
 
-/// `handler` is a macro to help create `Handler` from function or impl block easily.
+/// Converts a function or `impl` block into a Salvo `Handler`.
 ///
-/// `Handler` is a trait, if `#[handler]` applied to `fn`,  `fn` will converted to a struct, and
-/// then implement `Handler`, after use `handler`, you don't need to care arguments' order, omit
-/// unused arguments.
+/// On a function, `#[handler]` generates a zero-sized handler type with the
+/// same name as the function and implements `salvo::Handler` for it. Salvo
+/// injects any supported arguments by type, so handlers can list only the
+/// values they need and in any order:
 ///
-/// View `salvo_core::handler` for more details.
+/// - `&mut Request`
+/// - `&mut Depot`
+/// - `&mut Response`
+/// - `&mut FlowCtrl`
+/// - extractible request data
+///
+/// A return value that implements Salvo's writer traits is written to the
+/// response automatically.
+///
+/// On an `impl` block, the method named `handle` is used as the implementation
+/// of `Handler` for the implementing type.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use salvo_core::prelude::*;
+///
+/// #[handler]
+/// async fn hello() -> &'static str {
+///     "Hello, world!"
+/// }
+/// ```
+///
+/// ```rust,ignore
+/// use salvo_core::prelude::*;
+///
+/// struct Health;
+///
+/// #[handler]
+/// impl Health {
+///     fn handle() -> &'static str {
+///         "ok"
+///     }
+/// }
+/// ```
+///
+/// See `salvo_core::handler` for the full handler guide.
 #[proc_macro_attribute]
 pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
@@ -33,7 +75,56 @@ pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-/// Generate code for extractible type.
+/// Implements `salvo::extract::Extractible` for a request data struct.
+///
+/// `Extractible` describes where each field should be read from and then uses
+/// Salvo's request deserialization support to build the struct in a handler.
+/// The derive is intended for named or tuple structs that also implement
+/// `serde::Deserialize`.
+///
+/// Container attributes:
+///
+/// - `#[salvo(extract(default_source(from = "query")))]` sets a fallback source
+///   for fields without an explicit source.
+/// - `from` accepts `param`, `query`, `header`, `body`, or `depot`.
+/// - `parse` accepts `smart`, `json`, or `multimap`.
+/// - `#[salvo(extract(rename_all = "camelCase"))]` renames fields with the same
+///   case rules used by serde.
+///
+/// Field attributes:
+///
+/// - `#[salvo(extract(source(from = "param")))]` reads a field from a specific
+///   request source.
+/// - `#[salvo(extract(rename = "userId"))]` overrides the request field name.
+/// - `#[salvo(extract(alias = "uid"))]` accepts an alternate field name.
+/// - `#[salvo(extract(flatten))]` flattens another `Extractible` struct into
+///   the same request metadata.
+///
+/// `#[serde(rename)]`, `#[serde(rename_all)]`, `#[serde(alias)]`, and serde
+/// defaults are honored where they map to Salvo extraction metadata.
+/// `#[serde(flatten)]` is intentionally rejected; use
+/// `#[salvo(extract(flatten))]` instead.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use salvo_core::prelude::*;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize, Extractible)]
+/// #[salvo(extract(default_source(from = "query")))]
+/// struct Search<'a> {
+///     #[salvo(extract(source(from = "param")))]
+///     id: i64,
+///     term: &'a str,
+/// }
+///
+/// #[handler]
+/// async fn search(req: &mut Request, depot: &mut Depot) {
+///     let value: Search<'_> = req.extract(depot).await.unwrap();
+///     let _ = value;
+/// }
+/// ```
 #[proc_macro_derive(Extractible, attributes(salvo))]
 pub fn derive_extractible(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DeriveInput);

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -79,7 +79,7 @@ pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// `Extractible` describes where each field should be read from and then uses
 /// Salvo's request deserialization support to build the struct in a handler.
-/// The derive is intended for named or tuple structs that also implement
+/// The derive is intended for named-field structs that also implement
 /// `serde::Deserialize`.
 ///
 /// Container attributes:

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -1,8 +1,11 @@
-//! This is **private** salvo_oapi codegen library and is not used alone.
+//! Procedural macros used by `salvo_oapi`.
 //!
-//! The library contains macro implementations for salvo_oapi library. Content
-//! of the library documentation is available through **salvo_oapi** library itself.
-//! Consider browsing via the **salvo_oapi** crate so all links will work correctly.
+//! This crate contains the implementation of the `#[endpoint]`,
+//! `#[derive(ToSchema)]`, `#[derive(ToParameters)]`,
+//! `#[derive(ToResponse)]`, and `#[derive(ToResponses)]` macros. Most users
+//! should import these macros from `salvo_oapi` or from `salvo` with the
+//! `oapi` feature enabled so the generated paths and documentation links line
+//! up with the public API.
 
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
@@ -45,10 +48,43 @@ pub(crate) use self::server::Server;
 pub(crate) use self::shared::*;
 pub(crate) use self::type_tree::TypeTree;
 
-/// Enhanced of [handler][handler] for generate OpenAPI documentation, [Read more][more].
+/// Turns a Salvo handler function into an OpenAPI-aware endpoint.
 ///
-/// [handler]: ../salvo_core/attr.handler.html
-/// [more]: ../salvo_oapi/endpoint/index.html
+/// `#[endpoint]` behaves like Salvo's `#[handler]` macro and also records
+/// OpenAPI operation metadata. The generated endpoint can be registered on a
+/// router and later collected with `OpenApi::merge_router`.
+///
+/// Function doc comments are used for generated operation text: the first line
+/// becomes the summary and the remaining lines become the description.
+///
+/// Common attributes:
+///
+/// - `operation_id = ...`
+/// - `tags(...)`
+/// - `parameters(...)`
+/// - `request_body = ...` or `request_body(...)`
+/// - `responses(...)`
+/// - `status_codes(...)`
+/// - `security(...)`
+///
+/// Rust's own `#[deprecated]` attribute is reflected as OpenAPI deprecation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use salvo_oapi::endpoint;
+///
+/// /// Fetch one user.
+/// ///
+/// /// Returns `404` when the user does not exist.
+/// #[endpoint(tags("users"), responses((status_code = 200, body = String)))]
+/// async fn get_user() -> String {
+///     "Alice".to_owned()
+/// }
+/// ```
+///
+/// Full attribute reference:
+/// <https://docs.rs/salvo-oapi/latest/salvo_oapi/attr.endpoint.html>
 #[proc_macro_attribute]
 pub fn endpoint(attr: TokenStream, input: TokenStream) -> TokenStream {
     let attr = syn::parse_macro_input!(attr as EndpointAttr);
@@ -58,10 +94,31 @@ pub fn endpoint(attr: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error().into(),
     }
 }
-/// This is `#[derive]` implementation for [`ToSchema`][to_schema] trait, [Read more][more].
+/// Derives `salvo_oapi::ToSchema` for a Rust type.
 ///
-/// [to_schema]: ../salvo_oapi/trait.ToSchema.html
-/// [more]: ../salvo_oapi/derive.ToSchema.html
+/// The generated implementation produces an OpenAPI schema for structs and
+/// enums. Type and field doc comments become schema descriptions unless they
+/// are overridden with `#[salvo(schema(...))]`.
+///
+/// Common `#[salvo(schema(...))]` options include:
+///
+/// - `description = ...`
+/// - `example = json!(...)`
+/// - `default` or `default = ...`
+/// - `rename_all = "..."`
+/// - `rename = "..."`
+/// - `value_type = ...`
+/// - `format = ...`
+/// - `inline`
+/// - `required = ...`
+/// - `nullable`
+/// - `skip`
+///
+/// The derive also reflects supported serde rename/default/skip attributes and
+/// Rust's `#[deprecated]` attribute into the generated OpenAPI schema.
+///
+/// Full attribute reference:
+/// <https://docs.rs/salvo-oapi/latest/salvo_oapi/derive.ToSchema.html>
 #[proc_macro_derive(ToSchema, attributes(salvo))] //attributes(schema)
 pub fn derive_to_schema(input: TokenStream) -> TokenStream {
     match schema::to_schema(syn::parse_macro_input!(input)) {
@@ -70,9 +127,37 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Generate parameters from struct's fields, [Read more][more].
+/// Derives `salvo_oapi::ToParameters` for a parameter struct.
 ///
-/// [more]: ../salvo_oapi/derive.ToParameters.html
+/// The generated implementation converts fields into OpenAPI parameters,
+/// usually for query, path, header, or cookie data used by an endpoint.
+/// Field doc comments become parameter descriptions.
+///
+/// Container attributes use `#[salvo(parameters(...))]` and include:
+///
+/// - `names(...)` for unnamed tuple fields.
+/// - `style = ...`
+/// - `default_parameter_in = ...`
+/// - `rename_all = "..."`
+///
+/// Field attributes use `#[salvo(parameter(...))]` and include:
+///
+/// - `parameter_in = ...`
+/// - `style = ...`
+/// - `explode`
+/// - `allow_reserved`
+/// - `example = ...`
+/// - `value_type = ...`
+/// - `inline`
+/// - `required = ...`
+/// - `nullable`
+/// - `rename = "..."`
+///
+/// The derive also reflects supported serde rename/default/skip attributes and
+/// Rust's `#[deprecated]` attribute into the generated parameters.
+///
+/// Full attribute reference:
+/// <https://docs.rs/salvo-oapi/latest/salvo_oapi/derive.ToParameters.html>
 #[proc_macro_derive(ToParameters, attributes(salvo))] //attributes(parameter, parameters)
 pub fn derive_to_parameters(input: TokenStream) -> TokenStream {
     match parameter::to_parameters(syn::parse_macro_input!(input)) {
@@ -81,10 +166,26 @@ pub fn derive_to_parameters(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Generate reusable [OpenApi][openapi] response, [Read more][more].
+/// Derives `salvo_oapi::ToResponse` for one reusable OpenAPI response.
 ///
-/// [openapi]: ../salvo_oapi/struct.OpenApi.html
-/// [more]: ../salvo_oapi/derive.ToResponse.html
+/// Use this derive when a type should describe a single response component
+/// that can be referenced from endpoint `responses(...)` attributes. Struct
+/// and enum doc comments become the response description unless overridden.
+///
+/// Common `#[salvo(response(...))]` options include:
+///
+/// - `description = "..."`
+/// - `content_type = "..."`
+/// - `headers(...)`
+/// - `example = json!(...)`
+/// - `examples(...)`
+///
+/// Enum variants can use `#[salvo(content(...))]` to describe alternate
+/// response content types. `#[salvo(schema(...))]` can inline a schema for
+/// unnamed fields or content variants whose type implements `ToSchema`.
+///
+/// Full attribute reference:
+/// <https://docs.rs/salvo-oapi/latest/salvo_oapi/derive.ToResponse.html>
 #[proc_macro_derive(ToResponse, attributes(salvo))] //attributes(response, content, schema))
 pub fn derive_to_response(input: TokenStream) -> TokenStream {
     match response::to_response(syn::parse_macro_input!(input)) {
@@ -93,10 +194,24 @@ pub fn derive_to_response(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Generate responses with status codes what can be used in [OpenAPI][openapi], [Read more][more].
+/// Derives `salvo_oapi::ToResponses` for a response map.
 ///
-/// [openapi]: ../salvo_oapi/struct.OpenApi.html
-/// [more]: ../salvo_oapi/derive.ToResponses.html
+/// Use this derive when a type should describe all responses for an endpoint.
+/// A struct produces one response entry; an enum produces one response entry
+/// per variant. The generated map can be used directly in
+/// `#[endpoint(responses(...))]`.
+///
+/// `#[salvo(response(status_code = ...))]` is the central attribute and is
+/// required on most response structs or enum variants. It also accepts the same
+/// response metadata options as `ToResponse`, including `description`,
+/// `content_type`, `headers`, `example`, and `examples`.
+///
+/// Fields can reference or inline reusable response types with
+/// `#[salvo(to_response)]` and `#[salvo(ref_response)]`, or inline schemas with
+/// `#[salvo(schema(...))]`.
+///
+/// Full attribute reference:
+/// <https://docs.rs/salvo-oapi/latest/salvo_oapi/derive.ToResponses.html>
 #[proc_macro_derive(ToResponses, attributes(salvo))] //attributes(response, schema, ref_response, response))
 pub fn to_responses(input: TokenStream) -> TokenStream {
     match response::to_responses(syn::parse_macro_input!(input)) {

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -54,8 +54,9 @@ pub(crate) use self::type_tree::TypeTree;
 /// OpenAPI operation metadata. The generated endpoint can be registered on a
 /// router and later collected with `OpenApi::merge_router`.
 ///
-/// Function doc comments are used for generated operation text: the first line
-/// becomes the summary and the remaining lines become the description.
+/// Function doc comments are used for generated operation text: the first
+/// paragraph becomes the summary and the remaining paragraphs become the
+/// description.
 ///
 /// Common attributes:
 ///
@@ -206,9 +207,8 @@ pub fn derive_to_response(input: TokenStream) -> TokenStream {
 /// response metadata options as `ToResponse`, including `description`,
 /// `content_type`, `headers`, `example`, and `examples`.
 ///
-/// Fields can reference or inline reusable response types with
-/// `#[salvo(to_response)]` and `#[salvo(ref_response)]`, or inline schemas with
-/// `#[salvo(schema(...))]`.
+/// Unnamed response fields are represented as schemas by default; use
+/// `#[salvo(response(inline))]` on a field to inline that schema.
 ///
 /// Full attribute reference:
 /// <https://docs.rs/salvo-oapi/latest/salvo_oapi/derive.ToResponses.html>


### PR DESCRIPTION
## What changed

- Expanded rustdoc at the macro definition points for `salvo_macros`, `salvo-craft-macros`, and `salvo-oapi-macros`.
- Added hover-friendly summaries for `#[handler]`, `Extractible`, `#[craft]`, `#[endpoint]`, and the OAPI derive macros.
- Documented common attributes, receiver behavior, and links to the full `salvo_oapi` attribute references.

## Why

Macro crate definition points had sparse docs, so IDE hover often showed little context even though the public re-export docs were richer.

## Validation

- `cargo test -p salvo_macros -p salvo-craft-macros -p salvo-oapi-macros`
- `cargo doc -p salvo_macros -p salvo-craft-macros -p salvo-oapi-macros --no-deps`