### PR TITLE
fix(oapi): accept singular and plural parameter keys interchangeably

### DIFF
--- a/crates/oapi-macros/src/attribute.rs
+++ b/crates/oapi-macros/src/attribute.rs
@@ -2,10 +2,22 @@ use syn::punctuated::Punctuated;
 use syn::{Attribute, Meta, MetaList, Token};
 
 pub(crate) fn find_nested_list(attr: &Attribute, ident: &str) -> syn::Result<Option<MetaList>> {
+    find_nested_list_any(attr, &[ident])
+}
+
+/// Like [`find_nested_list`], but matches any of several accepted idents.
+///
+/// Used to accept both spellings of keys that historically drifted between
+/// singular and plural (e.g. `parameter` / `parameters`), so the same key works
+/// on both the container and its fields.
+pub(crate) fn find_nested_list_any(
+    attr: &Attribute,
+    idents: &[&str],
+) -> syn::Result<Option<MetaList>> {
     let metas = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
     for meta in metas {
         if let Meta::List(meta) = meta
-            && meta.path.is_ident(ident)
+            && idents.iter().any(|ident| meta.path.is_ident(ident))
         {
             return Ok(Some(meta));
         }

--- a/crates/oapi-macros/src/parameter/derive.rs
+++ b/crates/oapi-macros/src/parameter/derive.rs
@@ -73,12 +73,15 @@ impl TryToTokens for ToParameters {
         ex_generics.params.insert(0, ex_lifetime);
         let ex_impl_generics = ex_generics.split_for_impl().0;
 
+        // Container-level config is spelled `parameters(...)`, but the singular
+        // `parameter(...)` is accepted as an alias so the key matches its
+        // field-level counterpart (see `resolve_field_features`).
         let mut parameters_features = self
             .attrs
             .iter()
             .filter(|attr| attr.path().is_ident("salvo"))
             .filter_map(|attr| {
-                attribute::find_nested_list(attr, "parameters")
+                attribute::find_nested_list_any(attr, &["parameters", "parameter"])
                     .ok()
                     .flatten()
             })
@@ -91,22 +94,6 @@ impl TryToTokens for ToParameters {
             .into_iter()
             .reduce(|acc, item| acc.merge(item));
         let serde_container = serde_util::parse_container(&self.attrs).map_err(Diagnostic::from)?;
-
-        // #[param] is only supported over fields
-        if self.attrs.iter().any(|attr| {
-            attr.path().is_ident("salvo")
-                && attribute::find_nested_list(attr, "parameter")
-                    .ok()
-                    .flatten()
-                    .is_some()
-        }) {
-            return Err(Diagnostic::spanned(
-                ident.span(),
-                DiagLevel::Error,
-                "found `parameter` attribute in unsupported context",
-            )
-            .help("Did you mean `parameters`?"));
-        }
 
         let names = parameters_features.as_mut().and_then(|features| {
             let to_parameters_names = pop_feature!(features => Feature::ToParametersNames(_));
@@ -415,7 +402,10 @@ impl Parameter<'_> {
             .iter()
             .filter_map(|attr| {
                 if attr.path().is_ident("salvo") {
-                    attribute::find_nested_list(attr, "parameter")
+                    // Field-level config is spelled `parameter(...)`; the plural
+                    // `parameters(...)` is accepted as an alias so the key matches
+                    // its container-level counterpart.
+                    attribute::find_nested_list_any(attr, &["parameter", "parameters"])
                         .ok()
                         .flatten()
                         .map(|metas| {

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -1334,6 +1334,57 @@ mod tests {
     }
 
     #[test]
+    fn to_parameters_accepts_singular_and_plural_keys() {
+        // The container key was `parameters(...)` and the field key `parameter(...)`;
+        // the opposite spelling used to be a hard error / silently ignored. Both
+        // spellings are now accepted at both levels, so the drift is invisible to
+        // users. This test drives each level with its *alias* spelling.
+        #[derive(Deserialize, crate::ToParameters)]
+        // singular `parameter(...)` on the container (previously an error):
+        #[salvo(parameter(default_parameter_in = Header))]
+        #[allow(dead_code)]
+        struct AliasQuery {
+            page: i32,
+            // plural `parameters(...)` on a field (previously ignored):
+            #[salvo(parameters(rename = "renamed"))]
+            raw: String,
+        }
+
+        #[salvo_oapi::endpoint]
+        async fn list(query: AliasQuery) -> &'static str {
+            let _ = query;
+            "ok"
+        }
+
+        let router = Router::with_path("/alias").get(list);
+        let doc = OpenApi::new("test api", "0.0.1").merge_router(&router);
+        let operation = doc
+            .paths
+            .get("/alias")
+            .and_then(|item| item.operations.get(&PathItemType::Get))
+            .expect("get operation should exist");
+        let names: Vec<&str> = operation
+            .parameters
+            .0
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+
+        // container singular alias honored: every parameter is in `header`.
+        for param in &operation.parameters.0 {
+            assert_eq!(
+                param.parameter_in,
+                ParameterIn::Header,
+                "parameter `{}` should inherit the container `default_parameter_in`",
+                param.name
+            );
+        }
+        // field plural alias honored: `raw` was renamed to `renamed`.
+        assert!(names.contains(&"renamed"), "field rename alias not applied: {names:?}");
+        assert!(!names.contains(&"raw"));
+    }
+
+    #[test]
     fn merge_router_skips_route_without_method_filter() {
         #[salvo_oapi::endpoint]
         async fn any_handler() -> &'static str {


### PR DESCRIPTION
## The drift

`#[derive(ToParameters)]` spelled the **container** config `parameters(...)` but the **field** config `parameter(...)`:

```rust
#[derive(ToParameters)]
#[salvo(parameters(default_parameter_in = Query))]  // plural on the struct
struct Query {
    #[salvo(parameter(inline))]                     // singular on the field
    id: String,
}
```

Worse, each level actively rejected the other spelling — the container even returned a hard error *"found `parameter` attribute in unsupported context — Did you mean `parameters`?"*, and a plural key on a field was silently ignored. So the same concept required remembering plural-on-struct / singular-on-field. (This is the concrete, non-breaking half of the H4 ergonomics finding.)

## The fix

Both spellings are now accepted at both levels, via a small `find_nested_list_any(attr, &[...])` helper that tries several idents. The drift becomes invisible — whichever you type works.

- **Fully backward compatible.** The previous canonical spellings (`parameters` container / `parameter` field) are unchanged and still what the docs recommend; the *opposite* spelling simply stops being an error. No existing code changes meaning.
- The obsolete container-level rejection block is removed (the case it guarded against now just works).
- `response` / `schema` derives already use a single spelling at both levels — untouched.
- Deliberately scoped to the singular/plural drift only; the deeper `#[salvo(...)]` grammar questions (e.g. `extract(source(from = ...))` nesting) are left for a separate 0.94 discussion.

## Verification

- New test `to_parameters_accepts_singular_and_plural_keys` drives each level with its *alias* spelling (`parameter(...)` on the container, `parameters(...)` on a field) and asserts both are honored.
- `salvo-oapi-macros` builds clean; clippy clean. (`salvo-oapi` has 2 unrelated pre-existing test failures reproducible on `main` — `test_simple_document_with_security`, `test_openapi_schema_work_with_generics`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)