### PR TITLE
perf: borrow undecoded path segments

### DIFF
--- a/crates/core/benches/router_detect.rs
+++ b/crates/core/benches/router_detect.rs
@@ -24,9 +24,10 @@ fn bench_detect(c: &mut Criterion, name: &str, router: &Router, url: &str) {
         .build()
         .expect("build runtime");
     let mut req = TestClient::get(url).build();
+    let path = req.uri().path().to_owned();
     c.bench_function(name, |b| {
         b.iter(|| {
-            let mut state = PathState::new(req.uri().path());
+            let mut state = PathState::from_borrowed_path(&path);
             let matched = rt.block_on(router.detect(&mut req, &mut state));
             assert!(matched.is_some(), "route must match in benchmark");
             black_box(state);

--- a/crates/core/src/routing.rs
+++ b/crates/core/src/routing.rs
@@ -409,6 +409,7 @@ pub use path_params::PathParams;
 mod path_state;
 pub use path_state::PathState;
 mod flow_ctrl;
+use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
@@ -457,10 +458,12 @@ pub(crate) fn split_wild_name(name: &str) -> (&str, &str) {
 #[inline]
 #[doc(hidden)]
 #[must_use]
-pub fn decode_url_path(path: &str) -> String {
-    percent_encoding::percent_decode_str(path)
-        .decode_utf8_lossy()
-        .to_string()
+pub fn decode_url_path(path: &str) -> Cow<'_, str> {
+    if path.as_bytes().contains(&b'%') {
+        percent_encoding::percent_decode_str(path).decode_utf8_lossy()
+    } else {
+        Cow::Borrowed(path)
+    }
 }
 
 #[inline]
@@ -552,7 +555,7 @@ mod tests {
     use crate::http::header::LOCATION;
     use crate::http::uri::Uri;
     use crate::prelude::*;
-    use crate::routing::{is_windows_reserved_name, normalize_url_path};
+    use crate::routing::{decode_url_path, is_windows_reserved_name, normalize_url_path};
     use crate::test::{ResponseExt, TestClient};
 
     #[tokio::test]
@@ -649,6 +652,18 @@ mod tests {
         access(&service, "/open/alice2/bob2").await;
         access(&service, "/alice3").await;
         access(&service, "/alice1/bob3").await;
+    }
+
+    #[test]
+    fn test_decode_url_path_borrows_plain_path() {
+        assert!(matches!(
+            decode_url_path("plain-segment"),
+            std::borrow::Cow::Borrowed("plain-segment")
+        ));
+        assert!(matches!(
+            decode_url_path("hello%20world"),
+            std::borrow::Cow::Owned(ref decoded) if decoded == "hello world"
+        ));
     }
 
     #[test]

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -99,7 +99,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn and_then<F>(self, fun: F) -> AndThen<Self, F>
     where
         Self: Sized,
-        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
     {
         AndThen {
             filter: self,
@@ -112,7 +112,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn or_else<F>(self, fun: F) -> OrElse<Self, F>
     where
         Self: Sized,
-        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
     {
         OrElse {
             filter: self,
@@ -121,7 +121,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     }
 
     /// Filter `Request` and returns false or true.
-    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool;
+    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool;
 }
 
 /// `FnFilter` accepts a function as its parameter, using this function to filter requests.
@@ -132,10 +132,10 @@ pub struct FnFilter<F>(pub F);
 #[async_trait]
 impl<F> Filter for FnFilter<F>
 where
-    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool {
         self.0(req, path)
     }
 }
@@ -246,10 +246,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_opts() {
-        fn has_one(_req: &mut Request, path: &mut PathState<'_>) -> bool {
+        fn has_one(_req: &mut Request, path: &mut PathState) -> bool {
             path.parts().any(|part| part == "one")
         }
-        fn has_two(_req: &mut Request, path: &mut PathState<'_>) -> bool {
+        fn has_two(_req: &mut Request, path: &mut PathState) -> bool {
             path.parts().any(|part| part == "two")
         }
 

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -99,7 +99,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn and_then<F>(self, fun: F) -> AndThen<Self, F>
     where
         Self: Sized,
-        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         AndThen {
             filter: self,
@@ -112,7 +112,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn or_else<F>(self, fun: F) -> OrElse<Self, F>
     where
         Self: Sized,
-        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         OrElse {
             filter: self,
@@ -121,7 +121,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     }
 
     /// Filter `Request` and returns false or true.
-    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool;
+    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool;
 }
 
 /// `FnFilter` accepts a function as its parameter, using this function to filter requests.
@@ -132,10 +132,10 @@ pub struct FnFilter<F>(pub F);
 #[async_trait]
 impl<F> Filter for FnFilter<F>
 where
-    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool {
         self.0(req, path)
     }
 }
@@ -246,10 +246,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_opts() {
-        fn has_one(_req: &mut Request, path: &mut PathState) -> bool {
+        fn has_one(_req: &mut Request, path: &mut PathState<'_>) -> bool {
             path.parts.contains(&"one".into())
         }
-        fn has_two(_req: &mut Request, path: &mut PathState) -> bool {
+        fn has_two(_req: &mut Request, path: &mut PathState<'_>) -> bool {
             path.parts.contains(&"two".into())
         }
 

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -99,7 +99,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn and_then<F>(self, fun: F) -> AndThen<Self, F>
     where
         Self: Sized,
-        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         AndThen {
             filter: self,
@@ -112,7 +112,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     fn or_else<F>(self, fun: F) -> OrElse<Self, F>
     where
         Self: Sized,
-        F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         OrElse {
             filter: self,
@@ -121,7 +121,7 @@ pub trait Filter: Debug + Send + Sync + 'static {
     }
 
     /// Filter `Request` and returns false or true.
-    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool;
+    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool;
 }
 
 /// `FnFilter` accepts a function as its parameter, using this function to filter requests.
@@ -132,10 +132,10 @@ pub struct FnFilter<F>(pub F);
 #[async_trait]
 impl<F> Filter for FnFilter<F>
 where
-    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, path: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, path: &mut PathState<'_>) -> bool {
         self.0(req, path)
     }
 }
@@ -246,10 +246,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_opts() {
-        fn has_one(_req: &mut Request, path: &mut PathState) -> bool {
+        fn has_one(_req: &mut Request, path: &mut PathState<'_>) -> bool {
             path.parts().any(|part| part == "one")
         }
-        fn has_two(_req: &mut Request, path: &mut PathState) -> bool {
+        fn has_two(_req: &mut Request, path: &mut PathState<'_>) -> bool {
             path.parts().any(|part| part == "two")
         }
 
@@ -257,7 +257,7 @@ mod tests {
         let two_filter = FnFilter(has_two);
 
         let mut req = Request::default();
-        let mut path_state = PathState::new("http://localhost/one");
+        let mut path_state = PathState::from_borrowed_path("http://localhost/one");
         assert!(one_filter.filter(&mut req, &mut path_state).await);
         assert!(!two_filter.filter(&mut req, &mut path_state).await);
         assert!(
@@ -285,7 +285,7 @@ mod tests {
                 .await
         );
 
-        let mut path_state = PathState::new("http://localhost/one/two");
+        let mut path_state = PathState::from_borrowed_path("http://localhost/one/two");
         assert!(one_filter.filter(&mut req, &mut path_state).await);
         assert!(two_filter.filter(&mut req, &mut path_state).await);
         assert!(
@@ -313,7 +313,7 @@ mod tests {
                 .await
         );
 
-        let mut path_state = PathState::new("http://localhost/two");
+        let mut path_state = PathState::from_borrowed_path("http://localhost/two");
         assert!(!one_filter.filter(&mut req, &mut path_state).await);
         assert!(two_filter.filter(&mut req, &mut path_state).await);
         assert!(

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -247,10 +247,10 @@ mod tests {
     #[tokio::test]
     async fn test_opts() {
         fn has_one(_req: &mut Request, path: &mut PathState<'_>) -> bool {
-            path.parts.contains(&"one".into())
+            path.parts().any(|part| part == "one")
         }
         fn has_two(_req: &mut Request, path: &mut PathState<'_>) -> bool {
-            path.parts.contains(&"two".into())
+            path.parts().any(|part| part == "two")
         }
 
         let one_filter = FnFilter(has_one);

--- a/crates/core/src/routing/filters/opts.rs
+++ b/crates/core/src/routing/filters/opts.rs
@@ -17,7 +17,7 @@ where
     U: Filter + Send,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
         if self.first.filter(req, state).await {
             true
         } else {
@@ -35,10 +35,10 @@ pub struct OrElse<T, F> {
 impl<T, F> Filter for OrElse<T, F>
 where
     T: Filter,
-    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
         if self.filter.filter(req, state).await {
             true
         } else {
@@ -66,7 +66,7 @@ where
     U: Filter,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
         if !self.first.filter(req, state).await {
             false
         } else {
@@ -85,10 +85,10 @@ pub struct AndThen<T, F> {
 impl<T, F> Filter for AndThen<T, F>
 where
     T: Filter,
-    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
         if !self.filter.filter(req, state).await {
             false
         } else {

--- a/crates/core/src/routing/filters/opts.rs
+++ b/crates/core/src/routing/filters/opts.rs
@@ -17,7 +17,7 @@ where
     U: Filter + Send,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
         if self.first.filter(req, state).await {
             true
         } else {
@@ -35,10 +35,10 @@ pub struct OrElse<T, F> {
 impl<T, F> Filter for OrElse<T, F>
 where
     T: Filter,
-    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
         if self.filter.filter(req, state).await {
             true
         } else {
@@ -66,7 +66,7 @@ where
     U: Filter,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
         if !self.first.filter(req, state).await {
             false
         } else {
@@ -85,10 +85,10 @@ pub struct AndThen<T, F> {
 impl<T, F> Filter for AndThen<T, F>
 where
     T: Filter,
-    F: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+    F: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
 {
     #[inline]
-    async fn filter(&self, req: &mut Request, state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, state: &mut PathState) -> bool {
         if !self.filter.filter(req, state).await {
             false
         } else {

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -19,7 +19,7 @@ impl MethodFilter {
 #[async_trait]
 impl Filter for MethodFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         req.method() == self.0
     }
     #[inline]
@@ -70,7 +70,7 @@ impl SchemeFilter {
 #[async_trait]
 impl Filter for SchemeFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         req.uri()
             .scheme()
             .map(|s| s == &self.scheme)
@@ -143,7 +143,7 @@ fn split_host_port(authority: &str) -> (&str, Option<&str>) {
 #[async_trait]
 impl Filter for HostFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
@@ -206,7 +206,7 @@ impl PortFilter {
 #[async_trait]
 impl Filter for PortFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
@@ -257,7 +257,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_scheme_filter_result_when_scheme_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let mut state = PathState::from_owned_path(req.uri().path().to_owned());
 
         assert!(
             SchemeFilter::new(Scheme::HTTPS)
@@ -270,7 +270,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_host_filter_result_when_host_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let mut state = PathState::from_owned_path(req.uri().path().to_owned());
 
         assert!(
             HostFilter::new("example.com")
@@ -283,7 +283,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_port_filter_result_when_port_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let mut state = PathState::from_owned_path(req.uri().path().to_owned());
 
         assert!(
             PortFilter::new(443)

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -19,7 +19,7 @@ impl MethodFilter {
 #[async_trait]
 impl Filter for MethodFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         req.method() == self.0
     }
     #[inline]
@@ -70,7 +70,7 @@ impl SchemeFilter {
 #[async_trait]
 impl Filter for SchemeFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         req.uri()
             .scheme()
             .map(|s| s == &self.scheme)
@@ -143,7 +143,7 @@ fn split_host_port(authority: &str) -> (&str, Option<&str>) {
 #[async_trait]
 impl Filter for HostFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
@@ -206,7 +206,7 @@ impl PortFilter {
 #[async_trait]
 impl Filter for PortFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
@@ -257,7 +257,8 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_scheme_filter_result_when_scheme_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut state = PathState::new(&path);
 
         assert!(
             SchemeFilter::new(Scheme::HTTPS)
@@ -270,7 +271,8 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_host_filter_result_when_host_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut state = PathState::new(&path);
 
         assert!(
             HostFilter::new("example.com")
@@ -283,7 +285,8 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_port_filter_result_when_port_is_absent() {
         let mut req = Request::new();
-        let mut state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut state = PathState::new(&path);
 
         assert!(
             PortFilter::new(443)

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -257,8 +257,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_scheme_filter_result_when_scheme_is_absent() {
         let mut req = Request::new();
-        let path = req.uri().path().to_owned();
-        let mut state = PathState::new(&path);
+        let mut state = PathState::new(req.uri().path());
 
         assert!(
             SchemeFilter::new(Scheme::HTTPS)
@@ -271,8 +270,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_host_filter_result_when_host_is_absent() {
         let mut req = Request::new();
-        let path = req.uri().path().to_owned();
-        let mut state = PathState::new(&path);
+        let mut state = PathState::new(req.uri().path());
 
         assert!(
             HostFilter::new("example.com")
@@ -285,8 +283,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_sets_port_filter_result_when_port_is_absent() {
         let mut req = Request::new();
-        let path = req.uri().path().to_owned();
-        let mut state = PathState::new(&path);
+        let mut state = PathState::new(req.uri().path());
 
         assert!(
             PortFilter::new(443)

--- a/crates/core/src/routing/filters/others.rs
+++ b/crates/core/src/routing/filters/others.rs
@@ -19,7 +19,7 @@ impl MethodFilter {
 #[async_trait]
 impl Filter for MethodFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         req.method() == self.0
     }
     #[inline]
@@ -70,7 +70,7 @@ impl SchemeFilter {
 #[async_trait]
 impl Filter for SchemeFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         req.uri()
             .scheme()
             .map(|s| s == &self.scheme)
@@ -143,7 +143,7 @@ fn split_host_port(authority: &str) -> (&str, Option<&str>) {
 #[async_trait]
 impl Filter for HostFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]
@@ -206,7 +206,7 @@ impl PortFilter {
 #[async_trait]
 impl Filter for PortFilter {
     #[inline]
-    async fn filter(&self, req: &mut Request, _state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, req: &mut Request, _state: &mut PathState) -> bool {
         // On HTTP/1 without the `fix-http1-request-uri` feature, the URI has no authority,
         // so fall back to the `Host` header. See https://github.com/hyperium/hyper/issues/1310
         #[cfg(feature = "fix-http1-request-uri")]

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -41,7 +41,7 @@ pub trait PathWisp: Send + Sync + fmt::Debug + 'static {
         Ok(())
     }
     /// Return whether the path matches.
-    fn detect(&self, state: &mut PathState) -> bool;
+    fn detect(&self, state: &mut PathState<'_>) -> bool;
 }
 /// Builds a [`PathWisp`] from a parsed pattern fragment.
 ///
@@ -110,7 +110,7 @@ impl PathWisp for WispKind {
         }
     }
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         match self {
             Self::Const(wisp) => wisp.detect(state),
             Self::Named(wisp) => wisp.detect(state),
@@ -286,7 +286,7 @@ impl Debug for CharsWisp {
     }
 }
 impl PathWisp for CharsWisp {
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -429,7 +429,7 @@ impl CombWisp {
 }
 impl PathWisp for CombWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick().map(|s| s.to_owned()) else {
             return false;
         };
@@ -531,7 +531,7 @@ impl PathWisp for CombWisp {
 pub struct NamedWisp(pub String);
 impl PathWisp for NamedWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         if self.0.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.0.starts_with("*?")
@@ -603,7 +603,7 @@ impl PartialEq for RegexWisp {
 }
 impl PathWisp for RegexWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         if self.name.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.name.starts_with("*?")
@@ -654,7 +654,7 @@ impl PathWisp for RegexWisp {
 pub struct ConstWisp(pub String);
 impl PathWisp for ConstWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -1043,7 +1043,7 @@ impl Debug for PathFilter {
 #[async_trait]
 impl Filter for PathFilter {
     #[inline]
-    async fn filter(&self, _req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, _req: &mut Request, state: &mut PathState<'_>) -> bool {
         self.detect(state)
     }
     #[inline]
@@ -1128,7 +1128,7 @@ impl PathFilter {
         builders.insert(name.into(), Arc::new(RegexWispBuilder::new(regex)));
     }
     /// Detect is that path is match.
-    pub fn detect(&self, state: &mut PathState) -> bool {
+    pub fn detect(&self, state: &mut PathState<'_>) -> bool {
         let original_cursor = state.cursor;
         for ps in &self.path_wisps {
             let row = state.cursor.0;

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -41,7 +41,7 @@ pub trait PathWisp: Send + Sync + fmt::Debug + 'static {
         Ok(())
     }
     /// Return whether the path matches.
-    fn detect(&self, state: &mut PathState) -> bool;
+    fn detect(&self, state: &mut PathState<'_>) -> bool;
 }
 /// Builds a [`PathWisp`] from a parsed pattern fragment.
 ///
@@ -110,7 +110,7 @@ impl PathWisp for WispKind {
         }
     }
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         match self {
             Self::Const(wisp) => wisp.detect(state),
             Self::Named(wisp) => wisp.detect(state),
@@ -286,7 +286,7 @@ impl Debug for CharsWisp {
     }
 }
 impl PathWisp for CharsWisp {
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -429,7 +429,7 @@ impl CombWisp {
 }
 impl PathWisp for CombWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick().map(|s| s.to_owned()) else {
             return false;
         };
@@ -531,7 +531,7 @@ impl PathWisp for CombWisp {
 pub struct NamedWisp(pub String);
 impl PathWisp for NamedWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         if self.0.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.0.starts_with("*?")
@@ -603,7 +603,7 @@ impl PartialEq for RegexWisp {
 }
 impl PathWisp for RegexWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         if self.name.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.name.starts_with("*?")
@@ -654,7 +654,7 @@ impl PathWisp for RegexWisp {
 pub struct ConstWisp(pub String);
 impl PathWisp for ConstWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState) -> bool {
+    fn detect(&self, state: &mut PathState<'_>) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -1043,7 +1043,7 @@ impl Debug for PathFilter {
 #[async_trait]
 impl Filter for PathFilter {
     #[inline]
-    async fn filter(&self, _req: &mut Request, state: &mut PathState) -> bool {
+    async fn filter(&self, _req: &mut Request, state: &mut PathState<'_>) -> bool {
         self.detect(state)
     }
     #[inline]
@@ -1128,7 +1128,7 @@ impl PathFilter {
         builders.insert(name.into(), Arc::new(RegexWispBuilder::new(regex)));
     }
     /// Detect is that path is match.
-    pub fn detect(&self, state: &mut PathState) -> bool {
+    pub fn detect(&self, state: &mut PathState<'_>) -> bool {
         let original_cursor = state.cursor;
         for ps in &self.path_wisps {
             let row = state.cursor.0;
@@ -1304,7 +1304,7 @@ mod tests {
             min_width: 1,
             max_width: None,
         };
-        let mut state = PathState::new("1a2");
+        let mut state = PathState::from_borrowed_path("1a2");
         assert!(wisp.detect(&mut state));
         assert_eq!(state.params.get("id").map(String::as_str), Some("1"));
         assert_eq!(state.pick(), Some("a2"));
@@ -1318,7 +1318,7 @@ mod tests {
             min_width: 1,
             max_width: None,
         };
-        let mut state = PathState::new("\u{00E9}/rest");
+        let mut state = PathState::from_borrowed_path("\u{00E9}/rest");
         assert!(wisp.detect(&mut state));
         assert_eq!(state.params.get("x").map(String::as_str), Some("\u{00E9}"));
         assert_eq!(state.pick(), Some("rest"));
@@ -1337,7 +1337,7 @@ mod tests {
         );
 
         let filter = PathFilter::new("/first{id}world{**rest}");
-        let mut state = PathState::new("first123world.ext");
+        let mut state = PathState::from_borrowed_path("first123world.ext");
         assert!(filter.detect(&mut state));
         // The wild capture must be the tail only, not include the comb prefix.
         assert_eq!(state.params.get("id").map(String::as_str), Some("123"));
@@ -1347,23 +1347,23 @@ mod tests {
     #[test]
     fn test_parse_comb_2() {
         let filter = PathFilter::new("/abc/hello{id}world{**rest}");
-        let mut state = PathState::new("abc/hello123world.ext");
+        let mut state = PathState::from_borrowed_path("abc/hello123world.ext");
         assert!(filter.detect(&mut state));
     }
 
     #[test]
     fn test_parse_comb_3() {
         let filter = PathFilter::new("/{id}/{name}!hello.bu");
-        let mut state = PathState::new("123/gold!hello.bu");
+        let mut state = PathState::from_borrowed_path("123/gold!hello.bu");
         assert!(filter.detect(&mut state));
     }
     #[test]
     fn test_parse_comb_4() {
         let filter = PathFilter::new("/abc/l{**rest}");
-        let mut state = PathState::new("abc/llo1");
+        let mut state = PathState::from_borrowed_path("abc/llo1");
         assert!(filter.detect(&mut state));
 
-        let mut state = PathState::new("abc/hello1");
+        let mut state = PathState::from_borrowed_path("abc/hello1");
         assert!(!filter.detect(&mut state));
     }
     #[test]
@@ -1372,14 +1372,14 @@ mod tests {
         // After the literal `t` is consumed, the remaining `11` matches `\d+`, so
         // this is a match with `rest = "11"` (the wild regex is checked against the
         // tail, not the already-consumed `t` prefix).
-        let mut state = PathState::new("abc/t11");
+        let mut state = PathState::from_borrowed_path("abc/t11");
         assert!(filter.detect(&mut state));
         assert_eq!(state.params.get("rest").map(String::as_str), Some("11"));
 
         // `lo1` / `11a` tails are not all digits, so `\d+` rejects them.
-        let mut state = PathState::new("abc/tlo1");
+        let mut state = PathState::from_borrowed_path("abc/tlo1");
         assert!(!filter.detect(&mut state));
-        let mut state = PathState::new("abc/t11a");
+        let mut state = PathState::from_borrowed_path("abc/t11a");
         assert!(!filter.detect(&mut state));
     }
 
@@ -1417,45 +1417,45 @@ mod tests {
     #[test]
     fn test_detect_consts() {
         let filter = PathFilter::new("/hello/world");
-        let mut state = PathState::new("hello/world");
+        let mut state = PathState::from_borrowed_path("hello/world");
         assert!(filter.detect(&mut state));
     }
     #[test]
     fn test_detect_consts0() {
         let filter = PathFilter::new("/hello/world/");
-        let mut state = PathState::new("hello/world");
+        let mut state = PathState::from_borrowed_path("hello/world");
         assert!(filter.detect(&mut state));
     }
     #[test]
     fn test_detect_consts1() {
         let filter = PathFilter::new("/hello/world");
-        let mut state = PathState::new("hello/world/");
+        let mut state = PathState::from_borrowed_path("hello/world/");
         assert!(filter.detect(&mut state));
     }
     #[test]
     fn test_detect_consts2() {
         let filter = PathFilter::new("/hello/world2");
-        let mut state = PathState::new("hello/world");
+        let mut state = PathState::from_borrowed_path("hello/world");
         assert!(!filter.detect(&mut state));
     }
 
     #[test]
     fn test_detect_const_and_named() {
         let filter = PathFilter::new("/hello/world{id}");
-        let mut state = PathState::new("hello/worldabc");
+        let mut state = PathState::from_borrowed_path("hello/worldabc");
         filter.detect(&mut state);
     }
 
     #[test]
     fn test_detect_many() {
         let filter = PathFilter::new("/users/{id}/emails");
-        let mut state = PathState::new("/users/29/emails");
+        let mut state = PathState::from_borrowed_path("/users/29/emails");
         assert!(filter.detect(&mut state));
     }
     #[test]
     fn test_detect_many_slashes() {
         let filter = PathFilter::new("/users/{id}/emails");
-        let mut state = PathState::new("/users///29//emails");
+        let mut state = PathState::from_borrowed_path("/users///29//emails");
         assert!(filter.detect(&mut state));
     }
     #[test]
@@ -1465,10 +1465,12 @@ mod tests {
             regex::Regex::new("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}").unwrap(),
         );
         let filter = PathFilter::new("/users/{id:guid}");
-        let mut state = PathState::new("/users/123e4567-h89b-12d3-a456-9AC7CBDCEE52");
+        let mut state =
+            PathState::from_borrowed_path("/users/123e4567-h89b-12d3-a456-9AC7CBDCEE52");
         assert!(!filter.detect(&mut state));
 
-        let mut state = PathState::new("/users/123e4567-e89b-12d3-a456-9AC7CBDCEE52");
+        let mut state =
+            PathState::from_borrowed_path("/users/123e4567-e89b-12d3-a456-9AC7CBDCEE52");
         assert!(filter.detect(&mut state));
         assert_eq!(
             state.matched_parts,
@@ -1478,15 +1480,15 @@ mod tests {
     #[test]
     fn test_detect_wildcard() {
         let filter = PathFilter::new("/users/{id}/{**rest}");
-        let mut state = PathState::new("/users/12/facebook/insights/23");
+        let mut state = PathState::from_borrowed_path("/users/12/facebook/insights/23");
         assert!(filter.detect(&mut state));
         assert_eq!(
             state.matched_parts,
             vec!["users".to_owned(), "{id}".to_owned(), "{**rest}".to_owned()]
         );
-        let mut state = PathState::new("/users/12/");
+        let mut state = PathState::from_borrowed_path("/users/12/");
         assert!(filter.detect(&mut state));
-        let mut state = PathState::new("/users/12");
+        let mut state = PathState::from_borrowed_path("/users/12");
         assert!(filter.detect(&mut state));
         assert_eq!(
             state.matched_parts,
@@ -1494,21 +1496,21 @@ mod tests {
         );
 
         let filter = PathFilter::new("/users/{id}/{*+rest}");
-        let mut state = PathState::new("/users/12/facebook/insights/23");
+        let mut state = PathState::from_borrowed_path("/users/12/facebook/insights/23");
         assert!(filter.detect(&mut state));
-        let mut state = PathState::new("/users/12/");
+        let mut state = PathState::from_borrowed_path("/users/12/");
         assert!(!filter.detect(&mut state));
-        let mut state = PathState::new("/users/12");
+        let mut state = PathState::from_borrowed_path("/users/12");
         assert!(!filter.detect(&mut state));
 
         let filter = PathFilter::new("/users/{id}/{*?rest}");
-        let mut state = PathState::new("/users/12/facebook/insights/23");
+        let mut state = PathState::from_borrowed_path("/users/12/facebook/insights/23");
         assert!(!filter.detect(&mut state));
-        let mut state = PathState::new("/users/12/");
+        let mut state = PathState::from_borrowed_path("/users/12/");
         assert!(filter.detect(&mut state));
-        let mut state = PathState::new("/users/12");
+        let mut state = PathState::from_borrowed_path("/users/12");
         assert!(filter.detect(&mut state));
-        let mut state = PathState::new("/users/12/abc");
+        let mut state = PathState::from_borrowed_path("/users/12/abc");
         assert!(filter.detect(&mut state));
         assert_eq!(
             state.matched_parts,
@@ -1537,7 +1539,7 @@ mod tests {
         let filter = std::panic::catch_unwind(|| PathFilter::new(pattern.as_ref()))
             .expect("PathFilter::new should not panic on malformed patterns");
 
-        let mut state = PathState::new("/users/29/emails");
+        let mut state = PathState::from_borrowed_path("/users/29/emails");
         assert!(!filter.detect(&mut state));
     }
 }

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -41,7 +41,7 @@ pub trait PathWisp: Send + Sync + fmt::Debug + 'static {
         Ok(())
     }
     /// Return whether the path matches.
-    fn detect(&self, state: &mut PathState<'_>) -> bool;
+    fn detect(&self, state: &mut PathState) -> bool;
 }
 /// Builds a [`PathWisp`] from a parsed pattern fragment.
 ///
@@ -110,7 +110,7 @@ impl PathWisp for WispKind {
         }
     }
     #[inline]
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         match self {
             Self::Const(wisp) => wisp.detect(state),
             Self::Named(wisp) => wisp.detect(state),
@@ -286,7 +286,7 @@ impl Debug for CharsWisp {
     }
 }
 impl PathWisp for CharsWisp {
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -429,7 +429,7 @@ impl CombWisp {
 }
 impl PathWisp for CombWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         let Some(picked) = state.pick().map(|s| s.to_owned()) else {
             return false;
         };
@@ -531,7 +531,7 @@ impl PathWisp for CombWisp {
 pub struct NamedWisp(pub String);
 impl PathWisp for NamedWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         if self.0.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.0.starts_with("*?")
@@ -603,7 +603,7 @@ impl PartialEq for RegexWisp {
 }
 impl PathWisp for RegexWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         if self.name.starts_with('*') {
             let rest = state.all_rest().unwrap_or_default();
             if self.name.starts_with("*?")
@@ -654,7 +654,7 @@ impl PathWisp for RegexWisp {
 pub struct ConstWisp(pub String);
 impl PathWisp for ConstWisp {
     #[inline]
-    fn detect(&self, state: &mut PathState<'_>) -> bool {
+    fn detect(&self, state: &mut PathState) -> bool {
         let Some(picked) = state.pick() else {
             return false;
         };
@@ -1043,7 +1043,7 @@ impl Debug for PathFilter {
 #[async_trait]
 impl Filter for PathFilter {
     #[inline]
-    async fn filter(&self, _req: &mut Request, state: &mut PathState<'_>) -> bool {
+    async fn filter(&self, _req: &mut Request, state: &mut PathState) -> bool {
         self.detect(state)
     }
     #[inline]
@@ -1128,7 +1128,7 @@ impl PathFilter {
         builders.insert(name.into(), Arc::new(RegexWispBuilder::new(regex)));
     }
     /// Detect is that path is match.
-    pub fn detect(&self, state: &mut PathState<'_>) -> bool {
+    pub fn detect(&self, state: &mut PathState) -> bool {
         let original_cursor = state.cursor;
         for ps in &self.path_wisps {
             let row = state.cursor.0;

--- a/crates/core/src/routing/filters/path.rs
+++ b/crates/core/src/routing/filters/path.rs
@@ -545,7 +545,7 @@ impl PathWisp for NamedWisp {
             if !rest.is_empty() || !self.0.starts_with("*+") {
                 let rest = rest.into_owned();
                 state.params.insert_tracked(&self.0, rest);
-                state.cursor.0 = state.parts.len();
+                state.cursor.0 = state.parts_len();
                 #[cfg(feature = "matched-path")]
                 push_named_part(&mut state.matched_parts, &self.0);
                 true
@@ -1133,7 +1133,7 @@ impl PathFilter {
         for ps in &self.path_wisps {
             let row = state.cursor.0;
             if ps.detect(state) {
-                if row == state.cursor.0 && row != state.parts.len() {
+                if row == state.cursor.0 && row != state.parts_len() {
                     state.cursor = original_cursor;
                     return false;
                 }

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::marker::PhantomData;
 use std::ops::Range;
 
 use super::{PathParams, decode_url_path};
@@ -26,7 +25,7 @@ impl PathPart {
 
 #[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PathState<'a> {
+pub struct PathState {
     path: String,
     pub(crate) parts: Vec<PathPart>,
     /// (row, col), row is the index of parts, col is the index of char in the part.
@@ -37,9 +36,8 @@ pub struct PathState<'a> {
     pub(crate) end_slash: bool, // For rest match, we want include the last slash.
     pub(crate) once_ended: bool, /* Once it has ended, used to determine whether the error code
                                  * returned is 404 or 405. */
-    marker: PhantomData<&'a ()>,
 }
-impl<'a> PathState<'a> {
+impl PathState {
     /// Creates a new `PathState`.
     #[inline]
     #[must_use]
@@ -62,7 +60,6 @@ impl<'a> PathState<'a> {
             once_ended: false,
             #[cfg(feature = "matched-path")]
             matched_parts: vec![],
-            marker: PhantomData,
         }
     }
 

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -4,8 +4,8 @@ use super::{PathParams, decode_url_path};
 
 #[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PathState {
-    pub(crate) parts: Vec<String>,
+pub struct PathState<'a> {
+    pub(crate) parts: Vec<Cow<'a, str>>,
     /// (row, col), row is the index of parts, col is the index of char in the part.
     pub(crate) cursor: (usize, usize),
     pub(crate) params: PathParams,
@@ -15,11 +15,11 @@ pub struct PathState {
     pub(crate) once_ended: bool, /* Once it has ended, used to determine whether the error code
                                  * returned is 404 or 405. */
 }
-impl PathState {
+impl<'a> PathState<'a> {
     /// Creates a new `PathState`.
     #[inline]
     #[must_use]
-    pub fn new(url_path: &str) -> Self {
+    pub fn new(url_path: &'a str) -> Self {
         let end_slash = url_path.ends_with('/');
         let parts = url_path
             .trim_start_matches('/')

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
+use std::fmt::{self, Debug, Formatter};
 use std::ops::Range;
 
 use super::{PathParams, decode_url_path};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum PathPart {
+enum PathPart {
     Raw(Range<usize>),
     Decoded(String),
 }
@@ -24,10 +25,10 @@ impl PathPart {
 }
 
 #[doc(hidden)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub struct PathState {
     path: String,
-    pub(crate) parts: Vec<PathPart>,
+    parts: Vec<PathPart>,
     /// (row, col), row is the index of parts, col is the index of char in the part.
     pub(crate) cursor: (usize, usize),
     pub(crate) params: PathParams,
@@ -37,6 +38,42 @@ pub struct PathState {
     pub(crate) once_ended: bool, /* Once it has ended, used to determine whether the error code
                                  * returned is 404 or 405. */
 }
+impl Debug for PathState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let parts = self.parts_iter().collect::<Vec<_>>();
+        let mut debug = f.debug_struct("PathState");
+        debug
+            .field("parts", &parts)
+            .field("cursor", &self.cursor)
+            .field("params", &self.params);
+        #[cfg(feature = "matched-path")]
+        debug.field("matched_parts", &self.matched_parts);
+        debug
+            .field("end_slash", &self.end_slash)
+            .field("once_ended", &self.once_ended)
+            .finish()
+    }
+}
+impl PartialEq for PathState {
+    fn eq(&self, other: &Self) -> bool {
+        if !self.parts_iter().eq(other.parts_iter()) {
+            return false;
+        }
+        if self.cursor != other.cursor
+            || self.params != other.params
+            || self.end_slash != other.end_slash
+            || self.once_ended != other.once_ended
+        {
+            return false;
+        }
+        #[cfg(feature = "matched-path")]
+        if self.matched_parts != other.matched_parts {
+            return false;
+        }
+        true
+    }
+}
+impl Eq for PathState {}
 impl PathState {
     /// Creates a new `PathState`.
     #[inline]
@@ -134,9 +171,19 @@ impl PathState {
     }
 
     #[inline]
+    pub(crate) fn parts_len(&self) -> usize {
+        self.parts.len()
+    }
+
+    #[inline]
+    fn parts_iter(&self) -> impl Iterator<Item = &str> + '_ {
+        self.parts.iter().map(|part| part.as_str(&self.path))
+    }
+
+    #[inline]
     #[cfg(test)]
     pub(crate) fn parts(&self) -> impl Iterator<Item = &str> + '_ {
-        self.parts.iter().map(|part| part.as_str(&self.path))
+        self.parts_iter()
     }
 }
 
@@ -208,5 +255,12 @@ mod tests {
 
         state.forward("a/b".len());
         assert_eq!(state.pick(), Some("rest"));
+    }
+
+    #[test]
+    fn equality_uses_decoded_parts_not_internal_storage() {
+        let user = "\u{7528}\u{6237}";
+        assert_eq!(PathState::new(user), PathState::new(&format!("/{user}")));
+        assert_eq!(PathState::new(user), PathState::new("%E7%94%A8%E6%88%B7"));
     }
 }

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -162,3 +162,51 @@ fn parse_path_parts(path: &str) -> Vec<PathPart> {
     }
     parts
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PathState;
+
+    #[test]
+    fn raw_utf8_ranges_stay_on_char_boundaries() {
+        let user = "\u{7528}\u{6237}";
+        let emoji = "\u{1f600}";
+        let e_accent = "\u{e9}";
+        let mut state = PathState::new(&format!("/{user}/{emoji}/{e_accent}/rest/"));
+
+        assert_eq!(
+            state.parts().collect::<Vec<_>>(),
+            vec![user, emoji, e_accent, "rest"]
+        );
+        assert_eq!(state.pick(), Some(user));
+
+        state.forward(user.len());
+        assert_eq!(state.pick(), Some(emoji));
+
+        state.forward(emoji.len());
+        assert_eq!(state.pick(), Some(e_accent));
+        assert_eq!(state.all_rest().as_deref(), Some("\u{e9}/rest/"));
+    }
+
+    #[test]
+    fn decoded_utf8_parts_advance_by_bytes() {
+        let user = "\u{7528}\u{6237}";
+        let emoji = "\u{1f600}";
+        let mut state = PathState::new("/%E7%94%A8%E6%88%B7/%F0%9F%98%80/a%2Fb/rest");
+
+        assert_eq!(
+            state.parts().collect::<Vec<_>>(),
+            vec![user, emoji, "a/b", "rest"]
+        );
+        assert_eq!(state.pick(), Some(user));
+
+        state.forward(user.len());
+        assert_eq!(state.pick(), Some(emoji));
+
+        state.forward(emoji.len());
+        assert_eq!(state.pick(), Some("a/b"));
+
+        state.forward("a/b".len());
+        assert_eq!(state.pick(), Some("rest"));
+    }
+}

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -1,11 +1,34 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
+use std::ops::Range;
 
 use super::{PathParams, decode_url_path};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PathPart {
+    Raw(Range<usize>),
+    Decoded(String),
+}
+impl PathPart {
+    #[inline]
+    fn as_str<'a>(&'a self, source: &'a str) -> &'a str {
+        match self {
+            Self::Raw(range) => &source[range.clone()],
+            Self::Decoded(value) => value,
+        }
+    }
+
+    #[inline]
+    fn len(&self, source: &str) -> usize {
+        self.as_str(source).len()
+    }
+}
 
 #[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PathState<'a> {
-    pub(crate) parts: Vec<Cow<'a, str>>,
+    path: String,
+    pub(crate) parts: Vec<PathPart>,
     /// (row, col), row is the index of parts, col is the index of char in the part.
     pub(crate) cursor: (usize, usize),
     pub(crate) params: PathParams,
@@ -14,26 +37,24 @@ pub struct PathState<'a> {
     pub(crate) end_slash: bool, // For rest match, we want include the last slash.
     pub(crate) once_ended: bool, /* Once it has ended, used to determine whether the error code
                                  * returned is 404 or 405. */
+    marker: PhantomData<&'a ()>,
 }
 impl<'a> PathState<'a> {
     /// Creates a new `PathState`.
     #[inline]
     #[must_use]
-    pub fn new(url_path: &'a str) -> Self {
-        let end_slash = url_path.ends_with('/');
-        let parts = url_path
-            .trim_start_matches('/')
-            .trim_end_matches('/')
-            .split('/')
-            .filter_map(|p| {
-                if !p.is_empty() {
-                    Some(decode_url_path(p))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+    pub fn new(url_path: &str) -> Self {
+        Self::from_path(url_path.to_owned())
+    }
+
+    /// Creates a new `PathState` from an owned path.
+    #[inline]
+    #[must_use]
+    pub fn from_path(path: String) -> Self {
+        let end_slash = path.ends_with('/');
+        let parts = parse_path_parts(&path);
         Self {
+            path,
             parts,
             cursor: (0, 0),
             params: PathParams::new(),
@@ -41,6 +62,7 @@ impl<'a> PathState<'a> {
             once_ended: false,
             #[cfg(feature = "matched-path")]
             matched_parts: vec![],
+            marker: PhantomData,
         }
     }
 
@@ -50,9 +72,10 @@ impl<'a> PathState<'a> {
         match self.parts.get(self.cursor.0) {
             None => None,
             Some(part) => {
+                let part = part.as_str(&self.path);
                 if self.cursor.1 >= part.len() {
                     let row = self.cursor.0 + 1;
-                    self.parts.get(row).map(|s| &**s)
+                    self.parts.get(row).map(|s| s.as_str(&self.path))
                 } else {
                     part.get(self.cursor.1..)
                 }
@@ -73,12 +96,14 @@ impl<'a> PathState<'a> {
             } else {
                 let rest = &self.parts[self.cursor.0 + 1..];
                 let trailing = usize::from(self.end_slash);
-                let cap = picked.len() + rest.iter().map(|s| s.len() + 1).sum::<usize>() + trailing;
+                let cap = picked.len()
+                    + rest.iter().map(|s| s.len(&self.path) + 1).sum::<usize>()
+                    + trailing;
                 let mut buf = String::with_capacity(cap);
                 buf.push_str(picked);
                 for part in rest {
                     buf.push('/');
-                    buf.push_str(part);
+                    buf.push_str(part.as_str(&self.path));
                 }
                 if self.end_slash {
                     buf.push('/');
@@ -94,11 +119,12 @@ impl<'a> PathState<'a> {
     pub fn forward(&mut self, steps: usize) {
         let mut steps = steps + self.cursor.1;
         while let Some(part) = self.parts.get(self.cursor.0) {
-            if part.len() > steps {
+            let len = part.len(&self.path);
+            if len > steps {
                 self.cursor.1 = steps;
                 return;
             } else {
-                steps -= part.len();
+                steps -= len;
                 self.cursor = (self.cursor.0 + 1, 0);
             }
         }
@@ -109,4 +135,33 @@ impl<'a> PathState<'a> {
     pub fn is_ended(&self) -> bool {
         self.cursor.0 >= self.parts.len()
     }
+
+    #[inline]
+    #[cfg(test)]
+    pub(crate) fn parts(&self) -> impl Iterator<Item = &str> + '_ {
+        self.parts.iter().map(|part| part.as_str(&self.path))
+    }
+}
+
+fn parse_path_parts(path: &str) -> Vec<PathPart> {
+    let mut parts = Vec::new();
+    let end = path.trim_end_matches('/').len();
+    let mut cursor = path.len() - path.trim_start_matches('/').len();
+    while cursor < end {
+        while cursor < end && path.as_bytes()[cursor] == b'/' {
+            cursor += 1;
+        }
+        let start = cursor;
+        while cursor < end && path.as_bytes()[cursor] != b'/' {
+            cursor += 1;
+        }
+        if start == cursor {
+            continue;
+        }
+        match decode_url_path(&path[start..cursor]) {
+            Cow::Borrowed(_) => parts.push(PathPart::Raw(start..cursor)),
+            Cow::Owned(decoded) => parts.push(PathPart::Decoded(decoded)),
+        }
+    }
+    parts
 }

--- a/crates/core/src/routing/path_state.rs
+++ b/crates/core/src/routing/path_state.rs
@@ -26,8 +26,8 @@ impl PathPart {
 
 #[doc(hidden)]
 #[derive(Clone)]
-pub struct PathState {
-    path: String,
+pub struct PathState<'a> {
+    path: Cow<'a, str>,
     parts: Vec<PathPart>,
     /// (row, col), row is the index of parts, col is the index of char in the part.
     pub(crate) cursor: (usize, usize),
@@ -38,7 +38,7 @@ pub struct PathState {
     pub(crate) once_ended: bool, /* Once it has ended, used to determine whether the error code
                                  * returned is 404 or 405. */
 }
-impl Debug for PathState {
+impl<'a> Debug for PathState<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let parts = self.parts_iter().collect::<Vec<_>>();
         let mut debug = f.debug_struct("PathState");
@@ -54,8 +54,8 @@ impl Debug for PathState {
             .finish()
     }
 }
-impl PartialEq for PathState {
-    fn eq(&self, other: &Self) -> bool {
+impl<'a, 'b> PartialEq<PathState<'b>> for PathState<'a> {
+    fn eq(&self, other: &PathState<'b>) -> bool {
         if !self.parts_iter().eq(other.parts_iter()) {
             return false;
         }
@@ -73,21 +73,43 @@ impl PartialEq for PathState {
         true
     }
 }
-impl Eq for PathState {}
-impl PathState {
-    /// Creates a new `PathState`.
+impl<'a> Eq for PathState<'a> {}
+impl<'a> PathState<'a> {
+    /// Creates a new owned `PathState` from a borrowed path.
     #[inline]
     #[must_use]
+    #[deprecated(
+        since = "0.93.0",
+        note = "use PathState::from_owned_path or PathState::from_borrowed_path to make ownership explicit"
+    )]
     pub fn new(url_path: &str) -> Self {
-        Self::from_path(url_path.to_owned())
+        Self::from_owned_path(url_path.to_owned())
     }
 
-    /// Creates a new `PathState` from an owned path.
+    /// Creates a new `PathState` by borrowing the supplied path.
+    ///
+    /// Use this only when the borrowed path outlives the routing operation and is
+    /// not borrowed from the same [`Request`](crate::http::Request) that will be
+    /// passed mutably to router detection.
     #[inline]
     #[must_use]
-    pub fn from_path(path: String) -> Self {
+    pub fn from_borrowed_path(path: &'a str) -> Self {
+        Self::from_cow_path(Cow::Borrowed(path))
+    }
+
+    /// Creates a new `PathState` from an owned path without copying it.
+    #[inline]
+    #[must_use]
+    pub fn from_owned_path(path: String) -> Self {
+        Self::from_cow_path(Cow::Owned(path))
+    }
+
+    /// Creates a new `PathState` from a copy-on-write path.
+    #[inline]
+    #[must_use]
+    pub fn from_cow_path(path: Cow<'a, str>) -> Self {
         let end_slash = path.ends_with('/');
-        let parts = parse_path_parts(&path);
+        let parts = parse_path_parts(path.as_ref());
         Self {
             path,
             parts,
@@ -212,14 +234,29 @@ fn parse_path_parts(path: &str) -> Vec<PathPart> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::PathState;
+
+    #[test]
+    fn constructors_make_path_ownership_explicit() {
+        let borrowed = PathState::from_borrowed_path("plain");
+        assert!(matches!(borrowed.path, Cow::Borrowed("plain")));
+
+        let owned = PathState::from_owned_path("plain".to_owned());
+        assert!(matches!(owned.path, Cow::Owned(ref path) if path == "plain"));
+
+        let cow = PathState::from_cow_path(Cow::Borrowed("plain"));
+        assert!(matches!(cow.path, Cow::Borrowed("plain")));
+    }
 
     #[test]
     fn raw_utf8_ranges_stay_on_char_boundaries() {
         let user = "\u{7528}\u{6237}";
         let emoji = "\u{1f600}";
         let e_accent = "\u{e9}";
-        let mut state = PathState::new(&format!("/{user}/{emoji}/{e_accent}/rest/"));
+        let path = format!("/{user}/{emoji}/{e_accent}/rest/");
+        let mut state = PathState::from_borrowed_path(&path);
 
         assert_eq!(
             state.parts().collect::<Vec<_>>(),
@@ -239,7 +276,8 @@ mod tests {
     fn decoded_utf8_parts_advance_by_bytes() {
         let user = "\u{7528}\u{6237}";
         let emoji = "\u{1f600}";
-        let mut state = PathState::new("/%E7%94%A8%E6%88%B7/%F0%9F%98%80/a%2Fb/rest");
+        let mut state =
+            PathState::from_borrowed_path("/%E7%94%A8%E6%88%B7/%F0%9F%98%80/a%2Fb/rest");
 
         assert_eq!(
             state.parts().collect::<Vec<_>>(),
@@ -260,7 +298,13 @@ mod tests {
     #[test]
     fn equality_uses_decoded_parts_not_internal_storage() {
         let user = "\u{7528}\u{6237}";
-        assert_eq!(PathState::new(user), PathState::new(&format!("/{user}")));
-        assert_eq!(PathState::new(user), PathState::new("%E7%94%A8%E6%88%B7"));
+        assert_eq!(
+            PathState::from_borrowed_path(user),
+            PathState::from_owned_path(format!("/{user}"))
+        );
+        assert_eq!(
+            PathState::from_borrowed_path(user),
+            PathState::from_borrowed_path("%E7%94%A8%E6%88%B7")
+        );
     }
 }

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -86,7 +86,7 @@ impl Router {
     pub async fn detect(
         &self,
         req: &mut Request,
-        path_state: &mut PathState,
+        path_state: &mut PathState<'_>,
     ) -> Option<DetectMatched> {
         Box::pin(async move {
             for filter in &self.filters {
@@ -273,7 +273,7 @@ impl Router {
     #[must_use]
     pub fn with_filter_fn<T>(func: T) -> Self
     where
-        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         Self::with_filter(FnFilter(func))
     }
@@ -282,7 +282,7 @@ impl Router {
     #[must_use]
     pub fn filter_fn<T>(self, func: T) -> Self
     where
-        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         self.filter(FnFilter(func))
     }
@@ -563,7 +563,7 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -575,7 +575,7 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -590,12 +590,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_some());
@@ -611,13 +611,13 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -634,12 +634,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["id"], "12");
@@ -657,12 +657,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -680,13 +680,13 @@ mod tests {
         );
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -695,12 +695,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path("users/{sub|(images|css)}/{filename}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -709,12 +709,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"users/{*sub|(images|css)/.+}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/abc/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -723,12 +723,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"avatars/{width|\d+}x{height|\d+}.{ext}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/avatars/321x641f.webp").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/avatars/320x640.webp").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -740,7 +740,7 @@ mod tests {
         let mut req =
             TestClient::get("http://local.host/.well-known/acme-challenge/q1XXrxIx79uXNl3I")
                 .build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -752,12 +752,12 @@ mod tests {
             .get(fake_handler);
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e38641e").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e386e").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
     }
@@ -776,14 +776,14 @@ mod tests {
 
         // A HEAD request does not match the GET method filter of the first route.
         let mut req = TestClient::head("http://local.host/b33f/subpath.txt").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         // Must not panic, and should fall through with no matched goal.
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         // A GET request still matches the first route as before.
         let mut req = TestClient::get("http://local.host/b33f/subpath.txt").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["foo"], "b33f");
@@ -794,7 +794,7 @@ mod tests {
     async fn test_router_detect_path_encoded() {
         let router = Router::new().path("api/{p}").get(fake_handler);
         let mut req = TestClient::get("http://127.0.0.1:6060/api/a%2fb%2fc").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["p"], "a/b/c");
@@ -817,7 +817,7 @@ mod tests {
         );
 
         let mut req = TestClient::get("http://local.host/users/alice").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // The winning branch's param is present...
@@ -840,7 +840,7 @@ mod tests {
             .push(Router::with_path("edit").get(fake_handler));
 
         let mut req = TestClient::get("http://local.host/alice/edit").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // Must be the ancestor's value, not the overwritten-then-rolled-back "edit".

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -563,8 +563,7 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -576,8 +575,7 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -592,14 +590,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_some());
@@ -615,15 +611,13 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -640,14 +634,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["id"], "12");
@@ -665,14 +657,12 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -690,15 +680,13 @@ mod tests {
         );
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights/23").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -707,14 +695,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path("users/{sub|(images|css)}/{filename}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/m.jpg").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -723,14 +709,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"users/{*sub|(images|css)/.+}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/abc/m.jpg").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -739,14 +723,12 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"avatars/{width|\d+}x{height|\d+}.{ext}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/avatars/321x641f.webp").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/avatars/320x640.webp").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -758,8 +740,7 @@ mod tests {
         let mut req =
             TestClient::get("http://local.host/.well-known/acme-challenge/q1XXrxIx79uXNl3I")
                 .build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -771,14 +752,12 @@ mod tests {
             .get(fake_handler);
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e38641e").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e386e").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
     }
@@ -797,16 +776,14 @@ mod tests {
 
         // A HEAD request does not match the GET method filter of the first route.
         let mut req = TestClient::head("http://local.host/b33f/subpath.txt").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         // Must not panic, and should fall through with no matched goal.
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         // A GET request still matches the first route as before.
         let mut req = TestClient::get("http://local.host/b33f/subpath.txt").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["foo"], "b33f");
@@ -817,8 +794,7 @@ mod tests {
     async fn test_router_detect_path_encoded() {
         let router = Router::new().path("api/{p}").get(fake_handler);
         let mut req = TestClient::get("http://127.0.0.1:6060/api/a%2fb%2fc").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["p"], "a/b/c");
@@ -841,8 +817,7 @@ mod tests {
         );
 
         let mut req = TestClient::get("http://local.host/users/alice").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // The winning branch's param is present...
@@ -865,8 +840,7 @@ mod tests {
             .push(Router::with_path("edit").get(fake_handler));
 
         let mut req = TestClient::get("http://local.host/alice/edit").build();
-        let path = req.uri().path().to_owned();
-        let mut path_state = PathState::new(&path);
+        let mut path_state = PathState::new(req.uri().path());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // Must be the ancestor's value, not the overwritten-then-rolled-back "edit".

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -86,7 +86,7 @@ impl Router {
     pub async fn detect(
         &self,
         req: &mut Request,
-        path_state: &mut PathState,
+        path_state: &mut PathState<'_>,
     ) -> Option<DetectMatched> {
         Box::pin(async move {
             for filter in &self.filters {
@@ -273,7 +273,7 @@ impl Router {
     #[must_use]
     pub fn with_filter_fn<T>(func: T) -> Self
     where
-        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         Self::with_filter(FnFilter(func))
     }
@@ -282,7 +282,7 @@ impl Router {
     #[must_use]
     pub fn filter_fn<T>(self, func: T) -> Self
     where
-        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
+        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
     {
         self.filter(FnFilter(func))
     }
@@ -563,7 +563,8 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -575,7 +576,8 @@ mod tests {
                 Router::with_path("{id}").push(Router::with_path("emails").get(fake_handler)),
             ));
         let mut req = TestClient::get("http://local.host/users/12/emails").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -590,12 +592,14 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_some());
@@ -611,13 +615,15 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         // assert_eq!(format!("{:?}", path_state), "");
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -634,12 +640,14 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["id"], "12");
@@ -657,12 +665,14 @@ mod tests {
             ),
         );
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -680,13 +690,15 @@ mod tests {
         );
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req =
             TestClient::get("http://local.host/%E7%94%A8%E6%88%B7/12/facebook/insights/23").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -695,12 +707,14 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path("users/{sub|(images|css)}/{filename}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -709,12 +723,14 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"users/{*sub|(images|css)/.+}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/users/12/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/users/css/abc/m.jpg").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -723,12 +739,14 @@ mod tests {
         let router = Router::new()
             .push(Router::with_path(r"avatars/{width|\d+}x{height|\d+}.{ext}").goal(fake_handler));
         let mut req = TestClient::get("http://local.host/avatars/321x641f.webp").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         let mut req = TestClient::get("http://local.host/avatars/320x640.webp").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -740,7 +758,8 @@ mod tests {
         let mut req =
             TestClient::get("http://local.host/.well-known/acme-challenge/q1XXrxIx79uXNl3I")
                 .build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
     }
@@ -752,12 +771,14 @@ mod tests {
             .get(fake_handler);
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e38641e").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         let mut req =
             TestClient::get("http://local.host/user/726d694c-7af0-4bb0-9d22-706f7e386e").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
     }
@@ -776,14 +797,16 @@ mod tests {
 
         // A HEAD request does not match the GET method filter of the first route.
         let mut req = TestClient::head("http://local.host/b33f/subpath.txt").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         // Must not panic, and should fall through with no matched goal.
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_none());
 
         // A GET request still matches the first route as before.
         let mut req = TestClient::get("http://local.host/b33f/subpath.txt").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["foo"], "b33f");
@@ -794,7 +817,8 @@ mod tests {
     async fn test_router_detect_path_encoded() {
         let router = Router::new().path("api/{p}").get(fake_handler);
         let mut req = TestClient::get("http://127.0.0.1:6060/api/a%2fb%2fc").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert_eq!(path_state.params["p"], "a/b/c");
@@ -817,7 +841,8 @@ mod tests {
         );
 
         let mut req = TestClient::get("http://local.host/users/alice").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // The winning branch's param is present...
@@ -840,7 +865,8 @@ mod tests {
             .push(Router::with_path("edit").get(fake_handler));
 
         let mut req = TestClient::get("http://local.host/alice/edit").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let path = req.uri().path().to_owned();
+        let mut path_state = PathState::new(&path);
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         // Must be the ancestor's value, not the overwritten-then-rolled-back "edit".

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -86,7 +86,7 @@ impl Router {
     pub async fn detect(
         &self,
         req: &mut Request,
-        path_state: &mut PathState<'_>,
+        path_state: &mut PathState,
     ) -> Option<DetectMatched> {
         Box::pin(async move {
             for filter in &self.filters {
@@ -273,7 +273,7 @@ impl Router {
     #[must_use]
     pub fn with_filter_fn<T>(func: T) -> Self
     where
-        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
     {
         Self::with_filter(FnFilter(func))
     }
@@ -282,7 +282,7 @@ impl Router {
     #[must_use]
     pub fn filter_fn<T>(self, func: T) -> Self
     where
-        T: for<'a> Fn(&mut Request, &mut PathState<'a>) -> bool + Send + Sync + 'static,
+        T: Fn(&mut Request, &mut PathState) -> bool + Send + Sync + 'static,
     {
         self.filter(FnFilter(func))
     }

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -267,7 +267,7 @@ impl HyperHandler {
 
         async move {
             let path = req.uri().path().to_owned();
-            let mut path_state = PathState::from_path(path);
+            let mut path_state = PathState::from_owned_path(path);
             if let Some(dm) = state.router.detect(&mut req, &mut path_state).await {
                 path_state.params.seal();
                 req.params = path_state.params;

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -264,9 +264,10 @@ impl HyperHandler {
             res.headers_mut().insert(ALT_SVC, alt_svc_h3.clone());
         }
         let mut depot = Depot::new();
-        let mut path_state = PathState::new(req.uri().path());
 
         async move {
+            let path = req.uri().path().to_owned();
+            let mut path_state = PathState::new(&path);
             if let Some(dm) = state.router.detect(&mut req, &mut path_state).await {
                 path_state.params.seal();
                 req.params = path_state.params;

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -267,7 +267,7 @@ impl HyperHandler {
 
         async move {
             let path = req.uri().path().to_owned();
-            let mut path_state = PathState::new(&path);
+            let mut path_state = PathState::from_path(path);
             if let Some(dm) = state.router.detect(&mut req, &mut path_state).await {
                 path_state.params.seal();
                 req.params = path_state.params;

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -444,10 +444,12 @@ impl Handler for StaticDir {
         _ctrl: &mut FlowCtrl,
     ) {
         let req_path = req.uri().path();
+        let decoded_path;
         let rel_path = if let Some(rest) = req.params().tail() {
             rest
         } else {
-            &*decode_url_path(req_path)
+            decoded_path = decode_url_path(req_path);
+            decoded_path.as_ref()
         };
         let rel_path = normalize_url_path(rel_path);
         let mut files: HashMap<String, Metadata> = HashMap::new();
@@ -638,7 +640,7 @@ impl Handler for StaticDir {
                 .map(|(name, metadata)| DirInfo::new(name, &metadata))
                 .collect();
             dirs.sort_by(|a, b| a.name.cmp(&b.name));
-            let root = CurrentInfo::new(decode_url_path(req_path), files, dirs);
+            let root = CurrentInfo::new(decode_url_path(req_path).into_owned(), files, dirs);
             res.status_code(StatusCode::OK);
             match format.subtype().as_ref() {
                 "plain" => res.render(Text::Plain(list_text(&root))),

--- a/crates/serve-static/src/embed.rs
+++ b/crates/serve-static/src/embed.rs
@@ -283,10 +283,12 @@ where
         res: &mut Response,
         _ctrl: &mut FlowCtrl,
     ) {
+        let decoded_path;
         let req_path = if let Some(rest) = req.params().tail() {
             rest
         } else {
-            &*decode_url_path(req.uri().path())
+            decoded_path = decode_url_path(req.uri().path());
+            decoded_path.as_ref()
         };
         let req_path = normalize_url_path(req_path);
         let mut key_path = Cow::Borrowed(&*req_path);


### PR DESCRIPTION
## Summary
- return `Cow<'_, str>` from `decode_url_path`, borrowing plain path segments when no percent encoding is present
- store `PathState` as `Cow<'_, str>` plus raw segment ranges, so callers can choose borrowed or owned path storage explicitly
- deprecate ambiguous `PathState::new` in favor of `from_borrowed_path`, `from_owned_path`, and `from_cow_path`
- keep service dispatch sound by moving an owned request path into `PathState`, while direct/benchmark routing paths can use borrowed storage
- add coverage for borrowed/plain paths, owned/decoded paths, and UTF-8 byte-boundary handling

## Notes
- request dispatch still copies the request path because `Router::detect` receives `&mut Request`; borrowing from the same request would conflict with the mutable borrow
- callers that already have a stable path string can now avoid that copy with `PathState::from_borrowed_path`

## Tests
- `cargo test -p salvo_core -p salvo-serve-static --quiet`
- `cargo check -p salvo_core --features matched-path --quiet`
- `cargo bench -p salvo_core --bench router_detect --no-run --quiet`