### PR TITLE
perf(proxy): move reqwest response headers

### DIFF
--- a/crates/proxy/src/reqwest_client.rs
+++ b/crates/proxy/src/reqwest_client.rs
@@ -72,23 +72,31 @@ impl Client for ReqwestClient {
                 body.try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok()))),
             )
         });
-        let response = self
+        let mut response = self
             .inner
             .execute(proxied_request.try_into().map_err(Error::other)?)
             .await
             .map_err(Error::other)?;
 
-        let res_headers = response.headers().clone();
+        let status = response.status();
+        let version = response.version();
+        let response_upgrade_type = if status == StatusCode::SWITCHING_PROTOCOLS {
+            crate::get_upgrade_type(response.headers()).map(str::to_owned)
+        } else {
+            None
+        };
+        let res_headers = std::mem::take(response.headers_mut());
         let hyper_response = hyper::Response::builder()
-            .status(response.status())
-            .version(response.version());
+            .status(status)
+            .version(version);
 
-        let mut hyper_response = if response.status() == StatusCode::SWITCHING_PROTOCOLS {
-            let response_upgrade_type = crate::get_upgrade_type(response.headers());
-
+        let mut hyper_response = if status == StatusCode::SWITCHING_PROTOCOLS {
             // RFC 7230 §6.7 makes Upgrade tokens case-insensitive (`websocket`,
             // `WebSocket`, ... are all the same protocol). Compare without allocating.
-            if crate::upgrade_types_match(request_upgrade_type.as_deref(), response_upgrade_type) {
+            if crate::upgrade_types_match(
+                request_upgrade_type.as_deref(),
+                response_upgrade_type.as_deref(),
+            ) {
                 let mut response_upgraded = response.upgrade().await.map_err(|e| {
                     Error::other(format!("response does not have an upgrade extension. {e}"))
                 })?;


### PR DESCRIPTION
## Summary
- avoid cloning the full reqwest response `HeaderMap`
- capture status/version and upgrade token before moving headers out with `std::mem::take(response.headers_mut())`
- preserve the existing 101 Upgrade validation and streaming response behavior

## Tests
- `cargo test -p salvo-proxy --features reqwest-client --no-run`
- `cargo test -p salvo-proxy --features reqwest-client test_others`