### PR TITLE
perf: chunk json response rendering

### DIFF
--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -65,12 +65,10 @@
 //!
 //! Read more: <https://salvo.rs>
 
-use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use bytes::Bytes;
 use indexmap::IndexMap;
 use salvo_core::http::body::ResBody;
 use salvo_core::http::header::{
@@ -482,20 +480,15 @@ impl Handler for Compression {
                 }
             }
             ResBody::Chunks(chunks) => {
-                let len: usize = chunks.iter().map(|c| c.len()).sum();
-                if self.min_length > 0 && len < self.min_length {
-                    res.body(ResBody::Chunks(chunks));
-                    return;
+                if self.min_length > 0 {
+                    let len: usize = chunks.iter().map(|c| c.len()).sum();
+                    if len < self.min_length {
+                        res.body(ResBody::Chunks(chunks));
+                        return;
+                    }
                 }
                 if let Some((algo, level)) = self.negotiate(req, res) {
-                    // These chunks are already fully buffered in memory; flatten them
-                    // before compression so the encoder runs once for the response
-                    // instead of offloading one blocking task per chunk.
-                    res.stream(EncodeStream::new(
-                        algo,
-                        level,
-                        Some(flatten_chunks(chunks, len)),
-                    ));
+                    res.stream(EncodeStream::new(algo, level, chunks));
                     res.headers_mut().insert(CONTENT_ENCODING, algo.into());
                 } else {
                     res.body(ResBody::Chunks(chunks));
@@ -532,25 +525,8 @@ impl Handler for Compression {
     }
 }
 
-fn flatten_chunks(mut chunks: VecDeque<Bytes>, len: usize) -> Bytes {
-    match chunks.len() {
-        0 => Bytes::new(),
-        1 => chunks.pop_front().expect("chunk count checked"),
-        _ => {
-            let mut body = Vec::with_capacity(len);
-            for chunk in chunks {
-                body.extend_from_slice(&chunk);
-            }
-            Bytes::from(body)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-
-    use bytes::Bytes;
     use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
@@ -639,19 +615,6 @@ mod tests {
             .send(router)
             .await;
         assert!(res.headers().get(CONTENT_ENCODING).is_some());
-    }
-
-    #[test]
-    fn test_flatten_chunks_preserves_body() {
-        let chunks = VecDeque::from([
-            Bytes::from_static(b"hello "),
-            Bytes::from_static(b"chunked "),
-            Bytes::from_static(b"body"),
-        ]);
-
-        let body = flatten_chunks(chunks, "hello chunked body".len());
-
-        assert_eq!(body, Bytes::from_static(b"hello chunked body"));
     }
 
     #[handler]

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -65,10 +65,12 @@
 //!
 //! Read more: <https://salvo.rs>
 
+use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use bytes::Bytes;
 use indexmap::IndexMap;
 use salvo_core::http::body::ResBody;
 use salvo_core::http::header::{
@@ -480,15 +482,20 @@ impl Handler for Compression {
                 }
             }
             ResBody::Chunks(chunks) => {
-                if self.min_length > 0 {
-                    let len: usize = chunks.iter().map(|c| c.len()).sum();
-                    if len < self.min_length {
-                        res.body(ResBody::Chunks(chunks));
-                        return;
-                    }
+                let len: usize = chunks.iter().map(|c| c.len()).sum();
+                if self.min_length > 0 && len < self.min_length {
+                    res.body(ResBody::Chunks(chunks));
+                    return;
                 }
                 if let Some((algo, level)) = self.negotiate(req, res) {
-                    res.stream(EncodeStream::new(algo, level, chunks));
+                    // These chunks are already fully buffered in memory; flatten them
+                    // before compression so the encoder runs once for the response
+                    // instead of offloading one blocking task per chunk.
+                    res.stream(EncodeStream::new(
+                        algo,
+                        level,
+                        Some(flatten_chunks(chunks, len)),
+                    ));
                     res.headers_mut().insert(CONTENT_ENCODING, algo.into());
                 } else {
                     res.body(ResBody::Chunks(chunks));
@@ -525,8 +532,25 @@ impl Handler for Compression {
     }
 }
 
+fn flatten_chunks(mut chunks: VecDeque<Bytes>, len: usize) -> Bytes {
+    match chunks.len() {
+        0 => Bytes::new(),
+        1 => chunks.pop_front().expect("chunk count checked"),
+        _ => {
+            let mut body = Vec::with_capacity(len);
+            for chunk in chunks {
+                body.extend_from_slice(&chunk);
+            }
+            Bytes::from(body)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
+    use bytes::Bytes;
     use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
@@ -615,6 +639,19 @@ mod tests {
             .send(router)
             .await;
         assert!(res.headers().get(CONTENT_ENCODING).is_some());
+    }
+
+    #[test]
+    fn test_flatten_chunks_preserves_body() {
+        let chunks = VecDeque::from([
+            Bytes::from_static(b"hello "),
+            Bytes::from_static(b"chunked "),
+            Bytes::from_static(b"body"),
+        ]);
+
+        let body = flatten_chunks(chunks, "hello chunked body".len());
+
+        assert_eq!(body, Bytes::from_static(b"hello chunked body"));
     }
 
     #[handler]

--- a/crates/compression/src/stream.rs
+++ b/crates/compression/src/stream.rs
@@ -12,7 +12,10 @@ use tokio::task::{JoinHandle, spawn_blocking};
 
 use super::{CompressionAlgo, CompressionLevel, Encoder};
 
-const MAX_CHUNK_SIZE_ENCODE_IN_PLACE: usize = 1024;
+// Keep moderately sized buffered chunks on the async task. The previous 1 KiB
+// cutoff made 8 KiB JSON chunks spawn one blocking task each when compression
+// was enabled.
+const MAX_CHUNK_SIZE_ENCODE_IN_PLACE: usize = 16 * 1024;
 
 pub(super) struct EncodeStream<B> {
     encoder: Option<Encoder>,
@@ -151,6 +154,11 @@ mod tests {
     use futures_util::stream::StreamExt;
 
     use super::*;
+
+    #[test]
+    fn encode_in_place_threshold_covers_json_chunks() {
+        assert!(MAX_CHUNK_SIZE_ENCODE_IN_PLACE >= 8 * 1024);
+    }
 
     #[tokio::test]
     async fn test_encode_stream_once() {

--- a/crates/compression/src/stream.rs
+++ b/crates/compression/src/stream.rs
@@ -12,9 +12,8 @@ use tokio::task::{JoinHandle, spawn_blocking};
 
 use super::{CompressionAlgo, CompressionLevel, Encoder};
 
-// Keep moderately sized buffered chunks on the async task. The previous 1 KiB
-// cutoff made 8 KiB JSON chunks spawn one blocking task each when compression
-// was enabled.
+// Keep 8 KiB JSON chunks and similarly sized buffered chunks on the async task
+// when compression is enabled.
 const MAX_CHUNK_SIZE_ENCODE_IN_PLACE: usize = 16 * 1024;
 
 pub(super) struct EncodeStream<B> {

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -22,12 +22,13 @@ impl JsonBodyWriter {
     fn new() -> Self {
         Self {
             chunks: VecDeque::new(),
-            current: Vec::with_capacity(JSON_CHUNK_SIZE),
+            current: Vec::new(),
         }
     }
 
     fn finish(mut self) -> ResBody {
         if !self.current.is_empty() {
+            self.current.shrink_to_fit();
             self.chunks.push_back(Bytes::from(self.current));
         }
         match self.chunks.len() {
@@ -38,7 +39,7 @@ impl JsonBodyWriter {
     }
 
     fn push_current(&mut self) {
-        let chunk = std::mem::replace(&mut self.current, Vec::with_capacity(JSON_CHUNK_SIZE));
+        let chunk = std::mem::take(&mut self.current);
         if !chunk.is_empty() {
             self.chunks.push_back(Bytes::from(chunk));
         }
@@ -55,6 +56,10 @@ impl Write for JsonBodyWriter {
                 continue;
             }
             let next = available.min(buf.len());
+            let target_capacity = (self.current.len() + next).min(JSON_CHUNK_SIZE);
+            if self.current.capacity() < target_capacity {
+                self.current.reserve(target_capacity - self.current.len());
+            }
             self.current.extend_from_slice(&buf[..next]);
             buf = &buf[next..];
             if self.current.len() == JSON_CHUNK_SIZE {
@@ -194,9 +199,20 @@ impl<T: Display> Display for Json<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write as _;
+
     use super::*;
     use crate::prelude::*;
     use crate::test::{ResponseExt, TestClient};
+
+    #[test]
+    fn json_body_writer_does_not_preallocate_full_chunk_for_tiny_body() {
+        let mut writer = JsonBodyWriter::new();
+
+        writer.write_all(br#"{"ok":true}"#).unwrap();
+
+        assert!(writer.current.capacity() < JSON_CHUNK_SIZE);
+    }
 
     #[tokio::test]
     async fn test_write_json_content() {

--- a/crates/core/src/writing/json.rs
+++ b/crates/core/src/writing/json.rs
@@ -1,4 +1,6 @@
+use std::collections::VecDeque;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::io::{self, Write};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -8,6 +10,64 @@ use super::{Scribe, try_set_header};
 use crate::http::body::ResBody;
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
 use crate::http::{Response, StatusError};
+
+const JSON_CHUNK_SIZE: usize = 8 * 1024;
+
+struct JsonBodyWriter {
+    chunks: VecDeque<Bytes>,
+    current: Vec<u8>,
+}
+
+impl JsonBodyWriter {
+    fn new() -> Self {
+        Self {
+            chunks: VecDeque::new(),
+            current: Vec::with_capacity(JSON_CHUNK_SIZE),
+        }
+    }
+
+    fn finish(mut self) -> ResBody {
+        if !self.current.is_empty() {
+            self.chunks.push_back(Bytes::from(self.current));
+        }
+        match self.chunks.len() {
+            0 => ResBody::Once(Bytes::new()),
+            1 => ResBody::Once(self.chunks.pop_front().expect("chunk count checked")),
+            _ => ResBody::Chunks(self.chunks),
+        }
+    }
+
+    fn push_current(&mut self) {
+        let chunk = std::mem::replace(&mut self.current, Vec::with_capacity(JSON_CHUNK_SIZE));
+        if !chunk.is_empty() {
+            self.chunks.push_back(Bytes::from(chunk));
+        }
+    }
+}
+
+impl Write for JsonBodyWriter {
+    fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
+        let len = buf.len();
+        while !buf.is_empty() {
+            let available = JSON_CHUNK_SIZE - self.current.len();
+            if available == 0 {
+                self.push_current();
+                continue;
+            }
+            let next = available.min(buf.len());
+            self.current.extend_from_slice(&buf[..next]);
+            buf = &buf[next..];
+            if self.current.len() == JSON_CHUNK_SIZE {
+                self.push_current();
+            }
+        }
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 /// Writes serializable content to the response as JSON.
 ///
@@ -73,8 +133,9 @@ where
     T: Serialize + Send,
 {
     fn render(self, res: &mut Response) {
-        match serde_json::to_vec(&self.0) {
-            Ok(bytes) => {
+        let mut writer = JsonBodyWriter::new();
+        match serde_json::to_writer(&mut writer, &self.0) {
+            Ok(()) => {
                 try_set_header(
                     &mut res.headers,
                     CONTENT_TYPE,
@@ -102,7 +163,7 @@ where
                                 );
                             }
                         }
-                        res.body(ResBody::Once(Bytes::from(bytes)));
+                        res.body(writer.finish());
                     }
                     _ => {
                         // Streaming kinds cannot be replaced silently; mirror the
@@ -181,6 +242,27 @@ mod tests {
         // The body must be valid JSON — the old append behavior produced two
         // concatenated documents here.
         serde_json::from_str::<serde_json::Value>(&body).expect("body must be valid JSON");
+    }
+
+    #[test]
+    fn test_json_render_chunks_large_body() {
+        let mut res = Response::new();
+        let payload = vec!["x".repeat(JSON_CHUNK_SIZE); 2];
+
+        Json(payload).render(&mut res);
+
+        let ResBody::Chunks(chunks) = &res.body else {
+            panic!("large JSON should be rendered as chunks");
+        };
+        assert!(chunks.len() > 1);
+        assert!(res.body.size().unwrap() > JSON_CHUNK_SIZE as u64);
+        let body = chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter().copied())
+            .collect::<Vec<_>>();
+        let decoded =
+            serde_json::from_slice::<Vec<String>>(&body).expect("body must be valid JSON");
+        assert_eq!(decoded.len(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- replace `serde_json::to_vec` with `serde_json::to_writer` into a small chunking writer
- render large JSON bodies as `ResBody::Chunks` instead of one contiguous `Bytes` allocation
- keep existing replacement semantics for buffered bodies and the existing refusal to replace streaming bodies

## Notes
- this keeps the current synchronous `Scribe::render` contract; it avoids a single contiguous JSON buffer, but does not turn JSON rendering into an async streaming producer

## Tests
- `cargo test -p salvo_core writing::json`