### PR TITLE
feat(oapi): add endpoint attribute aliases

### DIFF
--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -169,7 +169,7 @@ impl Router {
         }
     }
 
-    async fn filters_match(&self, req: &mut Request, path_state: &mut PathState) -> bool {
+    async fn filters_match(&self, req: &mut Request, path_state: &mut PathState<'_>) -> bool {
         for filter in &self.filters {
             if !filter.filter(req, path_state).await {
                 return false;

--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -25,7 +25,7 @@ pub(crate) struct EndpointAttr<'p> {
 
 impl Parse for EndpointAttr<'_> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        const EXPECTED_ATTRIBUTE_MESSAGE: &str = "unexpected identifier, expected any of: operation_id, request_body, responses, status_codes, parameters, tags, security, description, summary";
+        const EXPECTED_ATTRIBUTE_MESSAGE: &str = "unexpected identifier, expected any of: operation_id, request_body, response, responses, status_code, status_codes, parameter, parameters, tag, tags, security, description, summary";
         let mut attr = EndpointAttr::default();
 
         while !input.is_empty() {
@@ -50,12 +50,30 @@ impl Parse for EndpointAttr<'_> {
                         Punctuated::<Response, Token![,]>::parse_terminated(&responses)
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Response>>())?;
                 }
+                "response" => {
+                    attr.responses.push(input.parse::<Response>()?);
+                }
                 "status_codes" => {
                     let status_codes;
                     parenthesized!(status_codes in input);
                     attr.status_codes =
                         Punctuated::<Expr, Token![,]>::parse_terminated(&status_codes)
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Expr>>())?;
+                }
+                "status_code" => {
+                    if input.peek(Token![=]) {
+                        attr.status_codes
+                            .push(parse_utils::parse_next(input, || Expr::parse(input))?);
+                    } else {
+                        let status_code;
+                        parenthesized!(status_code in input);
+                        attr.status_codes.push(status_code.parse::<Expr>()?);
+                        if !status_code.is_empty() {
+                            return Err(status_code.error(
+                                "`status_code(...)` accepts one status code; use `status_codes(...)` for a list",
+                            ));
+                        }
+                    }
                 }
                 "parameters" => {
                     let parameters;
@@ -64,12 +82,27 @@ impl Parse for EndpointAttr<'_> {
                         Punctuated::<Parameter, Token![,]>::parse_terminated(&parameters)
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Parameter>>())?;
                 }
+                "parameter" => {
+                    attr.parameters.push(input.parse::<Parameter>()?);
+                }
                 "tags" => {
                     let tags;
                     parenthesized!(tags in input);
                     let parsed: Punctuated<Expr, Token![,]> =
                         Punctuated::<Expr, Token![,]>::parse_terminated(&tags)?;
                     attr.tags = Some(parsed.into_iter().collect());
+                }
+                "tag" => {
+                    let tag;
+                    parenthesized!(tag in input);
+                    attr.tags
+                        .get_or_insert_with(Vec::new)
+                        .push(tag.parse::<Expr>()?);
+                    if !tag.is_empty() {
+                        return Err(
+                            tag.error("`tag(...)` accepts one tag; use `tags(...)` for a list")
+                        );
+                    }
                 }
                 "security" => {
                     let security;
@@ -122,8 +155,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_response_alias() {
+        let input = "response(status_code = 200)";
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.responses.len(), 1);
+    }
+
+    #[test]
     fn test_parse_status_codes() {
         let input = "status_codes(200, 404)";
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.status_codes.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_status_code_alias() {
+        let input = "status_code(200), status_code = 404";
         let attr = parse_str::<EndpointAttr>(input).unwrap();
         assert_eq!(attr.status_codes.len(), 2);
     }
@@ -137,8 +184,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_parameter_alias() {
+        let input = r#"parameter("id" = String, Path, description = "Pet id")"#;
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.parameters.len(), 1);
+    }
+
+    #[test]
     fn test_parse_tags() {
         let input = "tags(\"pet\", \"store\")";
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.tags.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_tag_alias() {
+        let input = r#"tag("pet"), tag("store")"#;
         let attr = parse_str::<EndpointAttr>(input).unwrap();
         assert_eq!(attr.tags.unwrap().len(), 2);
     }

--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -1,9 +1,11 @@
 use proc_macro2::Ident;
-use syn::parse::Parse;
+use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{Expr, parenthesized};
+use syn::{Expr, ExprPath, parenthesized};
 
 use crate::operation::request_body::RequestBodyAttr;
+use crate::parameter::StructParameter;
+use crate::response::ResponseTuple;
 use crate::security_requirement::SecurityRequirementsAttr;
 use crate::{Array, Parameter, Response, Token, parse_utils};
 
@@ -51,7 +53,7 @@ impl Parse for EndpointAttr<'_> {
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Response>>())?;
                 }
                 "response" => {
-                    attr.responses.push(input.parse::<Response>()?);
+                    attr.responses.push(parse_response_alias(input)?);
                 }
                 "status_codes" => {
                     let status_codes;
@@ -83,7 +85,7 @@ impl Parse for EndpointAttr<'_> {
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Parameter>>())?;
                 }
                 "parameter" => {
-                    attr.parameters.push(input.parse::<Parameter>()?);
+                    attr.parameters.push(parse_parameter_alias(input)?);
                 }
                 "tags" => {
                     let tags;
@@ -127,6 +129,44 @@ impl Parse for EndpointAttr<'_> {
     }
 }
 
+fn parse_response_alias<'p>(input: ParseStream) -> syn::Result<Response<'p>> {
+    let response;
+    parenthesized!(response in input);
+
+    let fork = response.fork();
+    if let Ok(path) = fork.parse::<ExprPath>()
+        && fork.is_empty()
+    {
+        response.parse::<ExprPath>()?;
+        return Ok(Response::ToResponses(path));
+    }
+
+    let tuple = response.parse::<ResponseTuple>()?;
+    if !response.is_empty() {
+        return Err(
+            response.error("`response(...)` accepts one response; use `responses(...)` for a list")
+        );
+    }
+    Ok(Response::Tuple(Box::new(tuple)))
+}
+
+fn parse_parameter_alias<'p>(input: ParseStream) -> syn::Result<Parameter<'p>> {
+    let fork = input.fork();
+    let parameter_input;
+    parenthesized!(parameter_input in fork);
+    let path_fork = parameter_input.fork();
+    if let Ok(path) = path_fork.parse::<ExprPath>()
+        && path_fork.is_empty()
+    {
+        let consumed;
+        parenthesized!(consumed in input);
+        consumed.parse::<ExprPath>()?;
+        return Ok(Parameter::Struct(StructParameter { path }));
+    }
+
+    input.parse::<Parameter>()
+}
+
 #[cfg(test)]
 mod tests {
     use syn::parse_str;
@@ -162,6 +202,14 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_response_alias_to_responses_path() {
+        let input = "response(MyResponses)";
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.responses.len(), 1);
+        assert!(matches!(attr.responses[0], Response::ToResponses(_)));
+    }
+
+    #[test]
     fn test_parse_status_codes() {
         let input = "status_codes(200, 404)";
         let attr = parse_str::<EndpointAttr>(input).unwrap();
@@ -188,6 +236,14 @@ mod tests {
         let input = r#"parameter("id" = String, Path, description = "Pet id")"#;
         let attr = parse_str::<EndpointAttr>(input).unwrap();
         assert_eq!(attr.parameters.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_parameter_alias_to_parameters_path() {
+        let input = "parameter(MyParameters)";
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+        assert_eq!(attr.parameters.len(), 1);
+        assert!(matches!(attr.parameters[0], Parameter::Struct(_)));
     }
 
     #[test]

--- a/crates/oapi-macros/src/endpoint/attr.rs
+++ b/crates/oapi-macros/src/endpoint/attr.rs
@@ -48,9 +48,9 @@ impl Parse for EndpointAttr<'_> {
                 "responses" => {
                     let responses;
                     parenthesized!(responses in input);
-                    attr.responses =
-                        Punctuated::<Response, Token![,]>::parse_terminated(&responses)
-                            .map(|punctuated| punctuated.into_iter().collect::<Vec<Response>>())?;
+                    let responses = Punctuated::<Response, Token![,]>::parse_terminated(&responses)
+                        .map(|punctuated| punctuated.into_iter().collect::<Vec<Response>>())?;
+                    attr.responses.extend(responses);
                 }
                 "response" => {
                     attr.responses.push(parse_response_alias(input)?);
@@ -58,9 +58,10 @@ impl Parse for EndpointAttr<'_> {
                 "status_codes" => {
                     let status_codes;
                     parenthesized!(status_codes in input);
-                    attr.status_codes =
+                    let status_codes =
                         Punctuated::<Expr, Token![,]>::parse_terminated(&status_codes)
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Expr>>())?;
+                    attr.status_codes.extend(status_codes);
                 }
                 "status_code" => {
                     if input.peek(Token![=]) {
@@ -80,9 +81,10 @@ impl Parse for EndpointAttr<'_> {
                 "parameters" => {
                     let parameters;
                     parenthesized!(parameters in input);
-                    attr.parameters =
+                    let parameters =
                         Punctuated::<Parameter, Token![,]>::parse_terminated(&parameters)
                             .map(|punctuated| punctuated.into_iter().collect::<Vec<Parameter>>())?;
+                    attr.parameters.extend(parameters);
                 }
                 "parameter" => {
                     attr.parameters.push(parse_parameter_alias(input)?);
@@ -92,7 +94,9 @@ impl Parse for EndpointAttr<'_> {
                     parenthesized!(tags in input);
                     let parsed: Punctuated<Expr, Token![,]> =
                         Punctuated::<Expr, Token![,]>::parse_terminated(&tags)?;
-                    attr.tags = Some(parsed.into_iter().collect());
+                    attr.tags
+                        .get_or_insert_with(Vec::new)
+                        .extend(parsed.into_iter());
                 }
                 "tag" => {
                     let tag;
@@ -258,6 +262,26 @@ mod tests {
         let input = r#"tag("pet"), tag("store")"#;
         let attr = parse_str::<EndpointAttr>(input).unwrap();
         assert_eq!(attr.tags.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_singular_then_plural_aliases_append() {
+        let input = r#"
+            response(status_code = 404),
+            responses((status_code = 200)),
+            status_code(201),
+            status_codes(202, 203),
+            parameter("id" = String, Path),
+            parameters(MyParameters),
+            tag("pet"),
+            tags("store", "admin")
+        "#;
+        let attr = parse_str::<EndpointAttr>(input).unwrap();
+
+        assert_eq!(attr.responses.len(), 2);
+        assert_eq!(attr.status_codes.len(), 3);
+        assert_eq!(attr.parameters.len(), 2);
+        assert_eq!(attr.tags.unwrap().len(), 3);
     }
 
     #[test]

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -16,7 +16,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::token::Bracket;
-use syn::{Ident, Item, Token, bracketed, parenthesized, parse_macro_input};
+use syn::{Ident, Item, Token, bracketed, parse_macro_input};
 
 mod attribute;
 pub(crate) mod bound;
@@ -47,35 +47,6 @@ pub(crate) use self::response::Response;
 pub(crate) use self::server::Server;
 pub(crate) use self::shared::*;
 pub(crate) use self::type_tree::TypeTree;
-
-enum SalvoAttr<'p> {
-    Endpoint(EndpointAttr<'p>),
-}
-
-impl Parse for SalvoAttr<'_> {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let ident = input.parse::<Ident>()?;
-        match &*ident.to_string() {
-            "endpoint" => {
-                let attr = if input.is_empty() {
-                    EndpointAttr::default()
-                } else {
-                    let content;
-                    parenthesized!(content in input);
-                    content.parse::<EndpointAttr>()?
-                };
-                if !input.is_empty() {
-                    return Err(input.error("unexpected tokens after `endpoint(...)`"));
-                }
-                Ok(Self::Endpoint(attr))
-            }
-            _ => Err(syn::Error::new(
-                ident.span(),
-                "unexpected identifier, expected `endpoint`",
-            )),
-        }
-    }
-}
 
 /// Turns a Salvo handler function into an OpenAPI-aware endpoint.
 ///
@@ -122,25 +93,6 @@ pub fn endpoint(attr: TokenStream, input: TokenStream) -> TokenStream {
     match endpoint::generate(attr, item) {
         Ok(stream) => stream.into(),
         Err(e) => e.to_compile_error().into(),
-    }
-}
-
-/// Unified Salvo OpenAPI attribute entry point.
-///
-/// This currently accepts `#[salvo(endpoint(...))]` and forwards to the existing
-/// [`endpoint`] macro implementation. Use a qualified path such as
-/// `#[salvo_oapi_macros::salvo(endpoint(...))]` or
-/// `#[salvo_oapi::attr::salvo(endpoint(...))]` to avoid interfering with
-/// derive helper attributes such as `#[salvo(schema(...))]`.
-#[proc_macro_attribute]
-pub fn salvo(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let attr = parse_macro_input!(attr as SalvoAttr);
-    let item = parse_macro_input!(input as Item);
-    match attr {
-        SalvoAttr::Endpoint(attr) => match endpoint::generate(attr, item) {
-            Ok(stream) => stream.into(),
-            Err(e) => e.to_compile_error().into(),
-        },
     }
 }
 

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -128,9 +128,10 @@ pub fn endpoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// Unified Salvo OpenAPI attribute entry point.
 ///
 /// This currently accepts `#[salvo(endpoint(...))]` and forwards to the existing
-/// [`endpoint`] macro implementation. The fully qualified form
-/// `#[salvo_oapi::salvo(endpoint(...))]` avoids interfering with derive helper
-/// attributes such as `#[salvo(schema(...))]`.
+/// [`endpoint`] macro implementation. Use a qualified path such as
+/// `#[salvo_oapi_macros::salvo(endpoint(...))]` or
+/// `#[salvo_oapi::attr::salvo(endpoint(...))]` to avoid interfering with
+/// derive helper attributes such as `#[salvo(schema(...))]`.
 #[proc_macro_attribute]
 pub fn salvo(attr: TokenStream, input: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr as SalvoAttr);

--- a/crates/oapi-macros/src/lib.rs
+++ b/crates/oapi-macros/src/lib.rs
@@ -13,7 +13,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::token::Bracket;
-use syn::{Ident, Item, Token, bracketed, parse_macro_input};
+use syn::{Ident, Item, Token, bracketed, parenthesized, parse_macro_input};
 
 mod attribute;
 pub(crate) mod bound;
@@ -45,6 +45,35 @@ pub(crate) use self::server::Server;
 pub(crate) use self::shared::*;
 pub(crate) use self::type_tree::TypeTree;
 
+enum SalvoAttr<'p> {
+    Endpoint(EndpointAttr<'p>),
+}
+
+impl Parse for SalvoAttr<'_> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ident = input.parse::<Ident>()?;
+        match &*ident.to_string() {
+            "endpoint" => {
+                let attr = if input.is_empty() {
+                    EndpointAttr::default()
+                } else {
+                    let content;
+                    parenthesized!(content in input);
+                    content.parse::<EndpointAttr>()?
+                };
+                if !input.is_empty() {
+                    return Err(input.error("unexpected tokens after `endpoint(...)`"));
+                }
+                Ok(Self::Endpoint(attr))
+            }
+            _ => Err(syn::Error::new(
+                ident.span(),
+                "unexpected identifier, expected `endpoint`",
+            )),
+        }
+    }
+}
+
 /// Enhanced of [handler][handler] for generate OpenAPI documentation, [Read more][more].
 ///
 /// [handler]: ../salvo_core/attr.handler.html
@@ -58,6 +87,25 @@ pub fn endpoint(attr: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error().into(),
     }
 }
+
+/// Unified Salvo OpenAPI attribute entry point.
+///
+/// This currently accepts `#[salvo(endpoint(...))]` and forwards to the existing
+/// [`endpoint`] macro implementation. The fully qualified form
+/// `#[salvo_oapi::salvo(endpoint(...))]` avoids interfering with derive helper
+/// attributes such as `#[salvo(schema(...))]`.
+#[proc_macro_attribute]
+pub fn salvo(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as SalvoAttr);
+    let item = parse_macro_input!(input as Item);
+    match attr {
+        SalvoAttr::Endpoint(attr) => match endpoint::generate(attr, item) {
+            Ok(stream) => stream.into(),
+            Err(e) => e.to_compile_error().into(),
+        },
+    }
+}
+
 /// This is `#[derive]` implementation for [`ToSchema`][to_schema] trait, [Read more][more].
 ///
 /// [to_schema]: ../salvo_oapi/trait.ToSchema.html

--- a/crates/oapi-macros/tests/endpoint_tests.rs
+++ b/crates/oapi-macros/tests/endpoint_tests.rs
@@ -44,3 +44,53 @@ fn test_endpoint_hello() {
         })
     );
 }
+
+#[test]
+fn test_salvo_endpoint_aliases() {
+    #[salvo::oapi::salvo(endpoint(
+        tag("pets"),
+        parameter("id" = String, Path, description = "Pet id"),
+        response(status_code = 404, description = "Not found")
+    ))]
+    async fn show_pet() -> String {
+        "pet".to_owned()
+    }
+
+    let router = Router::new().push(Router::with_path("pets/{id}").get(show_pet));
+
+    let doc = OpenApi::new("test api", "0.0.1").merge_router(&router);
+    assert_json_eq!(
+        doc,
+        json!({
+            "openapi":"3.1.0",
+            "info":{
+                "title":"test api",
+                "version":"0.0.1"
+            },
+            "paths":{
+                "/pets/{id}":{
+                    "get":{
+                        "operationId":"endpoint_tests.test_salvo_endpoint_aliases.show_pet",
+                        "tags":["pets"],
+                        "parameters":[{
+                            "name":"id",
+                            "in":"path",
+                            "description":"Pet id",
+                            "required":true,
+                            "schema":{"type":"string"}
+                        }],
+                        "responses":{
+                            "200":{
+                                "description":"Ok",
+                                "content":{"text/plain":{"schema":{"type":"string"}}}
+                            },
+                            "404":{
+                                "description":"Not found"
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+}

--- a/crates/oapi-macros/tests/endpoint_tests.rs
+++ b/crates/oapi-macros/tests/endpoint_tests.rs
@@ -46,12 +46,12 @@ fn test_endpoint_hello() {
 }
 
 #[test]
-fn test_salvo_endpoint_aliases() {
-    #[salvo::oapi::attr::salvo(endpoint(
+fn test_endpoint_singular_aliases() {
+    #[endpoint(
         tag("pets"),
         parameter("id" = String, Path, description = "Pet id"),
         response(status_code = 404, description = "Not found")
-    ))]
+    )]
     async fn show_pet() -> String {
         "pet".to_owned()
     }
@@ -70,7 +70,7 @@ fn test_salvo_endpoint_aliases() {
             "paths":{
                 "/pets/{id}":{
                     "get":{
-                        "operationId":"endpoint_tests.test_salvo_endpoint_aliases.show_pet",
+                        "operationId":"endpoint_tests.test_endpoint_singular_aliases.show_pet",
                         "tags":["pets"],
                         "parameters":[{
                             "name":"id",
@@ -93,19 +93,4 @@ fn test_salvo_endpoint_aliases() {
             }
         })
     );
-}
-
-#[test]
-fn test_oapi_glob_import_does_not_shadow_salvo_helper_attrs() {
-    mod glob_import {
-        use salvo::oapi::*;
-
-        #[derive(ToSchema)]
-        #[salvo(schema(rename_all = "camelCase"))]
-        pub(crate) struct Pet {
-            _pet_name: String,
-        }
-    }
-
-    let _ = std::any::TypeId::of::<glob_import::Pet>();
 }

--- a/crates/oapi-macros/tests/endpoint_tests.rs
+++ b/crates/oapi-macros/tests/endpoint_tests.rs
@@ -47,7 +47,7 @@ fn test_endpoint_hello() {
 
 #[test]
 fn test_salvo_endpoint_aliases() {
-    #[salvo::oapi::salvo(endpoint(
+    #[salvo::oapi::attr::salvo(endpoint(
         tag("pets"),
         parameter("id" = String, Path, description = "Pet id"),
         response(status_code = 404, description = "Not found")
@@ -93,4 +93,19 @@ fn test_salvo_endpoint_aliases() {
             }
         })
     );
+}
+
+#[test]
+fn test_oapi_glob_import_does_not_shadow_salvo_helper_attrs() {
+    mod glob_import {
+        use salvo::oapi::*;
+
+        #[derive(ToSchema)]
+        #[salvo(schema(rename_all = "camelCase"))]
+        pub(crate) struct Pet {
+            _pet_name: String,
+        }
+    }
+
+    let _ = std::any::TypeId::of::<glob_import::Pet>();
 }

--- a/crates/oapi/docs/endpoint.md
+++ b/crates/oapi/docs/endpoint.md
@@ -22,12 +22,8 @@ fn endpoint() {}
 
 # Endpoint Attributes
 
-The endpoint macro can be written directly as `#[salvo_oapi::endpoint(...)]`, or through the
-unified entry point as `#[salvo_oapi::attr::salvo(endpoint(...))]`. The unified form is also
-available from the umbrella crate as `#[salvo::oapi::attr::salvo(endpoint(...))]`. The unified
-macro intentionally lives under `attr` so wildcard imports such as `use salvo_oapi::*` do not bring
-an active attribute macro named `salvo` into scope and interfere with derive helper attributes like
-`#[salvo(schema(...))]`.
+If the unqualified attribute name conflicts with another crate, use a fully qualified path such as
+`#[salvo_oapi::endpoint(...)]` or `#[salvo::oapi::endpoint(...)]`.
 
 The plural list attributes remain supported. For codebases that prefer one item per attribute,
 the following singular aliases are accepted as well: `tag(...)` for `tags(...)`, `parameter(...)`

--- a/crates/oapi/docs/endpoint.md
+++ b/crates/oapi/docs/endpoint.md
@@ -23,8 +23,11 @@ fn endpoint() {}
 # Endpoint Attributes
 
 The endpoint macro can be written directly as `#[salvo_oapi::endpoint(...)]`, or through the
-unified entry point as `#[salvo_oapi::salvo(endpoint(...))]`. The unified form is also available
-from the umbrella crate as `#[salvo::oapi::salvo(endpoint(...))]`.
+unified entry point as `#[salvo_oapi::attr::salvo(endpoint(...))]`. The unified form is also
+available from the umbrella crate as `#[salvo::oapi::attr::salvo(endpoint(...))]`. The unified
+macro intentionally lives under `attr` so wildcard imports such as `use salvo_oapi::*` do not bring
+an active attribute macro named `salvo` into scope and interfere with derive helper attributes like
+`#[salvo(schema(...))]`.
 
 The plural list attributes remain supported. For codebases that prefer one item per attribute,
 the following singular aliases are accepted as well: `tag(...)` for `tags(...)`, `parameter(...)`

--- a/crates/oapi/docs/endpoint.md
+++ b/crates/oapi/docs/endpoint.md
@@ -22,6 +22,15 @@ fn endpoint() {}
 
 # Endpoint Attributes
 
+The endpoint macro can be written directly as `#[salvo_oapi::endpoint(...)]`, or through the
+unified entry point as `#[salvo_oapi::salvo(endpoint(...))]`. The unified form is also available
+from the umbrella crate as `#[salvo::oapi::salvo(endpoint(...))]`.
+
+The plural list attributes remain supported. For codebases that prefer one item per attribute,
+the following singular aliases are accepted as well: `tag(...)` for `tags(...)`, `parameter(...)`
+for `parameters(...)`, `response(...)` for `responses(...)`, and `status_code(...)` for
+`status_codes(...)`.
+
 * `operation_id = ...` Unique operation id for the endpoint. By default this is mapped to function name.
   The operation_id can be any "valid expression (e.g. string literals, macro invocations, variables) so long
   as its result can be converted to a `String` using `String::from`.

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -56,9 +56,9 @@ pub use salvo_oapi_macros::ToResponse;
 pub use salvo_oapi_macros::ToResponses;
 #[doc = include_str!("../docs/derive_to_schema.md")]
 pub use salvo_oapi_macros::ToSchema;
-#[doc = include_str!("../docs/endpoint.md")]
-pub use salvo_oapi_macros::endpoint;
 pub(crate) use salvo_oapi_macros::schema;
+#[doc = include_str!("../docs/endpoint.md")]
+pub use salvo_oapi_macros::{endpoint, salvo};
 
 use crate::oapi::openapi::schema::OneOf;
 

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -56,9 +56,14 @@ pub use salvo_oapi_macros::ToResponse;
 pub use salvo_oapi_macros::ToResponses;
 #[doc = include_str!("../docs/derive_to_schema.md")]
 pub use salvo_oapi_macros::ToSchema;
-pub(crate) use salvo_oapi_macros::schema;
 #[doc = include_str!("../docs/endpoint.md")]
-pub use salvo_oapi_macros::{endpoint, salvo};
+pub use salvo_oapi_macros::endpoint;
+pub(crate) use salvo_oapi_macros::schema;
+
+/// Attribute macro entry points kept out of wildcard imports.
+pub mod attr {
+    pub use salvo_oapi_macros::salvo;
+}
 
 use crate::oapi::openapi::schema::OneOf;
 

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -60,11 +60,6 @@ pub use salvo_oapi_macros::ToSchema;
 pub use salvo_oapi_macros::endpoint;
 pub(crate) use salvo_oapi_macros::schema;
 
-/// Attribute macro entry points kept out of wildcard imports.
-pub mod attr {
-    pub use salvo_oapi_macros::salvo;
-}
-
 use crate::oapi::openapi::schema::OneOf;
 
 // https://github.com/bkchr/proc-macro-crate/issues/10


### PR DESCRIPTION
## Summary
- add singular endpoint attribute aliases: `response(...)`, `parameter(...)`, `tag(...)`, and `status_code(...)`
- keep conflict resolution on the existing qualified macro paths, such as `#[salvo_oapi::endpoint(...)]` and `#[salvo::oapi::endpoint(...)]`
- document the qualified-path guidance and cover the singular alias syntax with parser and integration tests
- merge `origin/main` and fix the `PathState<'_>` signature needed by the updated router internals

## Tests
- `cargo check -p salvo_core --all-targets --all-features`
- `cargo check --all --bins --examples --tests`
- `cargo test -p salvo-oapi-macros`
- GitHub PR checks: all passing on PR head `5ec9e024`
- `cargo test -p salvo-oapi --lib` still has 2 local default-feature integer-format assertion failures where `StatusError.code` renders as `uint16` but the older expectations use `int32` (`test_simple_document_with_security`, `test_openapi_schema_work_with_generics`)