### PR TITLE
feat(tus): add absolute location builder

### DIFF
--- a/crates/tus/README.md
+++ b/crates/tus/README.md
@@ -95,6 +95,22 @@ async fn main() {
 }
 ```
 
+## Absolute Location URLs
+
+Tus returns relative `Location` headers by default. If clients need absolute
+upload URLs in production, set a fixed trusted origin with
+`absolute_location`:
+
+```rust
+let tus = Tus::new()
+    .path("/uploads")
+    .absolute_location("https://uploads.example.com");
+```
+
+Avoid using `relative_location(false)` by itself for internet-facing services:
+without a canonical origin, absolute URLs are derived from request `Host` or
+forwarded headers.
+
 ## Lifecycle Hooks
 
 React to upload events:

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -285,6 +285,10 @@ impl Tus {
     }
 
     /// Controls whether generated `Location` headers use relative URLs.
+    ///
+    /// If you set this to `false` without also setting a trusted origin, absolute
+    /// URLs are derived from inbound request headers. Prefer
+    /// [`Self::absolute_location`] for production absolute URLs.
     #[must_use]
     pub fn relative_location(mut self, yes: bool) -> Self {
         self.options.relative_location = yes;
@@ -292,8 +296,23 @@ impl Tus {
     }
 
     /// Sets the trusted origin used for absolute `Location` headers.
+    ///
+    /// This only sets the origin. Use [`Self::absolute_location`] when you want
+    /// to both enable absolute URLs and pin them to a trusted origin.
     #[must_use]
     pub fn canonical_origin(mut self, origin: impl Into<String>) -> Self {
+        self.options.canonical_origin = Some(origin.into());
+        self
+    }
+
+    /// Uses absolute `Location` headers with a fixed, trusted origin.
+    ///
+    /// This is a convenience for calling [`Self::relative_location`] with
+    /// `false` and then [`Self::canonical_origin`]. It avoids deriving absolute
+    /// upload URLs from client-controlled `Host` or forwarded headers.
+    #[must_use]
+    pub fn absolute_location(mut self, origin: impl Into<String>) -> Self {
+        self.options.relative_location = false;
         self.options.canonical_origin = Some(origin.into());
         self
     }
@@ -379,7 +398,7 @@ impl Tus {
                 "Tus is configured with relative_location(false) but no canonical_origin; \
                  absolute Location headers will be derived from the inbound Host / Forwarded \
                  headers, which a misbehaving client or unauthenticated proxy can spoof. \
-                 Set Tus::canonical_origin(\"https://your.host\") to pin the origin."
+                 Set Tus::absolute_location(\"https://your.host\") to pin the origin."
             );
         }
         let state = Arc::new(self);
@@ -520,6 +539,15 @@ mod tests {
         let _ = Tus::new()
             .relative_location(false)
             .canonical_origin("https://uploads.example.com")
+            .into_router();
+        assert!(!logs_contain("no canonical_origin"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_into_router_does_not_warn_when_absolute_location_is_set() {
+        let _ = Tus::new()
+            .absolute_location("https://uploads.example.com")
             .into_router();
         assert!(!logs_contain("no canonical_origin"));
     }
@@ -676,6 +704,16 @@ mod tests {
 
         let tus = Tus::new().relative_location(true);
         assert!(tus.options.relative_location);
+    }
+
+    #[test]
+    fn test_tus_absolute_location() {
+        let tus = Tus::new().absolute_location("https://uploads.example.com");
+        assert!(!tus.options.relative_location);
+        assert_eq!(
+            tus.options.canonical_origin.as_deref(),
+            Some("https://uploads.example.com")
+        );
     }
 
     #[test]

--- a/crates/tus/src/options.rs
+++ b/crates/tus/src/options.rs
@@ -126,9 +126,10 @@ pub struct TusOptions {
     /// `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and
     /// `X-Forwarded-Ssl`) headers, all of which are client-controlled. An
     /// attacker can then poison the returned upload URL via `Host` header
-    /// injection. In production prefer a relative `Location` or set
-    /// `canonical_origin` to a fixed, trusted origin so the host is never taken
-    /// from request headers.
+    /// injection. In production prefer a relative `Location`, or use
+    /// [`Tus::absolute_location`](crate::Tus::absolute_location) to switch to
+    /// absolute URLs and set a fixed, trusted origin in one step so the host is
+    /// never taken from request headers.
     pub canonical_origin: Option<String>,
 
     /// Allows trusted forwarded headers to override the host and protocol used for `Location`.


### PR DESCRIPTION
## Summary
- add `Tus::absolute_location(origin)` to enable absolute `Location` URLs with a trusted origin in one call
- update warnings and docs to recommend the safer builder instead of bare `relative_location(false)`
- cover the new builder with option and warning-regression tests

## Tests
- `cargo test -p salvo-tus`