### PR TITLE
perf: skip empty request cookie jar clone

### DIFF
--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -138,6 +138,17 @@ impl Response {
         }
     }
 
+    #[cfg(feature = "cookie")]
+    #[inline]
+    #[must_use]
+    pub(crate) fn with_request_cookies(cookies: &CookieJar) -> Self {
+        if cookies.iter().next().is_some() {
+            Self::with_cookies(cookies.clone())
+        } else {
+            Self::new()
+        }
+    }
+
     /// Get headers reference.
     #[inline]
     pub fn headers(&self) -> &HeaderMap {
@@ -746,6 +757,32 @@ mod test {
         );
         assert!(cookie_headers.iter().any(|v| v.starts_with("sid=abc")));
         assert!(cookie_headers.iter().any(|v| v.starts_with("theme=dark")));
+    }
+
+    #[cfg(feature = "cookie")]
+    #[test]
+    fn test_with_request_cookies_preserves_non_empty_request_jar() {
+        let mut cookies = CookieJar::new();
+        cookies.add_original(Cookie::new("sid", "abc"));
+
+        let res = Response::with_request_cookies(&cookies);
+
+        assert_eq!(
+            res.cookies.get("sid").map(|cookie| cookie.value()),
+            Some("abc")
+        );
+        assert_eq!(res.cookies.delta().count(), 0);
+    }
+
+    #[cfg(feature = "cookie")]
+    #[test]
+    fn test_with_request_cookies_uses_empty_response_for_empty_request_jar() {
+        let cookies = CookieJar::new();
+
+        let res = Response::with_request_cookies(&cookies);
+
+        assert_eq!(res.cookies.iter().count(), 0);
+        assert_eq!(res.cookies.delta().count(), 0);
     }
 
     #[cfg(feature = "cookie")]

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -257,7 +257,7 @@ impl HyperHandler {
         #[cfg(not(feature = "cookie"))]
         let mut res = Response::new();
         #[cfg(feature = "cookie")]
-        let mut res = Response::with_cookies(req.cookies.clone());
+        let mut res = Response::with_request_cookies(&req.cookies);
         if let Some(alt_svc_h3) = &self.alt_svc_h3
             && !res.headers().contains_key(ALT_SVC)
         {

--- a/crates/core/src/test/request/builder.rs
+++ b/crates/core/src/test/request/builder.rs
@@ -295,7 +295,7 @@ where
         #[cfg(not(feature = "cookie"))]
         let mut res = Response::new();
         #[cfg(feature = "cookie")]
-        let mut res = Response::with_cookies(req.cookies.clone());
+        let mut res = Response::with_request_cookies(&req.cookies);
         let mut ctrl = FlowCtrl::new(vec![self.clone()]);
         self.handle(&mut req, &mut depot, &mut res, &mut ctrl).await;
         res


### PR DESCRIPTION
## Summary
- avoid cloning the request `CookieJar` when the incoming request has no cookies
- keep the existing response-cookie behavior for requests that do have cookies
- update the test request sender to use the same helper as the service path

## Notes
I reviewed the other Tier 3 candidates and left them unchanged:
- `ChunkedFile` hands each buffer to `Bytes`, so reusing a `BytesMut` across chunks would not safely retain ownership for the next read.
- the compression stream `spawn_blocking` threshold is a latency/throughput policy choice and needs benchmark evidence before changing the constant.

## Tests
- `cargo test -p salvo_core http::response::test`
- `cargo test -p salvo_core service`
- `cargo test -p salvo_core`