### PR TITLE
Tighten public struct field visibility

### DIFF
--- a/crates/acme/src/lib.rs
+++ b/crates/acme/src/lib.rs
@@ -224,7 +224,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "key-authorization");
     }
 
@@ -239,6 +239,6 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::NOT_FOUND));
+        assert_eq!(response.status(), Some(StatusCode::NOT_FOUND));
     }
 }

--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -135,7 +135,7 @@ impl<T> AcmeListenerBuilder<T> {
             let handler = Http01Handler {
                 keys: keys_for_http01.clone(),
             };
-            router.routers.insert(
+            router.routers_mut().insert(
                 0,
                 Router::with_path(format!("{WELL_KNOWN_PATH}/{{token}}")).goal(handler),
             );

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -611,7 +611,7 @@ fn cached_response(
     headers_before: &HeaderMap,
     cache_private: bool,
 ) -> Option<CachedEntry> {
-    if res.body.is_stream() || res.body.is_error() {
+    if res.body_ref().is_stream() || res.body_ref().is_error() {
         return None;
     }
     // Only cache successful responses. Use the *effective* status: a missing
@@ -620,7 +620,7 @@ fn cached_response(
     // redirect statuses (e.g. a transient `500`, an auth-dependent `401`/`403`,
     // or an empty unmatched `404`) would replay them to every client for the
     // whole TTL.
-    let effective_status = res.status_code.unwrap_or(if res.body.is_none() {
+    let effective_status = res.status().unwrap_or(if res.body_ref().is_none() {
         StatusCode::NOT_FOUND
     } else {
         StatusCode::OK
@@ -648,14 +648,14 @@ fn cached_response(
         return None;
     }
     let headers = handler_response_headers(headers_before, res.headers());
-    let body = match TryInto::<CachedBody>::try_into(&res.body) {
+    let body = match TryInto::<CachedBody>::try_into(res.body_ref()) {
         Ok(body) => body,
         Err(e) => {
             tracing::error!(error = ?e, "cache failed");
             return None;
         }
     };
-    Some(CachedEntry::new(res.status_code, headers, body))
+    Some(CachedEntry::new(res.status(), headers, body))
 }
 
 /// Headers the inner handler contributed, i.e. names whose values changed
@@ -877,14 +877,14 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let content0 = res.take_string().await.unwrap();
 
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let content1 = res.take_string().await.unwrap();
         assert_eq!(content0, content1);
@@ -918,7 +918,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5802")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(res.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
         let content0 = res.take_string().await.unwrap();
 
         // A non-success response must not be cached, so the backend runs again
@@ -945,7 +945,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5803")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let body = res.take_string().await.unwrap();
         assert!(body.contains("Hello World"));
     }
@@ -956,7 +956,7 @@ mod tests {
         // (see `Response::into_hyper`), so its effective status is non-success
         // and it must not be cached.
         let res = Response::new();
-        assert!(res.status_code.is_none() && res.body.is_none());
+        assert!(res.status().is_none() && res.body_ref().is_none());
         assert!(cached_response(&res, &HeaderMap::new(), false).is_none());
     }
 
@@ -965,7 +965,7 @@ mod tests {
         // No status code but a body present is sent as `200 OK`, so it is cached.
         let mut res = Response::new();
         res.render("ok");
-        assert!(res.status_code.is_none());
+        assert!(res.status().is_none());
         assert!(cached_response(&res, &HeaderMap::new(), false).is_some());
     }
 
@@ -1408,7 +1408,7 @@ mod tests {
                 .add_header(AUTHORIZATION, "Bearer token", true)
                 .send(router.clone())
                 .await;
-            assert_eq!(res.status_code, Some(StatusCode::OK));
+            assert_eq!(res.status(), Some(StatusCode::OK));
             let _ = res.take_string().await.unwrap();
         }
 

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -458,7 +458,7 @@ impl Handler for Compression {
             return;
         }
 
-        if let Some(StatusCode::SWITCHING_PROTOCOLS | StatusCode::NO_CONTENT) = res.status_code {
+        if let Some(StatusCode::SWITCHING_PROTOCOLS | StatusCode::NO_CONTENT) = res.status() {
             return;
         }
 

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -39,7 +39,7 @@
 //!
 //! #[handler]
 //! async fn handle404(res: &mut Response, ctrl: &mut FlowCtrl) {
-//!     if let Some(StatusCode::NOT_FOUND) = res.status_code {
+//!     if let Some(StatusCode::NOT_FOUND) = res.status() {
 //!         res.render("custom 404 error page");
 //!         ctrl.skip_rest();
 //!     }

--- a/crates/core/src/http/response.rs
+++ b/crates/core/src/http/response.rs
@@ -44,18 +44,18 @@ use crate::{BoxedError, Error, Scribe};
 #[non_exhaustive]
 pub struct Response {
     /// The HTTP status code.
-    pub status_code: Option<StatusCode>,
+    pub(crate) status_code: Option<StatusCode>,
     /// The HTTP headers.
-    pub headers: HeaderMap,
+    pub(crate) headers: HeaderMap,
     /// The HTTP version.
-    pub version: Version,
+    pub(crate) version: Version,
     /// The HTTP cookies.
     #[cfg(feature = "cookie")]
-    pub cookies: CookieJar,
+    pub(crate) cookies: CookieJar,
     /// The HTTP body.
-    pub body: ResBody,
+    pub(crate) body: ResBody,
     /// Used to store extra data derived from the underlying protocol.
-    pub extensions: Extensions,
+    pub(crate) extensions: Extensions,
 }
 impl Default for Response {
     #[inline]
@@ -199,6 +199,12 @@ impl Response {
         }
     }
 
+    /// Get body reference.
+    #[inline]
+    #[must_use]
+    pub fn body_ref(&self) -> &ResBody {
+        &self.body
+    }
     /// Get mutable body reference.
     #[inline]
     pub fn body_mut(&mut self) -> &mut ResBody {
@@ -422,6 +428,18 @@ impl Response {
             .and_then(|v| v.parse().ok())
     }
 
+    /// Get status code.
+    #[inline]
+    #[must_use]
+    pub fn status(&self) -> Option<StatusCode> {
+        self.status_code
+    }
+    /// Get mutable status code reference.
+    #[inline]
+    pub fn status_mut(&mut self) -> &mut Option<StatusCode> {
+        &mut self.status_code
+    }
+
     /// Sets status code and returns `&mut Self`.
     ///
     /// # Example
@@ -437,6 +455,18 @@ impl Response {
     pub fn status_code(&mut self, code: StatusCode) -> &mut Self {
         self.status_code = Some(code);
         self
+    }
+
+    /// Get extensions reference.
+    #[inline]
+    #[must_use]
+    pub fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+    /// Get mutable extensions reference.
+    #[inline]
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
     }
 
     /// Render content into this response.

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -14,15 +14,15 @@ use crate::{Depot, Request};
 #[non_exhaustive]
 pub struct Router {
     #[doc(hidden)]
-    pub id: usize,
+    pub(crate) id: usize,
     /// The children of current router.
-    pub routers: Vec<Self>,
+    pub(crate) routers: Vec<Self>,
     /// The filters of current router.
-    pub filters: Vec<Box<dyn Filter>>,
+    pub(crate) filters: Vec<Box<dyn Filter>>,
     /// The middlewares of current router.
-    pub hoops: Vec<Arc<dyn Handler>>,
+    pub(crate) hoops: Vec<Arc<dyn Handler>>,
     /// The final handler to handle request of current router.
-    pub goal: Option<Arc<dyn Handler>>,
+    pub(crate) goal: Option<Arc<dyn Handler>>,
 }
 
 impl Default for Router {
@@ -44,6 +44,13 @@ impl Router {
             hoops: Vec::new(),
             goal: None,
         }
+    }
+
+    /// Get the stable id of this router.
+    #[inline]
+    #[must_use]
+    pub fn id(&self) -> usize {
+        self.id
     }
 
     /// Get current router's children reference.
@@ -80,6 +87,13 @@ impl Router {
     #[inline]
     pub fn filters_mut(&mut self) -> &mut Vec<Box<dyn Filter>> {
         &mut self.filters
+    }
+
+    /// Get current router's final handler reference.
+    #[inline]
+    #[must_use]
+    pub fn goal_ref(&self) -> Option<&Arc<dyn Handler>> {
+        self.goal.as_ref()
     }
 
     /// Detect current router is matched for current request.

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -21,13 +21,13 @@ use crate::{Depot, async_trait};
 #[non_exhaustive]
 pub struct Service {
     /// The router of this service.
-    pub router: Arc<Router>,
+    pub(crate) router: Arc<Router>,
     /// The catcher of this service.
-    pub catcher: Option<Arc<Catcher>>,
+    pub(crate) catcher: Option<Arc<Catcher>>,
     /// These hoops will always be called when request received.
-    pub hoops: Vec<Arc<dyn Handler>>,
+    pub(crate) hoops: Vec<Arc<dyn Handler>>,
     /// The allowed media types of this service.
-    pub allowed_media_types: Arc<Vec<Mime>>,
+    pub(crate) allowed_media_types: Arc<Vec<Mime>>,
 }
 
 impl Debug for Service {
@@ -63,6 +63,40 @@ impl Service {
         self.router.clone()
     }
 
+    /// Get router reference in this `Service`.
+    #[inline]
+    #[must_use]
+    pub fn router_ref(&self) -> &Arc<Router> {
+        &self.router
+    }
+
+    /// Get catcher reference in this `Service`.
+    #[inline]
+    #[must_use]
+    pub fn catcher_ref(&self) -> Option<&Arc<Catcher>> {
+        self.catcher.as_ref()
+    }
+
+    /// Get service-level middleware references.
+    #[inline]
+    #[must_use]
+    pub fn hoops(&self) -> &[Arc<dyn Handler>] {
+        &self.hoops
+    }
+
+    /// Get mutable service-level middleware references.
+    #[inline]
+    pub fn hoops_mut(&mut self) -> &mut Vec<Arc<dyn Handler>> {
+        &mut self.hoops
+    }
+
+    /// Get allowed media types.
+    #[inline]
+    #[must_use]
+    pub fn allowed_media_types_ref(&self) -> &[Mime] {
+        &self.allowed_media_types
+    }
+
     /// When the response code is 400-599 and the body is empty, capture and set the error page
     /// content. If no catcher is set, the default error page will be used.
     ///
@@ -80,7 +114,7 @@ impl Service {
     ///     res: &mut Response,
     ///     ctrl: &mut FlowCtrl,
     /// ) {
-    ///     if let Some(StatusCode::NOT_FOUND) = res.status_code {
+    ///     if let Some(StatusCode::NOT_FOUND) = res.status() {
     ///         res.render("Custom 404 Error Page");
     ///         ctrl.skip_rest();
     ///     }

--- a/crates/cors/src/lib.rs
+++ b/crates/cors/src/lib.rs
@@ -520,7 +520,7 @@ impl Handler for CorsHandler {
             headers.extend(self.cors.allow_methods.to_header(origin, req, depot).await);
             headers.extend(self.cors.allow_headers.to_header(origin, req, depot).await);
             headers.extend(self.cors.max_age.to_header(origin, req, depot).await);
-            res.status_code = Some(StatusCode::NO_CONTENT);
+            res.status_code(StatusCode::NO_CONTENT);
         } else {
             // This header is applied only to non-preflight requests
             headers.extend(self.cors.expose_headers.to_header(origin, req, depot).await);

--- a/crates/csrf/src/lib.rs
+++ b/crates/csrf/src/lib.rs
@@ -419,7 +419,7 @@ mod tests {
         );
         let router = Router::new().hoop(csrf).get(get_index);
         let res = TestClient::get("http://127.0.0.1:5801").send(router).await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -433,7 +433,7 @@ mod tests {
 
         let mut res = TestClient::get("http://127.0.0.1:5801").send(router).await;
 
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_ne!(res.take_string().await.unwrap(), "");
         assert_ne!(res.cookie("salvo.csrf"), None);
     }
@@ -450,7 +450,7 @@ mod tests {
 
         let mut res = TestClient::get("http://127.0.0.1:5801").send(router).await;
 
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_ne!(res.take_string().await.unwrap(), "");
     }
 
@@ -467,7 +467,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token1 = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
         let cookie_header = cookie.to_string();
@@ -476,7 +476,7 @@ mod tests {
             .add_header("cookie", cookie_header, true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token2 = res.take_string().await.unwrap();
 
         assert_eq!(token1, token2);
@@ -496,7 +496,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token1 = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
         let cookie_header = cookie.to_string();
@@ -505,7 +505,7 @@ mod tests {
             .add_header("cookie", cookie_header, true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token2 = res.take_string().await.unwrap();
         let rotated_cookie = res.cookie("salvo.csrf").unwrap();
         let rotated_token = rotated_cookie.value().split_once('.').unwrap().0;
@@ -528,7 +528,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token1 = res.take_string().await.unwrap();
         let cookie1 = res.cookie("salvo.csrf").unwrap();
         let cookie1_header = cookie1.to_string();
@@ -538,7 +538,7 @@ mod tests {
             .add_header("cookie", cookie1_header, true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token2 = res.take_string().await.unwrap();
         let cookie2 = res.cookie("salvo.csrf").unwrap();
         let cookie2_header = cookie2.to_string();
@@ -552,14 +552,14 @@ mod tests {
             .add_header("cookie", cookie2_header.clone(), true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-csrf-token", token2.clone(), true)
             .add_header("cookie", cookie2_header, true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let token3 = res.take_string().await.unwrap();
 
         assert_ne!(token2, token3);
@@ -578,7 +578,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -586,14 +586,14 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-csrf-token", csrf_token, true)
             .add_header("cookie", cookie.to_string(), true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
 
@@ -609,7 +609,7 @@ mod tests {
 
         let mut res = TestClient::post("http://127.0.0.1:5801").send(router).await;
 
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
 
@@ -626,7 +626,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -634,14 +634,14 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-mycsrf-header", csrf_token, true)
             .add_header("cookie", cookie.to_string(), true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
 
@@ -658,7 +658,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -666,14 +666,14 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801?a=1&b=2")
             .add_header("csrf-token", csrf_token, true)
             .add_header("cookie", cookie.to_string(), true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
     #[cfg(feature = "hmac-cipher")]
@@ -690,7 +690,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -698,14 +698,14 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801?a=1&b=2")
             .add_header("my-csrf-token", csrf_token, true)
             .add_header("cookie", cookie.to_string(), true)
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
 
@@ -723,7 +723,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -731,14 +731,14 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let mut res = TestClient::post("http://127.0.0.1:5801")
             .add_header("cookie", cookie.to_string(), true)
             .form(&[("a", "1"), ("csrf-token", &*csrf_token), ("b", "2")])
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
     #[tokio::test]
@@ -754,7 +754,7 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let csrf_token = res.take_string().await.unwrap();
         let cookie = res.cookie("salvo.csrf").unwrap();
@@ -762,13 +762,13 @@ mod tests {
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
         let mut res = TestClient::post("http://127.0.0.1:5801")
             .add_header("cookie", cookie.to_string(), true)
             .form(&[("a", "1"), ("my-csrf-token", &*csrf_token), ("b", "2")])
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         assert_eq!(res.take_string().await.unwrap(), "POST");
     }
 
@@ -785,14 +785,14 @@ mod tests {
         let res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let cookie = res.cookie("salvo.csrf").unwrap();
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-csrf-token", "aGVsbG8=", true)
@@ -803,7 +803,7 @@ mod tests {
             )
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -819,14 +819,14 @@ mod tests {
         let res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let cookie = res.cookie("salvo.csrf").unwrap();
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-csrf-token", "aGVsbG8", true)
@@ -837,7 +837,7 @@ mod tests {
             )
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -853,19 +853,19 @@ mod tests {
         let mut res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let csrf_token = res.take_string().await.unwrap();
 
         let res = TestClient::get("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
         let cookie = res.cookie("salvo.csrf").unwrap();
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
 
         let res = TestClient::post("http://127.0.0.1:5801")
             .add_header("x-csrf-token", csrf_token, true)
@@ -876,6 +876,6 @@ mod tests {
             )
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::FORBIDDEN);
+        assert_eq!(res.status().unwrap(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/extra/src/caching_headers.rs
+++ b/crates/extra/src/caching_headers.rs
@@ -85,7 +85,7 @@ impl Handler for ETag {
             .and_then(|etag| etag.parse::<EntityTag>().ok());
 
         let etag = res_etag.or_else(|| {
-                let etag = match &res.body {
+                let etag = match res.body_ref() {
                     ResBody::Once(bytes) => Some(EntityTag::from_data(bytes)),
                     ResBody::Chunks(bytes) => {
                         let tags = bytes
@@ -200,7 +200,7 @@ impl Handler for CachingHeaders {
         ctrl: &mut FlowCtrl,
     ) {
         self.0.handle(req, depot, res, ctrl).await;
-        if res.status_code != Some(StatusCode::NOT_MODIFIED) {
+        if res.status() != Some(StatusCode::NOT_MODIFIED) {
             self.1.handle(req, depot, res, ctrl).await;
         }
     }
@@ -227,15 +227,15 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
 
         let etag = response.headers().get(ETAG).unwrap();
         let response = TestClient::get("http://127.0.0.1:8698/")
             .add_header(IF_NONE_MATCH, etag, true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::NOT_MODIFIED));
-        assert!(response.body.is_none());
+        assert_eq!(response.status(), Some(StatusCode::NOT_MODIFIED));
+        assert!(response.body_ref().is_none());
     }
 
     #[tokio::test]
@@ -253,7 +253,7 @@ mod tests {
 
         // The real body-derived ETag does not match the forged value, so the
         // response is served normally instead of a spurious 304.
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         let etag = response.headers().get(ETAG).unwrap();
         assert_ne!(etag, "\"forged\"");
     }

--- a/crates/extra/src/concurrency_limiter.rs
+++ b/crates/extra/src/concurrency_limiter.rs
@@ -175,10 +175,10 @@ mod tests {
         let second = TestClient::get("http://127.0.0.1:5801")
             .send(router)
             .await;
-        assert_eq!(second.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(second.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         release.notify_one();
         let first = first.await.unwrap();
-        assert_eq!(first.status_code, Some(StatusCode::OK));
+        assert_eq!(first.status(), Some(StatusCode::OK));
     }
 }

--- a/crates/extra/src/force_https.rs
+++ b/crates/extra/src/force_https.rs
@@ -260,7 +260,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_eq!(response.status(), Some(StatusCode::BAD_REQUEST));
         assert_ne!(
             response.take_string().await.unwrap_or_default(),
             "leaked plaintext"
@@ -276,7 +276,7 @@ mod tests {
             .add_header(HOST, "127.0.0.1:8698", true)
             .send(router)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::PERMANENT_REDIRECT));
+        assert_eq!(response.status(), Some(StatusCode::PERMANENT_REDIRECT));
         assert_eq!(
             response.headers().get(LOCATION),
             Some(&"https://127.0.0.1:1234/".parse().unwrap())
@@ -291,7 +291,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.headers().get(LOCATION), None);
         assert_eq!(response.take_string().await.unwrap(), "Hello World");
     }
@@ -309,7 +309,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::PERMANENT_REDIRECT));
+        assert_eq!(response.status(), Some(StatusCode::PERMANENT_REDIRECT));
         assert_eq!(
             response.headers().get(LOCATION),
             Some(&"https://public.example/".parse().unwrap())
@@ -325,7 +325,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::PERMANENT_REDIRECT));
+        assert_eq!(response.status(), Some(StatusCode::PERMANENT_REDIRECT));
         assert_eq!(
             response.headers().get(LOCATION),
             Some(&"https://public.example.com/".parse().unwrap())

--- a/crates/extra/src/logging.rs
+++ b/crates/extra/src/logging.rs
@@ -86,12 +86,12 @@ impl Handler for Logger {
             ctrl.call_next(req, depot, res).await;
             let duration = now.elapsed();
 
-            let status = res.status_code.unwrap_or(match &res.body {
+            let status = res.status().unwrap_or(match res.body_ref() {
                 ResBody::None => StatusCode::NOT_FOUND,
                 ResBody::Error(e) => e.code,
                 _ => StatusCode::OK,
             });
-            if let ResBody::Error(error) = &res.body {
+            if let ResBody::Error(error) = res.body_ref() {
                 tracing::info!(
                     %status,
                     ?duration,

--- a/crates/extra/src/request_id.rs
+++ b/crates/extra/src/request_id.rs
@@ -217,8 +217,8 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
-        assert!(response.headers.contains_key("x-request-id"));
+        assert_eq!(response.status(), Some(StatusCode::OK));
+        assert!(response.headers().contains_key("x-request-id"));
     }
 
     #[tokio::test]
@@ -231,8 +231,8 @@ mod tests {
             .add_header("x-request-id", "existing-id", true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
-        assert_ne!(response.headers.get("x-request-id").unwrap(), "existing-id");
+        assert_eq!(response.status(), Some(StatusCode::OK));
+        assert_ne!(response.headers().get("x-request-id").unwrap(), "existing-id");
     }
 
     #[tokio::test]
@@ -245,8 +245,8 @@ mod tests {
             .add_header("x-request-id", "existing-id", true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
-        assert_eq!(response.headers.get("x-request-id").unwrap(), "existing-id");
+        assert_eq!(response.status(), Some(StatusCode::OK));
+        assert_eq!(response.headers().get("x-request-id").unwrap(), "existing-id");
     }
 
     #[tokio::test]
@@ -258,8 +258,8 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
-        assert_eq!(response.headers.get("x-request-id").unwrap(), "custom-id");
+        assert_eq!(response.status(), Some(StatusCode::OK));
+        assert_eq!(response.headers().get("x-request-id").unwrap(), "custom-id");
     }
 
     #[tokio::test]
@@ -271,9 +271,9 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         let request_id = response
-            .headers
+            .headers()
             .get("x-request-id")
             .unwrap()
             .to_str()
@@ -300,9 +300,9 @@ mod tests {
         let mut response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         let header_id = response
-            .headers
+            .headers()
             .get("x-request-id")
             .unwrap()
             .to_str()

--- a/crates/extra/src/size_limiter.rs
+++ b/crates/extra/src/size_limiter.rs
@@ -183,7 +183,7 @@ mod tests {
             .text("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(res.status().unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[tokio::test]
@@ -203,7 +203,7 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(res.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(res.status().unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[test]

--- a/crates/extra/src/tower_compat.rs
+++ b/crates/extra/src/tower_compat.rs
@@ -198,7 +198,7 @@ impl Service<hyper::Request<ReqBody>> for FlowCtrlService {
             ctrl.call_next(&mut request, &mut depot, &mut response)
                 .await;
             response
-                .extensions
+                .extensions_mut()
                 .insert(Arc::new(FlowCtrlOutContext::new(ctrl, request, depot)));
             Ok(response.strip_to_hyper())
         })
@@ -421,7 +421,7 @@ mod tests {
             .send(NotReadyService.compat())
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::INTERNAL_SERVER_ERROR));
+        assert_eq!(response.status(), Some(StatusCode::INTERNAL_SERVER_ERROR));
         let ResBody::Error(error) = response.take_body() else {
             panic!("expected an error response body");
         };
@@ -435,7 +435,7 @@ mod tests {
             .send(FailingService.compat())
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::INTERNAL_SERVER_ERROR));
+        assert_eq!(response.status(), Some(StatusCode::INTERNAL_SERVER_ERROR));
         let ResBody::Error(error) = response.take_body() else {
             panic!("expected an error response body");
         };

--- a/crates/extra/src/trailing_slash.rs
+++ b/crates/extra/src/trailing_slash.rs
@@ -226,17 +226,17 @@ mod tests {
         let res = TestClient::get("http://127.0.0.1:8698/hello")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::MOVED_PERMANENTLY);
+        assert_eq!(res.status().unwrap(), StatusCode::MOVED_PERMANENTLY);
 
         let res = TestClient::get("http://127.0.0.1:8698/hello/")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let res = TestClient::get("http://127.0.0.1:8698/hello.world")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
     }
     #[tokio::test]
     async fn test_remove_slash() {
@@ -248,16 +248,16 @@ mod tests {
         let res = TestClient::get("http://127.0.0.1:8698/hello/")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
 
         let res = TestClient::get("http://127.0.0.1:8698/hello.world/")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status().unwrap(), StatusCode::TEMPORARY_REDIRECT);
 
         let res = TestClient::get("http://127.0.0.1:8698/hello.world")
             .send(&service)
             .await;
-        assert_eq!(res.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(res.status().unwrap(), StatusCode::OK);
     }
 }

--- a/crates/extra/src/websocket.rs
+++ b/crates/extra/src/websocket.rs
@@ -862,7 +862,7 @@ mod tests {
             .add_header(ORIGIN, "https://evil.example", true)
             .send(router)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::FORBIDDEN));
+        assert_eq!(response.status(), Some(StatusCode::FORBIDDEN));
         assert!(
             response
                 .take_string()
@@ -920,7 +920,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_eq!(response.status(), Some(StatusCode::BAD_REQUEST));
         assert!(
             response
                 .take_string()
@@ -941,7 +941,7 @@ mod tests {
             .send(router)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_eq!(response.status(), Some(StatusCode::BAD_REQUEST));
         assert!(
             response
                 .take_string()

--- a/crates/flash/src/lib.rs
+++ b/crates/flash/src/lib.rs
@@ -451,7 +451,7 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/set")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
+        assert_eq!(response.status(), Some(StatusCode::SEE_OTHER));
 
         let cookie = response.headers().get(SET_COOKIE).unwrap();
         assert!(cookie.to_str().unwrap().contains(&cookie_name));
@@ -493,7 +493,7 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/set")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
+        assert_eq!(response.status(), Some(StatusCode::SEE_OTHER));
 
         let cookie = response.headers().get(SET_COOKIE).unwrap();
 

--- a/crates/macros/src/handler.rs
+++ b/crates/macros/src/handler.rs
@@ -123,7 +123,7 @@ fn handle_fn(salvo: &Ident, sig: &Signature) -> syn::Result<TokenStream> {
                             Err(e) => {
                                 e.write(__macro_gen_req, __macro_gen_depot, __macro_gen_res).await;
                                 // If status code is not set or is not error, set it to 400.
-                                let status_code = __macro_gen_res.status_code.unwrap_or_default();
+                                let status_code = __macro_gen_res.status().unwrap_or_default();
                                 if !status_code.is_client_error() && !status_code.is_server_error() {
                                     __macro_gen_res.status_code(#salvo::http::StatusCode::BAD_REQUEST);
                                 }

--- a/crates/oapi-macros/src/endpoint.rs
+++ b/crates/oapi-macros/src/endpoint.rs
@@ -296,7 +296,7 @@ fn handle_fn(
                             Err(e) => {
                                 e.write(__macro_gen_req, __macro_gen_depot, __macro_gen_res).await;
                                 // If status code is not set or is not error, set it to 400.
-                                let status_code = __macro_gen_res.status_code.unwrap_or_default();
+                                let status_code = __macro_gen_res.status().unwrap_or_default();
                                 if !status_code.is_client_error() && !status_code.is_server_error() {
                                     __macro_gen_res.status_code(#salvo::http::StatusCode::BAD_REQUEST);
                                 }
@@ -381,7 +381,7 @@ mod tests {
                     Err(e) => {
                         e.write(__macro_gen_req, __macro_gen_depot, __macro_gen_res).await;
                         // If status code is not set or is not error, set it to 400.
-                        let status_code = __macro_gen_res.status_code.unwrap_or_default();
+                        let status_code = __macro_gen_res.status().unwrap_or_default();
                         if !status_code.is_client_error() && !status_code.is_server_error() {
                             __macro_gen_res.status_code(salvo::http::StatusCode::BAD_REQUEST);
                         }

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -1618,7 +1618,7 @@ mod tests {
         let mut ctrl = FlowCtrl::default();
         doc.handle(&mut req, &mut depot, &mut res, &mut ctrl).await;
 
-        let bytes = match res.body.take() {
+        let bytes = match res.take_body() {
             ResBody::Once(bytes) => bytes,
             _ => Bytes::new(),
         };
@@ -1650,7 +1650,7 @@ mod tests {
         let mut ctrl = FlowCtrl::default();
         doc.handle(&mut req, &mut depot, &mut res, &mut ctrl).await;
 
-        let bytes = match res.body.take() {
+        let bytes = match res.take_body() {
             ResBody::Once(bytes) => bytes,
             _ => Bytes::new(),
         };

--- a/crates/oapi/src/routing.rs
+++ b/crates/oapi/src/routing.rs
@@ -97,7 +97,7 @@ impl NormNode {
         let registry = METADATA_REGISTRY
             .read()
             .expect("failed to lock METADATA_REGISTRY for read");
-        if let Some(metadata) = registry.get(&router.id) {
+        if let Some(metadata) = registry.get(&router.id()) {
             node.metadata.tags.extend(metadata.tags.iter().cloned());
             node.metadata
                 .securities
@@ -145,8 +145,8 @@ impl NormNode {
                 _ => {}
             }
         }
-        node.handler_type_id = router.goal.as_ref().map(|h| h.type_id());
-        node.handler_type_name = router.goal.as_ref().map(|h| h.type_name());
+        node.handler_type_id = router.goal_ref().map(|h| h.type_id());
+        node.handler_type_name = router.goal_ref().map(|h| h.type_name());
         let routers = router.routers();
         if !routers.is_empty() {
             for router in routers {
@@ -198,7 +198,7 @@ impl RouterExt for Router {
         let mut guard = METADATA_REGISTRY
             .write()
             .expect("failed to lock METADATA_REGISTRY for write");
-        let metadata = guard.entry(self.id).or_default();
+        let metadata = guard.entry(self.id()).or_default();
         metadata.securities.push(security);
         self
     }
@@ -209,7 +209,7 @@ impl RouterExt for Router {
         let mut guard = METADATA_REGISTRY
             .write()
             .expect("failed to lock METADATA_REGISTRY for write");
-        let metadata = guard.entry(self.id).or_default();
+        let metadata = guard.entry(self.id()).or_default();
         metadata.securities.extend(iter);
         self
     }
@@ -217,7 +217,7 @@ impl RouterExt for Router {
         let mut guard = METADATA_REGISTRY
             .write()
             .expect("failed to lock METADATA_REGISTRY for write");
-        let metadata = guard.entry(self.id).or_default();
+        let metadata = guard.entry(self.id()).or_default();
         metadata.tags.insert(tag.into());
         self
     }
@@ -229,7 +229,7 @@ impl RouterExt for Router {
         let mut guard = METADATA_REGISTRY
             .write()
             .expect("failed to lock METADATA_REGISTRY for write");
-        let metadata = guard.entry(self.id).or_default();
+        let metadata = guard.entry(self.id()).or_default();
         metadata.tags.extend(iter.into_iter().map(Into::into));
         self
     }

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -65,7 +65,7 @@ impl Handler for Metrics {
         ctrl.call_next(req, depot, res).await;
         let elapsed = s.elapsed();
 
-        let status = res.status_code.unwrap_or_else(|| {
+        let status = res.status().unwrap_or_else(|| {
             tracing::info!("[otel::Metrics] Treat status_code=none as 200(OK)");
             StatusCode::OK
         });
@@ -75,7 +75,7 @@ impl Handler for Metrics {
         ));
         if status.is_client_error() || status.is_server_error() {
             self.error_count.add(1, &labels);
-            let msg = if let ResBody::Error(body) = &res.body {
+            let msg = if let ResBody::Error(body) = res.body_ref() {
                 body.to_string()
             } else {
                 format!("ErrorCode: {}", status.as_u16())

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -101,7 +101,7 @@ where
             let cx = Context::current();
             let span = cx.span();
 
-            let status = res.status_code.unwrap_or_else(|| {
+            let status = res.status().unwrap_or_else(|| {
                 tracing::info!("[otel::Tracing] Treat status_code=none as 200(OK)");
                 StatusCode::OK
             });

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -644,46 +644,46 @@ mod tests {
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
     }
 
@@ -724,46 +724,46 @@ mod tests {
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user1")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
         let response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::TOO_MANY_REQUESTS));
+        assert_eq!(response.status(), Some(StatusCode::TOO_MANY_REQUESTS));
 
         tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
 
         let mut response = TestClient::get("http://127.0.0.1:8698/limited?user=user2")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         assert_eq!(response.take_string().await.unwrap(), "Limited page");
     }
 
@@ -782,7 +782,7 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_eq!(response.status(), Some(StatusCode::BAD_REQUEST));
         assert!(
             response
                 .take_string()

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -163,22 +163,22 @@ where
 #[non_exhaustive]
 pub struct StaticDir {
     /// Static root directories to search for files
-    pub roots: Vec<PathBuf>,
+    pub(crate) roots: Vec<PathBuf>,
     /// Chunk size for file reading (in bytes)
-    pub chunk_size: Option<u64>,
+    pub(crate) chunk_size: Option<u64>,
     /// Small-file preload threshold for served files (in bytes)
-    pub preload_threshold: Option<u64>,
+    pub(crate) preload_threshold: Option<u64>,
     /// Whether to include dot files (files/directories starting with .)
-    pub include_dot_files: bool,
+    pub(crate) include_dot_files: bool,
     exclude_filters: Vec<Box<dyn Fn(&str) -> bool + Send + Sync>>,
     /// Whether to automatically list directories when default file isn't found
-    pub auto_list: bool,
+    pub(crate) auto_list: bool,
     /// Map of compression algorithms to file extensions for compressed variants
-    pub compressed_variations: HashMap<CompressionAlgo, Vec<String>>,
+    pub(crate) compressed_variations: HashMap<CompressionAlgo, Vec<String>>,
     /// Default file names to look for in directories (e.g., "index.html")
-    pub defaults: Vec<String>,
+    pub(crate) defaults: Vec<String>,
     /// Fallback file to serve when requested file isn't found
-    pub fallback: Option<String>,
+    pub(crate) fallback: Option<String>,
 }
 impl Debug for StaticDir {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -215,6 +215,66 @@ impl StaticDir {
             defaults: vec![],
             fallback: None,
         }
+    }
+
+    /// Gets the configured static root directories.
+    ///
+    /// The returned roots are read-only. Build a new `StaticDir` instead of
+    /// mutating roots after construction; future versions may cache derived root
+    /// metadata from this configuration.
+    #[inline]
+    #[must_use]
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
+    /// Gets the configured file chunk size.
+    #[inline]
+    #[must_use]
+    pub fn configured_chunk_size(&self) -> Option<u64> {
+        self.chunk_size
+    }
+
+    /// Gets the configured small-file preload threshold.
+    #[inline]
+    #[must_use]
+    pub fn configured_preload_threshold(&self) -> Option<u64> {
+        self.preload_threshold
+    }
+
+    /// Returns whether dot files are included.
+    #[inline]
+    #[must_use]
+    pub fn includes_dot_files(&self) -> bool {
+        self.include_dot_files
+    }
+
+    /// Returns whether automatic directory listings are enabled.
+    #[inline]
+    #[must_use]
+    pub fn auto_list_enabled(&self) -> bool {
+        self.auto_list
+    }
+
+    /// Gets compressed variant extension configuration.
+    #[inline]
+    #[must_use]
+    pub fn compressed_variations(&self) -> &HashMap<CompressionAlgo, Vec<String>> {
+        &self.compressed_variations
+    }
+
+    /// Gets default file names.
+    #[inline]
+    #[must_use]
+    pub fn default_files(&self) -> &[String] {
+        &self.defaults
+    }
+
+    /// Gets the fallback file path.
+    #[inline]
+    #[must_use]
+    pub fn fallback_file(&self) -> Option<&str> {
+        self.fallback.as_deref()
     }
 
     /// Sets include_dot_files.

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -175,12 +175,12 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:5801/link/secret.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_FOUND);
 
         let response = TestClient::get("http://127.0.0.1:5801/missing")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -201,13 +201,13 @@ mod tests {
         let mut response = TestClient::get("http://127.0.0.1:5801/test1.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(response.take_string().await.unwrap(), "copy1");
 
         let response = TestClient::get("http://127.0.0.1:5801/notexist.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -219,7 +219,7 @@ mod tests {
             .add_header("accept-encoding", "br;q=0.1, gzip;q=1", true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(
             response.headers().get(CONTENT_ENCODING),
             Some(&HeaderValue::from_static("gzip"))
@@ -237,7 +237,7 @@ mod tests {
             .add_header("accept-encoding", "br;q=1, gzip;q=0.1", true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(
             response.headers().get(CONTENT_ENCODING),
             Some(&HeaderValue::from_static("br"))
@@ -247,7 +247,7 @@ mod tests {
             .add_header("accept-encoding", "identity;q=1, gzip;q=0.5", true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(response.headers().get(CONTENT_ENCODING), None);
         let varies_on_accept_encoding = response
             .headers()
@@ -298,19 +298,19 @@ mod tests {
         let mut response = TestClient::get("http://127.0.0.1:5801/files/test1.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(response.take_string().await.unwrap(), "copy1");
 
         let mut response = TestClient::get("http://127.0.0.1:5801/dir/test1.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert_eq!(response.take_string().await.unwrap(), "copy1");
 
         let mut response = TestClient::get("http://127.0.0.1:5801/dir/test1111.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert!(
             response
                 .take_string()
@@ -322,31 +322,31 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:5801/dir")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
 
         let mut response = TestClient::get("http://127.0.0.1:5801/dir/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         assert!(response.take_string().await.unwrap().contains("Index page"));
 
         let response = TestClient::get("http://127.0.0.1:5801/dir2/")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_FOUND);
 
         let response = TestClient::get("http://127.0.0.1:5801/dir3/abc.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_FOUND);
 
         // A 200 response carries a quoted RFC 7232 ETag...
         let response = TestClient::get("http://127.0.0.1:5801/files/test1.txt")
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.status().unwrap(), StatusCode::OK);
         let etag = response
-            .headers
+            .headers()
             .get("etag")
             .expect("200 response should carry an ETag")
             .to_str()
@@ -360,9 +360,9 @@ mod tests {
             .add_header("if-none-match", &etag, true)
             .send(&service)
             .await;
-        assert_eq!(response.status_code.unwrap(), StatusCode::NOT_MODIFIED);
+        assert_eq!(response.status().unwrap(), StatusCode::NOT_MODIFIED);
         assert_eq!(
-            response.headers.get("etag").and_then(|v| v.to_str().ok()),
+            response.headers().get("etag").and_then(|v| v.to_str().ok()),
             Some(etag.as_str())
         );
     }

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -613,7 +613,7 @@ mod tests {
             .raw_form("username=salvo")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
+        assert_eq!(response.status(), Some(StatusCode::SEE_OTHER));
         let cookie = response.headers().get(SET_COOKIE).unwrap();
 
         let mut response = TestClient::get("http://127.0.0.1:8698/")
@@ -625,7 +625,7 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/logout")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::SEE_OTHER));
+        assert_eq!(response.status(), Some(StatusCode::SEE_OTHER));
 
         let mut response = TestClient::get("http://127.0.0.1:8698/")
             .send(&service)
@@ -932,7 +932,7 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/destroy")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
     }
 
     #[tokio::test]
@@ -1063,7 +1063,7 @@ mod tests {
         let response = TestClient::get("http://127.0.0.1:8698/nochange")
             .send(&service)
             .await;
-        assert_eq!(response.status_code, Some(StatusCode::OK));
+        assert_eq!(response.status(), Some(StatusCode::OK));
         // When save_unchanged is false and no data is modified, no cookie should be set
         // for a new session (unless there's existing session data)
     }

--- a/crates/tus/src/handlers/delete.rs
+++ b/crates/tus/src/handlers/delete.rs
@@ -14,7 +14,7 @@ async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
-    let headers = apply_common_headers(req, opts, &mut res.headers);
+    let headers = apply_common_headers(req, opts, res.headers_mut());
 
     if let Err(e) = check_tus_version(
         req.headers()
@@ -29,8 +29,9 @@ async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     }
 
     if !store.has_extension(Extension::Termination) {
-        res.status_code =
-            Some(TusError::Protocol(ProtocolError::UnsupportedTerminationExtension).status());
+        res.status_code(
+            TusError::Protocol(ProtocolError::UnsupportedTerminationExtension).status(),
+        );
         return;
     }
 
@@ -52,7 +53,7 @@ async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         Ok(lock) => lock,
         Err(e) => {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
     };
@@ -62,14 +63,14 @@ async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         && let (Some(size), Some(offset)) = (info.size, info.offset)
         && size == offset
     {
-        res.status_code = Some(StatusCode::FORBIDDEN);
+        res.status_code(StatusCode::FORBIDDEN);
         return;
     }
 
     match store.remove(&id).await {
-        Ok(_) => res.status_code = Some(StatusCode::NO_CONTENT),
-        Err(e) => res.status_code = Some(e.status()),
-    }
+        Ok(_) => res.status_code(StatusCode::NO_CONTENT),
+        Err(e) => res.status_code(e.status()),
+    };
 }
 
 pub(crate) fn delete_handler() -> Router {

--- a/crates/tus/src/handlers/get.rs
+++ b/crates/tus/src/handlers/get.rs
@@ -14,7 +14,7 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
-    let headers = apply_common_headers(req, opts, &mut res.headers);
+    let headers = apply_common_headers(req, opts, res.headers_mut());
 
     if let Err(e) = check_tus_version(
         req.headers()
@@ -47,7 +47,7 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         {
             Ok(lock) => lock,
             Err(e) => {
-                res.status_code = Some(e.status());
+                res.status_code(e.status());
                 return;
             }
         };
@@ -71,19 +71,18 @@ async fn get(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         {
             let expires = created_at.with_timezone(&chrono::Utc) + delta;
             if chrono::Utc::now() > expires {
-                res.status_code = Some(TusError::FileNoLongerExists.status());
+                res.status_code(TusError::FileNoLongerExists.status());
                 return;
             }
         }
 
         let Some(storage) = info.storage else {
-            res.status_code =
-                Some(TusError::Internal("upload storage info missing".into()).status());
+            res.status_code(TusError::Internal("upload storage info missing".into()).status());
             return;
         };
 
         if storage.type_name != "file" {
-            res.status_code = Some(
+            res.status_code(
                 TusError::Internal(format!("unsupported storage type: {}", storage.type_name))
                     .status(),
             );

--- a/crates/tus/src/handlers/head.rs
+++ b/crates/tus/src/handlers/head.rs
@@ -16,7 +16,7 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
-    let headers = apply_common_headers(req, opts, &mut res.headers);
+    apply_common_headers(req, opts, res.headers_mut());
 
     if let Err(e) = check_tus_version(
         req.headers()
@@ -24,7 +24,8 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             .and_then(|v| v.to_str().ok()),
     ) {
         if matches!(e, ProtocolError::UnsupportedTusVersion(_)) {
-            headers.insert(H_TUS_VERSION, HeaderValue::from_static(TUS_VERSION));
+            res.headers_mut()
+                .insert(H_TUS_VERSION, HeaderValue::from_static(TUS_VERSION));
         }
         res.status_code(TusError::Protocol(e).status());
         return;
@@ -48,7 +49,7 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         {
             Ok(lock) => lock,
             Err(e) => {
-                res.status_code = Some(e.status());
+                res.status_code(e.status());
                 return;
             }
         };
@@ -82,32 +83,36 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         let expires = created_at.with_timezone(&chrono::Utc) + delta;
         if chrono::Utc::now() > expires {
-            res.status_code = Some(TusError::FileNoLongerExists.status());
+            res.status_code(TusError::FileNoLongerExists.status());
             return;
         }
         expires_at = Some(expires);
     }
 
-    res.status_code = Some(StatusCode::OK);
+    res.status_code(StatusCode::OK);
 
     let Some(offset) = &upload_info.offset else {
-        res.status_code =
-            Some(TusError::Internal("Upload file's offset value not found!".into()).status());
+        res.status_code(
+            TusError::Internal("Upload file's offset value not found!".into()).status(),
+        );
         return;
     };
-    headers.insert("Upload-Offset", HeaderValue::from(*offset));
+    res.headers_mut()
+        .insert("Upload-Offset", HeaderValue::from(*offset));
 
     if upload_info.is_size_deferred() {
-        headers.insert("Upload-Defer-Length", HeaderValue::from_static("1"));
+        res.headers_mut()
+            .insert("Upload-Defer-Length", HeaderValue::from_static("1"));
     } else if let Some(size) = &upload_info.size {
-        headers.insert("Upload-Length", HeaderValue::from(*size));
+        res.headers_mut()
+            .insert("Upload-Length", HeaderValue::from(*size));
     }
 
     if let Some(metadata) = upload_info.metadata {
         if let Ok(v) = HeaderValue::from_str(&Metadata::stringify(metadata)) {
-            headers.insert("Upload-Metadata", v);
+            res.headers_mut().insert("Upload-Metadata", v);
         } else {
-            res.status_code = Some(
+            res.status_code(
                 TusError::Internal("Stored Upload-Metadata is not a valid header".into()).status(),
             );
             return;
@@ -122,7 +127,7 @@ async fn head(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         if !is_finished {
             let expires_value = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
             if let Ok(v) = HeaderValue::from_str(&expires_value) {
-                headers.insert(H_UPLOAD_EXPIRES, v);
+                res.headers_mut().insert(H_UPLOAD_EXPIRES, v);
             }
         }
     }

--- a/crates/tus/src/handlers/options.rs
+++ b/crates/tus/src/handlers/options.rs
@@ -17,7 +17,7 @@ async fn options(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let store = &state.store;
     let opts = &state.options;
     let max_size = opts.get_configured_max_size(req, None).await;
-    let headers = apply_options_headers(req, opts, &mut res.headers);
+    let headers = apply_options_headers(req, opts, res.headers_mut());
 
     headers.insert(H_TUS_VERSION, HeaderValue::from_static(TUS_VERSION));
     if let Some(ext_header) = Extension::to_header_value(&store.extensions()) {

--- a/crates/tus/src/handlers/patch.rs
+++ b/crates/tus/src/handlers/patch.rs
@@ -18,12 +18,12 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let opts = &state.options;
     let store = &state.store;
-    apply_common_headers(req, opts, &mut res.headers);
+    apply_common_headers(req, opts, res.headers_mut());
 
     let id = match opts.extract_file_id_from_request(req) {
         Ok(id) => id,
         Err(e) => {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
     };
@@ -35,10 +35,10 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             .and_then(|v| v.to_str().ok()),
     ) {
         if matches!(e, ProtocolError::UnsupportedTusVersion(_)) {
-            res.headers
+            res.headers_mut()
                 .insert(H_TUS_VERSION, HeaderValue::from_static(TUS_VERSION));
         }
-        res.status_code = Some(TusError::Protocol(e).status());
+        res.status_code(TusError::Protocol(e).status());
         return;
     }
 
@@ -48,7 +48,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         .get(H_CONTENT_TYPE)
         .and_then(|v| v.to_str().ok());
     if content_type != Some(CT_OFFSET_OCTET_STREAM) {
-        res.status_code = Some(TusError::Protocol(ProtocolError::InvalidContentType).status());
+        res.status_code(TusError::Protocol(ProtocolError::InvalidContentType).status());
         return;
     }
 
@@ -61,7 +61,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     ) {
         Ok(offset) => offset,
         Err(e) => {
-            res.status_code = Some(TusError::Protocol(e).status());
+            res.status_code(TusError::Protocol(e).status());
             return;
         }
     };
@@ -77,7 +77,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         Ok(lock) => lock,
         Err(e) => {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
     };
@@ -85,7 +85,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let mut already_uploaded_info = match store.get_upload_file_info(&id).await {
         Ok(info) => info,
         Err(e) => {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
     };
@@ -101,7 +101,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         let expires = created_at.with_timezone(&chrono::Utc) + delta;
         if chrono::Utc::now() > expires {
-            res.status_code = Some(TusError::FileNoLongerExists.status());
+            res.status_code(TusError::FileNoLongerExists.status());
             return;
         }
         expires_at = Some(expires);
@@ -118,7 +118,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     // TODO: Time handle
 
     let Some(uploaded_info_offset) = already_uploaded_info.offset else {
-        res.status_code = Some(TusError::InvalidOffset.status());
+        res.status_code(TusError::InvalidOffset.status());
         return;
     };
 
@@ -128,7 +128,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             offset,
             uploaded_info_offset
         );
-        res.status_code = Some(TusError::InvalidOffset.status());
+        res.status_code(TusError::InvalidOffset.status());
         return;
     }
 
@@ -137,40 +137,41 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             match parse_u64(Some(value), H_UPLOAD_LENGTH) {
                 Ok(size) => size,
                 Err(e) => {
-                    res.status_code = Some(TusError::Protocol(e).status());
+                    res.status_code(TusError::Protocol(e).status());
                     return;
                 }
             }
         } else {
-            res.status_code =
-                Some(TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status());
+            res.status_code(
+                TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status(),
+            );
             return;
         };
 
         if !store.has_extension(Extension::CreationDeferLength) {
-            res.status_code = Some(
+            res.status_code(
                 TusError::Protocol(ProtocolError::UnsupportedCreationDeferLengthExtension).status(),
             );
             return;
         }
         // Return if upload-length is already set.
         if already_uploaded_info.size.is_some() {
-            res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
+            res.status_code(TusError::Protocol(ProtocolError::InvalidLength).status());
             return;
         }
 
         if size < uploaded_info_offset {
-            res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
+            res.status_code(TusError::Protocol(ProtocolError::InvalidLength).status());
             return;
         }
 
         if max_file_size > 0 && size > max_file_size {
-            res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+            res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
             return;
         }
 
         if let Err(e) = store.declare_upload_length(&id, size).await {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
         already_uploaded_info.size = Some(size);
@@ -182,13 +183,14 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
                 match parse_u64(Some(v), H_CONTENT_LENGTH) {
                     Ok(size) => Some(size),
                     Err(e) => {
-                        res.status_code = Some(TusError::Protocol(e).status());
+                        res.status_code(TusError::Protocol(e).status());
                         return;
                     }
                 }
             } else {
-                res.status_code =
-                    Some(TusError::Protocol(ProtocolError::InvalidInt(H_CONTENT_LENGTH)).status());
+                res.status_code(
+                    TusError::Protocol(ProtocolError::InvalidInt(H_CONTENT_LENGTH)).status(),
+                );
                 return;
             }
         }
@@ -205,7 +207,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let remaining_u64_capacity = u64::MAX - offset;
     let max_write_size = match max_allowed {
         Some(max_allowed) if offset > max_allowed => {
-            res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+            res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
             return;
         }
         Some(max_allowed) => Some((max_allowed - offset).min(remaining_u64_capacity)),
@@ -214,11 +216,11 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
 
     if let Some(incoming) = content_length {
         let Some(end) = offset.checked_add(incoming) else {
-            res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+            res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
             return;
         };
         if max_allowed.is_some_and(|max_allowed| end > max_allowed) {
-            res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+            res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
             return;
         }
     }
@@ -235,13 +237,13 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         Ok(written) => written,
         Err(e) => {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         }
     };
 
     let Some(new_offset) = offset.checked_add(written) else {
-        res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+        res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
         return;
     };
 
@@ -254,7 +256,7 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         if !is_finished {
             let expires_value = expires_at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
             if let Ok(v) = HeaderValue::from_str(&expires_value) {
-                res.headers.insert(H_UPLOAD_EXPIRES, v);
+                res.headers_mut().insert(H_UPLOAD_EXPIRES, v);
             }
         }
     }
@@ -263,8 +265,8 @@ async fn patch(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     // It MUST include the Upload-Offset header containing the new offset.
     // The new offset MUST be the sum of the offset before the PATCH request and the number of bytes
     // received and processed or stored during the current PATCH request.
-    res.status_code = Some(StatusCode::NO_CONTENT);
-    res.headers
+    res.status_code(StatusCode::NO_CONTENT);
+    res.headers_mut()
         .insert(H_UPLOAD_OFFSET, HeaderValue::from(new_offset));
 }
 
@@ -398,7 +400,7 @@ mod tests {
             .await;
 
         assert_eq!(
-            response.status_code.unwrap(),
+            response.status().unwrap(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
         assert!(declare_called.load(Ordering::SeqCst));
@@ -433,7 +435,7 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(response.status_code.unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status().unwrap(), StatusCode::PAYLOAD_TOO_LARGE);
         assert!(!write_called.load(Ordering::SeqCst));
     }
 
@@ -465,7 +467,7 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(response.status_code.unwrap(), StatusCode::NO_CONTENT);
+        assert_eq!(response.status().unwrap(), StatusCode::NO_CONTENT);
         assert!(write_called.load(Ordering::SeqCst));
         assert_eq!(
             *write_limit.lock().expect("write limit lock"),

--- a/crates/tus/src/handlers/post.rs
+++ b/crates/tus/src/handlers/post.rs
@@ -22,25 +22,26 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let state = depot.get_typed::<Arc<Tus>>().expect("missing tus state");
     let store = &state.store;
     let opts = &state.options;
-    apply_common_headers(req, opts, &mut res.headers);
+    apply_common_headers(req, opts, res.headers_mut());
     if let Err(e) = check_tus_version(
         req.headers()
             .get(H_TUS_RESUMABLE)
             .and_then(|v| v.to_str().ok()),
     ) {
         if matches!(e, ProtocolError::UnsupportedTusVersion(_)) {
-            res.headers
+            res.headers_mut()
                 .insert(H_TUS_VERSION, HeaderValue::from_static(TUS_VERSION));
         }
-        res.status_code = Some(TusError::Protocol(e).status());
+        res.status_code(TusError::Protocol(e).status());
         return;
     }
 
     if req.headers().get(H_UPLOAD_CONCAT).is_some()
         && !store.has_extension(Extension::Concatenation)
     {
-        res.status_code =
-            Some(TusError::Protocol(ProtocolError::UnsupportedConcatenationExtension).status());
+        res.status_code(
+            TusError::Protocol(ProtocolError::UnsupportedConcatenationExtension).status(),
+        );
         return;
     }
 
@@ -49,7 +50,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let upload_metadata = req.headers().get(H_UPLOAD_METADATA);
 
     if upload_defer_length.is_some() && !store.has_extension(Extension::CreationDeferLength) {
-        res.status_code = Some(
+        res.status_code(
             TusError::Protocol(ProtocolError::UnsupportedCreationDeferLengthExtension).status(),
         );
         return;
@@ -58,13 +59,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     if let Some(value) = upload_defer_length
         && !matches!(value.to_str(), Ok("1"))
     {
-        res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
+        res.status_code(TusError::Protocol(ProtocolError::InvalidLength).status());
         return;
     }
 
     // Must provide either Upload-Length or Upload-Defer-Length, but not both or neither
     if upload_length.is_none() == upload_defer_length.is_none() {
-        res.status_code = Some(TusError::Protocol(ProtocolError::InvalidLength).status());
+        res.status_code(TusError::Protocol(ProtocolError::InvalidLength).status());
         return;
     }
 
@@ -75,13 +76,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     {
         Some(value) if value == CT_OFFSET_OCTET_STREAM => true,
         Some(_) => {
-            res.status_code = Some(TusError::Protocol(ProtocolError::InvalidContentType).status());
+            res.status_code(TusError::Protocol(ProtocolError::InvalidContentType).status());
             return;
         }
         None => false,
     };
     if creation_with_upload && !store.has_extension(Extension::CreationWithUpload) {
-        res.status_code = Some(
+        res.status_code(
             TusError::Protocol(ProtocolError::UnsupportedCreationWithUploadExtension).status(),
         );
         return;
@@ -99,7 +100,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         Ok(Some(m)) => Some(m),
         Ok(None) => None,
         Err(e) => {
-            res.status_code = Some(TusError::Protocol(e).status());
+            res.status_code(TusError::Protocol(e).status());
             return;
         }
     };
@@ -107,12 +108,12 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     let upload_id = match (opts.upload_id_naming_function)(req, metadata.clone()).await {
         Ok(id) => id,
         Err(err) => {
-            res.status_code = Some(err.status());
+            res.status_code(err.status());
             return;
         }
     };
     if !is_safe_upload_id(&upload_id) {
-        res.status_code = Some(TusError::FileIdError.status());
+        res.status_code(TusError::FileIdError.status());
         return;
     }
 
@@ -122,13 +123,14 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
                 match parse_u64(Some(v), H_UPLOAD_LENGTH) {
                     Ok(size) => Some(size),
                     Err(e) => {
-                        res.status_code = Some(TusError::Protocol(e).status());
+                        res.status_code(TusError::Protocol(e).status());
                         return;
                     }
                 }
             } else {
-                res.status_code =
-                    Some(TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status());
+                res.status_code(
+                    TusError::Protocol(ProtocolError::InvalidInt(H_UPLOAD_LENGTH)).status(),
+                );
                 return;
             }
         }
@@ -143,7 +145,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         && max_file_size > 0
         && size > max_file_size
     {
-        res.status_code = Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+        res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
         return;
     }
 
@@ -168,13 +170,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
                 }
             }
             Err(e) => {
-                res.status_code = Some(e.status());
+                res.status_code(e.status());
                 return;
             }
         }
     }
 
-    res.status_code = Some(StatusCode::CREATED);
+    res.status_code(StatusCode::CREATED);
 
     let is_final = {
         let _lock = match opts
@@ -183,13 +185,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         {
             Ok(lock) => lock,
             Err(e) => {
-                res.status_code = Some(e.status());
+                res.status_code(e.status());
                 return;
             }
         };
 
         if let Err(e) = store.create(upload.clone()).await {
-            res.status_code = Some(e.status());
+            res.status_code(e.status());
             return;
         };
 
@@ -200,12 +202,12 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
                         match parse_u64(Some(v), H_CONTENT_LENGTH) {
                             Ok(size) => Some(size),
                             Err(e) => {
-                                res.status_code = Some(TusError::Protocol(e).status());
+                                res.status_code(TusError::Protocol(e).status());
                                 return;
                             }
                         }
                     } else {
-                        res.status_code = Some(
+                        res.status_code(
                             TusError::Protocol(ProtocolError::InvalidInt(H_CONTENT_LENGTH))
                                 .status(),
                         );
@@ -225,8 +227,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             if let (Some(incoming), Some(max_allowed)) = (content_length, max_allowed)
                 && incoming > max_allowed
             {
-                res.status_code =
-                    Some(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
+                res.status_code(TusError::Protocol(ProtocolError::ErrMaxSizeExceeded).status());
                 return;
             }
 
@@ -238,13 +239,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             {
                 Ok(written) => written,
                 Err(e) => {
-                    res.status_code = Some(e.status());
+                    res.status_code(e.status());
                     return;
                 }
             };
 
             upload.offset = Some(written);
-            res.headers
+            res.headers_mut()
                 .insert(H_UPLOAD_OFFSET, HeaderValue::from(written));
         }
 
@@ -253,7 +254,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     };
 
     let Ok(url) = opts.generate_upload_url(req, &upload_id) else {
-        res.status_code = Some(TusError::GenerateUploadURLError.status());
+        res.status_code(TusError::GenerateUploadURLError.status());
         return;
     };
 
@@ -276,7 +277,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
             let expires = created_at.with_timezone(&chrono::Utc) + delta;
             let expires_value = expires.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
             if let Ok(v) = HeaderValue::from_str(&expires_value) {
-                res.headers.insert(H_UPLOAD_EXPIRES, v);
+                res.headers_mut().insert(H_UPLOAD_EXPIRES, v);
             }
         }
     }
@@ -285,27 +286,28 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         match on_upload_finish(req, upload.clone()).await {
             Ok(patch) => {
                 if let Some(status) = patch.status_code {
-                    res.status_code = Some(status);
+                    res.status_code(status);
                 }
                 if let Some(body) = patch.body
                     && res.write_body(body).is_err()
                 {
-                    res.status_code =
-                        Some(TusError::Internal("failed to write response body".into()).status());
+                    res.status_code(
+                        TusError::Internal("failed to write response body".into()).status(),
+                    );
                     return;
                 }
                 if let Some(headers) = patch.headers {
                     for (key, value) in headers {
                         if let Some(key) = key
-                            && !res.headers.contains_key(&key)
+                            && !res.headers().contains_key(&key)
                         {
-                            res.headers.insert(key, value);
+                            res.headers_mut().insert(key, value);
                         }
                     }
                 }
             }
             Err(e) => {
-                res.status_code = Some(e.status());
+                res.status_code(e.status());
                 return;
             }
         }
@@ -315,13 +317,13 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
     // expires. If expiration is known at creation time, Upload-Expires header MUST be included
     // in the response
 
-    let should_set_location = matches!(res.status_code, Some(StatusCode::CREATED))
-        || res.status_code.is_some_and(|s| s.is_redirection());
+    let should_set_location = matches!(res.status(), Some(StatusCode::CREATED))
+        || res.status().is_some_and(|s| s.is_redirection());
     if should_set_location {
         if let Ok(v) = HeaderValue::from_str(&url) {
-            res.headers.insert("Location", v);
+            res.headers_mut().insert("Location", v);
         } else {
-            res.status_code = Some(
+            res.status_code(
                 TusError::Internal("Generated upload URL is not a valid header value".into())
                     .status(),
             );
@@ -329,8 +331,8 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) {
         }
     }
 
-    if res.body.is_none() {
-        let status = res.status_code.unwrap_or(StatusCode::OK);
+    if res.body_ref().is_none() {
+        let status = res.status().unwrap_or(StatusCode::OK);
         if !status.is_client_error()
             && !status.is_server_error()
             && !status.is_redirection()

--- a/crates/tus/src/lib.rs
+++ b/crates/tus/src/lib.rs
@@ -794,7 +794,7 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(response.status_code.unwrap(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status().unwrap(), StatusCode::BAD_REQUEST);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make Router, Response, Service, and StaticDir internals crate-visible instead of publicly mutable
- add public accessors for response status/body/extensions, router ids/goals, service internals, and StaticDir configuration
- move downstream crates, macro expansions, and tests to the accessor APIs

## Verification
- cargo check --workspace --all-features
- cargo test --workspace --all-features --no-run