### PR TITLE
Bump Rust MSRV to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 version = "0.93.0"
 authors = ["chrislearn <chris@acroidea.com>"]
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.94"
 description = """
 Salvo is a powerful web framework that can make your work easier.
 """

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -24,7 +24,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,7 +24,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/acme/README.md
+++ b/crates/acme/README.md
@@ -22,7 +22,7 @@
 <a href="https://crates.io/crates/salvo"><img alt="crates.io" src="https://img.shields.io/crates/v/salvo" /></a>
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/cache/README.md
+++ b/crates/cache/README.md
@@ -22,7 +22,7 @@
 <a href="https://crates.io/crates/salvo"><img alt="crates.io" src="https://img.shields.io/crates/v/salvo" /></a>
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/compression/README.md
+++ b/crates/compression/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/compression/src/stream.rs
+++ b/crates/compression/src/stream.rs
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn encode_in_place_threshold_covers_json_chunks() {
-        assert!(MAX_CHUNK_SIZE_ENCODE_IN_PLACE >= 8 * 1024);
+        const _: () = assert!(MAX_CHUNK_SIZE_ENCODE_IN_PLACE >= 8 * 1024);
     }
 
     #[tokio::test]

--- a/crates/core/benches/router_detect.rs
+++ b/crates/core/benches/router_detect.rs
@@ -9,10 +9,9 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use salvo_core::Router;
-use salvo_core::handler;
 use salvo_core::routing::PathState;
 use salvo_core::test::TestClient;
+use salvo_core::{Router, handler};
 
 #[handler]
 async fn goal() -> &'static str {

--- a/crates/core/benches/service_dispatch.rs
+++ b/crates/core/benches/service_dispatch.rs
@@ -49,12 +49,14 @@ fn hoop_chain(c: &mut Criterion) {
 }
 
 fn dynamic_path(c: &mut Criterion) {
-    let service = Service::new(Router::new().push(
-        Router::with_path("users").push(
-            Router::with_path("{id}")
-                .push(Router::with_path("articles").push(Router::with_path("{aid}").get(hello))),
-        ),
-    ));
+    let service =
+        Service::new(Router::new().push(
+            Router::with_path("users").push(
+                Router::with_path("{id}").push(
+                    Router::with_path("articles").push(Router::with_path("{aid}").get(hello)),
+                ),
+            ),
+        ));
     bench_dispatch(
         c,
         "dispatch/dynamic_path",

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -112,10 +112,10 @@ impl Handler for SecureMaxSize {
 /// This can be configured using:
 ///
 /// - [`set_global_secure_max_size()`] - Set the process-wide fallback limit.
-/// - [`SecureMaxSize`] middleware - Set per-route limits without changing the
-///   fallback for unrelated routes.
-/// - [`set_secure_max_size()`](Request::set_secure_max_size) - Set per-request
-///   limits inside middleware or handlers.
+/// - [`SecureMaxSize`] middleware - Set per-route limits without changing the fallback for
+///   unrelated routes.
+/// - [`set_secure_max_size()`](Request::set_secure_max_size) - Set per-request limits inside
+///   middleware or handlers.
 ///
 /// **Note**: Size limits apply to request body reads and form parsing, including
 /// multipart file uploads. Increase the limit if you need to accept large uploads.

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -423,10 +423,10 @@ impl Router {
     /// Each method helper (`get`, `post`, ...) pushes a filtered **child** router;
     /// it does not set the goal of `self`. Two consequences worth knowing:
     ///
-    /// - `Router::with_path("x").get(a).post(b)` builds one path router with two
-    ///   method children — the usual pattern.
-    /// - `.get(a).get(b)` registers two **sibling** GET routes rather than
-    ///   replacing `a`; the first match wins, so `b` is unreachable.
+    /// - `Router::with_path("x").get(a).post(b)` builds one path router with two method children —
+    ///   the usual pattern.
+    /// - `.get(a).get(b)` registers two **sibling** GET routes rather than replacing `a`; the first
+    ///   match wins, so `b` is unreachable.
     ///
     /// [`MethodFilter`]: super::filters::MethodFilter
     #[inline]
@@ -638,7 +638,7 @@ mod tests {
             .get(fake_handler)
             .push(Router::with_path("{id}/profile").get(fake_handler));
         let mut req = TestClient::get("http://local.host/users").build();
-        let mut path_state = PathState::new(req.uri().path());
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
         assert!(path_state.params.is_empty());

--- a/crates/core/src/writing.rs
+++ b/crates/core/src/writing.rs
@@ -39,13 +39,12 @@ pub trait Writer {
 /// Each `Scribe` decides for itself how to interact with body bytes that were
 /// already written to the response — the framework does not impose one rule:
 ///
-/// - **Whole-document scribes replace.** [`Json`] emits one complete JSON
-///   document; two concatenated documents would be invalid, so rendering `Json`
-///   replaces any previously buffered body bytes.
-/// - **Incremental scribes append.** A scribe that adds a footer to a page, or
-///   emits one NDJSON record per call, should append via
-///   [`Response::write_body`] — concatenation *is* its output format. The
-///   text-like scribes (`&str`, `String`, [`Text`]) append for this reason.
+/// - **Whole-document scribes replace.** [`Json`] emits one complete JSON document; two
+///   concatenated documents would be invalid, so rendering `Json` replaces any previously buffered
+///   body bytes.
+/// - **Incremental scribes append.** A scribe that adds a footer to a page, or emits one NDJSON
+///   record per call, should append via [`Response::write_body`] — concatenation *is* its output
+///   format. The text-like scribes (`&str`, `String`, [`Text`]) append for this reason.
 ///
 /// When implementing your own `Scribe`, pick the semantics that make the final
 /// body valid in your format: use [`Response::write_body`] to append, or replace

--- a/crates/cors/README.md
+++ b/crates/cors/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/craft-macros/README.md
+++ b/crates/craft-macros/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/craft-macros/src/lib.rs
+++ b/crates/craft-macros/src/lib.rs
@@ -17,8 +17,8 @@ use syn::{Item, parse_macro_input};
 /// Apply `#[craft]` to an `impl` block, then mark individual methods with:
 ///
 /// - `#[craft(handler)]` for a regular Salvo handler.
-/// - `#[craft(endpoint(...))]` for a Salvo OpenAPI endpoint handler. The
-///   arguments are forwarded to `salvo_oapi::endpoint`.
+/// - `#[craft(endpoint(...))]` for a Salvo OpenAPI endpoint handler. The arguments are forwarded to
+///   `salvo_oapi::endpoint`.
 ///
 /// Each marked method is rewritten into a handler factory with the same method
 /// name. Calling that method returns a handler value suitable for
@@ -27,8 +27,8 @@ use syn::{Item, parse_macro_input};
 ///
 /// Supported receivers:
 ///
-/// - `&self`: clones the containing value into the generated handler, so the
-///   type must implement `Clone`.
+/// - `&self`: clones the containing value into the generated handler, so the type must implement
+///   `Clone`.
 /// - `self: Arc<Self>`: reuses the existing `Arc`.
 /// - no receiver: generates a static handler constructor.
 ///

--- a/crates/craft/README.md
+++ b/crates/craft/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/csrf/README.md
+++ b/crates/csrf/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/flash/README.md
+++ b/crates/flash/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -84,21 +84,20 @@ pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// Container attributes:
 ///
-/// - `#[salvo(extract(default_source(from = "query")))]` sets a fallback source
-///   for fields without an explicit source.
+/// - `#[salvo(extract(default_source(from = "query")))]` sets a fallback source for fields without
+///   an explicit source.
 /// - `from` accepts `param`, `query`, `header`, `body`, or `depot`.
 /// - `parse` accepts `smart`, `json`, or `multimap`.
-/// - `#[salvo(extract(rename_all = "camelCase"))]` renames fields with the same
-///   case rules used by serde.
+/// - `#[salvo(extract(rename_all = "camelCase"))]` renames fields with the same case rules used by
+///   serde.
 ///
 /// Field attributes:
 ///
-/// - `#[salvo(extract(source(from = "param")))]` reads a field from a specific
-///   request source.
+/// - `#[salvo(extract(source(from = "param")))]` reads a field from a specific request source.
 /// - `#[salvo(extract(rename = "userId"))]` overrides the request field name.
 /// - `#[salvo(extract(alias = "uid"))]` accepts an alternate field name.
-/// - `#[salvo(extract(flatten))]` flattens another `Extractible` struct into
-///   the same request metadata.
+/// - `#[salvo(extract(flatten))]` flattens another `Extractible` struct into the same request
+///   metadata.
 ///
 /// `#[serde(rename)]`, `#[serde(rename_all)]`, `#[serde(alias)]`, and serde
 /// defaults are honored where they map to Salvo extraction metadata.

--- a/crates/oapi-macros/README.md
+++ b/crates/oapi-macros/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/oapi/README.md
+++ b/crates/oapi/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -1380,7 +1380,10 @@ mod tests {
             );
         }
         // field plural alias honored: `raw` was renamed to `renamed`.
-        assert!(names.contains(&"renamed"), "field rename alias not applied: {names:?}");
+        assert!(
+            names.contains(&"renamed"),
+            "field rename alias not applied: {names:?}"
+        );
         assert!(!names.contains(&"raw"));
     }
 

--- a/crates/otel/README.md
+++ b/crates/otel/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/proxy/README.md
+++ b/crates/proxy/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/rate-limiter/README.md
+++ b/crates/rate-limiter/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/rate-limiter/src/lib.rs
+++ b/crates/rate-limiter/src/lib.rs
@@ -18,12 +18,12 @@
 //!
 //! ## Issuers
 //! - [`RemoteIpIssuer`]: Identifies clients by their direct connection IP
-//! - [`TrustedProxyIssuer`]: Honours `X-Forwarded-For` / `X-Real-IP` only when the request
-//!   actually arrived from a configured proxy IP. **This is the safe choice for deployments
-//!   behind a reverse proxy.**
+//! - [`TrustedProxyIssuer`]: Honours `X-Forwarded-For` / `X-Real-IP` only when the request actually
+//!   arrived from a configured proxy IP. **This is the safe choice for deployments behind a reverse
+//!   proxy.**
 //! - `ForwardedHeaderIssuer` (deprecated): Unconditionally trusts the forwarded headers, so a
-//!   client that reaches the application directly can spoof its IP and bypass rate limiting —
-//!   use [`TrustedProxyIssuer`] instead.
+//!   client that reaches the application directly can spoof its IP and bypass rate limiting — use
+//!   [`TrustedProxyIssuer`] instead.
 //!
 //! ## Guards (Algorithms)
 //! - `FixedGuard`: Fixed window algorithm (requires `fixed-guard` feature)

--- a/crates/serve-static/README.md
+++ b/crates/serve-static/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/session/README.md
+++ b/crates/session/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/crates/tus/README.md
+++ b/crates/tus/README.md
@@ -21,7 +21,7 @@
 <a href="https://docs.rs/salvo"><img alt="Documentation" src="https://docs.rs/salvo/badge.svg" /></a>
 <a href="https://crates.io/crates/salvo"><img alt="Download" src="https://img.shields.io/crates/d/salvo.svg" /></a>
 <a href="https://github.com/rust-secure-code/safety-dance/"><img alt="unsafe forbidden" src="https://img.shields.io/badge/unsafe-forbidden-success.svg" /></a>
-<a href="https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.92%2B-blue" /></a>
+<a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/"><img alt="Rust Version" src="https://img.shields.io/badge/rust-1.94%2B-blue" /></a>
 <br>
 <a href="https://salvo.rs">
     <img alt="Website" src="https://img.shields.io/badge/https-salvo.rs-%23f00" />

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 authors = ["chrislearn <chris@acroidea.com>"]
 edition = "2024"
 publish = false
-rust-version = "1.92"
+rust-version = "1.94"
 description = """
 Salvo is a powerful web framework that can make your work easier.
 """

--- a/examples/affix-state/src/main.rs
+++ b/examples/affix-state/src/main.rs
@@ -19,11 +19,11 @@ struct State {
 #[handler]
 async fn hello(depot: &mut Depot) -> String {
     // Obtain the Config instance from the depot
-    let config = depot.obtain::<Config>().unwrap();
+    let config = depot.get_typed::<Config>().unwrap();
     // Get custom data from the depot
     let custom_data = depot.get::<&str>("custom_data").unwrap();
     // Obtain the shared State instance from the depot
-    let state = depot.obtain::<Arc<State>>().unwrap();
+    let state = depot.get_typed::<Arc<State>>().unwrap();
     // Lock the fails vector and add a new fail message
     let mut fails_ref = state.fails.lock().unwrap();
     fails_ref.push("fail message".into());

--- a/examples/db-mysql-rbatis/src/main.rs
+++ b/examples/db-mysql-rbatis/src/main.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use rbatis::RBatis;
-use rbs::value;
 use rbdc_mysql::driver::MysqlDriver;
+use rbs::value;
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ pub struct User {
 }
 
 // Generate CRUD methods for User model
-rbatis::crud!(User{});
+rbatis::crud!(User {});
 
 // Handler for retrieving a user by ID from the database
 #[handler]
@@ -26,7 +26,7 @@ pub async fn get_user(req: &mut Request, res: &mut Response) {
     // Extract user ID from query parameters
     let uid = req.query::<i64>("uid").unwrap();
     // Execute select query and get user data
-    let data: Vec<User> = User::select_by_map(&*RB, value!{"id": uid}).await.unwrap();
+    let data: Vec<User> = User::select_by_map(&*RB, value! {"id": uid}).await.unwrap();
     let data = data.into_iter().next();
     println!("{data:?}");
     // Return user data as JSON response

--- a/examples/db-postgres-diesel/Dockerfile
+++ b/examples/db-postgres-diesel/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92 AS builder
+FROM rust:1.94 AS builder
 
 WORKDIR /app
 

--- a/examples/db-postgres-diesel/src/auth.rs
+++ b/examples/db-postgres-diesel/src/auth.rs
@@ -23,7 +23,7 @@ pub fn auth_user(
     println!("🔐 Call Authentication");
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     // ✅ Decode the JWT

--- a/examples/db-postgres-diesel/src/main.rs
+++ b/examples/db-postgres-diesel/src/main.rs
@@ -25,7 +25,7 @@ pub mod utils;
 )]
 pub async fn hello(name: QueryParam<String, false>, res: &mut Response, depot: &mut Depot) {
     println!("{:?}", name);
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut _conn = pool.get().expect("Failed to get DB connection");
     res.status_code(StatusCode::OK);
     res.render(format!("Hello, {}!", name.clone().unwrap()))

--- a/examples/db-postgres-diesel/src/routers/posts.rs
+++ b/examples/db-postgres-diesel/src/routers/posts.rs
@@ -22,7 +22,7 @@ use crate::schema::*;
 fn get_all_posts(res: &mut Response, authentication: HeaderParam<String, true>, depot: &mut Depot) {
     println!("🪪 Authentication header: {}", authentication.as_str());
 
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -52,7 +52,7 @@ fn create_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -98,7 +98,7 @@ fn update_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -170,7 +170,7 @@ fn delete_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -225,7 +225,7 @@ fn get_posts_information(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();

--- a/examples/db-postgres-diesel/src/routers/users.rs
+++ b/examples/db-postgres-diesel/src/routers/users.rs
@@ -26,7 +26,7 @@ fn get_all_users(res: &mut Response, authentication: HeaderParam<String, true>, 
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -58,7 +58,7 @@ fn get_all_users(res: &mut Response, authentication: HeaderParam<String, true>, 
 )]
 fn create_users(res: &mut Response, depot: &mut Depot, user_create: JsonBody<UserCreate>) {
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("❌ Failed to get DB connection");
 
     println!("📥 Create new user ...");
@@ -129,7 +129,7 @@ pub async fn get_users_information(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut _conn = pool.get().expect("❌ Failed to get DB connection");
 
     println!("📥 Fetching user information...");
@@ -168,7 +168,7 @@ fn update_users(
 
     let user_uuid = user_id.into_inner();
 
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -235,7 +235,7 @@ fn delete_users(
 ) {
     println!("🪪 Authentication header: {}", authentication.as_str());
 
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -294,7 +294,7 @@ fn get_posts_by_users(
 ) {
     println!("🪪 Authentication header: {}", authentication.as_str());
 
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("Failed to get DB connection");
 
     let current_user = depot.get::<User>("user").unwrap();
@@ -333,7 +333,7 @@ fn get_access_token(
     user_credentials: JsonBody<UserCredentials>,
     depot: &mut Depot,
 ) {
-    let pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     let mut conn = pool.get().expect("Failed to get DB connection");
 
     // ✅ Query user by ID

--- a/examples/db-postgres-sea-orm/migration/Cargo.toml
+++ b/examples/db-postgres-sea-orm/migration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "migration"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.94"
 publish = false
 
 [lib]

--- a/examples/db-postgres-sea-orm/src/auth.rs
+++ b/examples/db-postgres-sea-orm/src/auth.rs
@@ -23,7 +23,7 @@ pub async fn auth_user(
     println!("🔐 Call Authentication");
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
 
     let db = &**connection;
 

--- a/examples/db-postgres-sea-orm/src/db.rs
+++ b/examples/db-postgres-sea-orm/src/db.rs
@@ -9,8 +9,7 @@ pub async fn establish_connection_pool() -> DatabaseConnection {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let db: DatabaseConnection = Database::connect(database_url).await.unwrap();
-    return db;
+    Database::connect(database_url).await.unwrap()
 }
 
 pub async fn check(db: DatabaseConnection) {

--- a/examples/db-postgres-sea-orm/src/main.rs
+++ b/examples/db-postgres-sea-orm/src/main.rs
@@ -26,7 +26,7 @@ pub mod utils;
 )]
 pub async fn hello(name: QueryParam<String, false>, res: &mut Response, depot: &mut Depot) {
     println!("{:?}", name);
-    let _pool = depot.obtain::<Arc<DbPool>>().unwrap();
+    let _pool = depot.get_typed::<Arc<DbPool>>().unwrap();
     // let mut _conn = pool.get().expect("Failed to get DB connection");
     res.status_code(StatusCode::OK);
     res.render(format!("Hello, {}!", name.clone().unwrap()))

--- a/examples/db-postgres-sea-orm/src/routers/posts.rs
+++ b/examples/db-postgres-sea-orm/src/routers/posts.rs
@@ -28,7 +28,7 @@ async fn get_all_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -59,7 +59,7 @@ async fn create_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -73,7 +73,7 @@ async fn create_posts(
         id: Set(Uuid::new_v4()),
         content: Set(post_create.content.clone()),
         title: Set(post_create.title.clone()),
-        user_id: Set(current_user.id.clone()),
+        user_id: Set(current_user.id),
         created_at: Set(now),
         updated_at: Set(now),
     };
@@ -109,7 +109,7 @@ async fn update_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
 
@@ -118,7 +118,7 @@ async fn update_posts(
     let post_uuid = post_id.into_inner();
 
     let existing_post: Option<posts::Model> = Posts::find()
-        .filter(PostColumn::Id.eq(post_uuid.clone()))
+        .filter(PostColumn::Id.eq(post_uuid))
         .one(db)
         .await
         .expect("❌ Failed to query post");
@@ -137,7 +137,7 @@ async fn update_posts(
     if post.user_id != current_user.id {
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("You can delete the post that you don't create"),
+            detail: "You can delete the post that you don't create".to_owned(),
         }));
         return;
     }
@@ -154,11 +154,11 @@ async fn update_posts(
     if post.is_err() {
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("❌ Failed to update post"),
+            detail: "❌ Failed to update post".to_owned(),
         }));
     } else {
         let existing_post: Option<posts::Model> = Posts::find()
-            .filter(PostColumn::Id.eq(post_uuid.clone()))
+            .filter(PostColumn::Id.eq(post_uuid))
             .one(db)
             .await
             .expect("❌ Failed to query post");
@@ -183,7 +183,7 @@ async fn delete_posts(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -193,7 +193,7 @@ async fn delete_posts(
     let post_uuid = post_id.into_inner();
 
     let existing_post: Option<posts::Model> = Posts::find()
-        .filter(PostColumn::Id.eq(post_uuid.clone()))
+        .filter(PostColumn::Id.eq(post_uuid))
         .one(db)
         .await
         .expect("❌ Failed to query post");
@@ -211,7 +211,7 @@ async fn delete_posts(
     if post.user_id != current_user.id {
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("You can delete the post that you don't create"),
+            detail: "You can delete the post that you don't create".to_owned(),
         }));
         return;
     }
@@ -220,7 +220,7 @@ async fn delete_posts(
 
     if post_delete.is_err() {
         res.status_code(StatusCode::BAD_REQUEST);
-        res.render(format!("Error during the delete post"));
+        res.render("Error during the delete post".to_owned());
     } else {
         let post_result = post_delete.unwrap();
         println!(
@@ -247,7 +247,7 @@ async fn get_posts_information(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -273,7 +273,7 @@ async fn get_posts_information(
     if post.user_id != current_user.id {
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("You can delete the post that you don't create"),
+            detail: "You can delete the post that you don't create".to_owned(),
         }));
         return;
     }
@@ -282,7 +282,7 @@ async fn get_posts_information(
 }
 
 pub fn get_posts_router() -> Router {
-    let posts_router = Router::with_path("/posts")
+    Router::with_path("/posts")
         .hoop(auth_user)
         .get(get_all_posts)
         .post(create_posts)
@@ -291,6 +291,5 @@ pub fn get_posts_router() -> Router {
                 .get(get_posts_information)
                 .put(update_posts)
                 .delete(delete_posts),
-        );
-    posts_router
+        )
 }

--- a/examples/db-postgres-sea-orm/src/routers/users.rs
+++ b/examples/db-postgres-sea-orm/src/routers/users.rs
@@ -34,7 +34,7 @@ async fn get_all_users(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -49,8 +49,8 @@ async fn get_all_users(
             id: user.id,
             email: user.username.clone(),
             full_name: user.full_name.clone(),
-            created_at: user.created_at.clone(),
-            updated_at: user.updated_at.clone(),
+            created_at: user.created_at,
+            updated_at: user.updated_at,
         })
         .collect();
 
@@ -64,7 +64,7 @@ async fn get_all_users(
 )]
 async fn create_users(res: &mut Response, depot: &mut Depot, user_create: JsonBody<UserCreate>) {
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     println!("📥 Create new user ...");
@@ -85,7 +85,7 @@ async fn create_users(res: &mut Response, depot: &mut Depot, user_create: JsonBo
     }
 
     // ✅ Hash the password
-    let hashed = match hash_password(&user_create.password.clone().as_str()) {
+    let hashed = match hash_password(user_create.password.as_str()) {
         Ok(h) => h,
         Err(e) => {
             res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
@@ -137,7 +137,7 @@ pub async fn get_users_information(
     println!("🪪 Authentication header: {}", authentication.as_str());
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let _db = &**connection;
 
     println!("📥 Fetching user information...");
@@ -148,11 +148,11 @@ pub async fn get_users_information(
 
     // ✅ Build response model
     let user_response_model = UserResponseModel {
-        id: current_user.id.clone(),
+        id: current_user.id,
         email: current_user.username.clone(), // or change field if you have separate email
         full_name: current_user.full_name.clone(),
-        created_at: current_user.created_at.clone(),
-        updated_at: current_user.created_at.clone(),
+        created_at: current_user.created_at,
+        updated_at: current_user.created_at,
     };
 
     // ✅ Send JSON response
@@ -177,7 +177,7 @@ async fn update_users(
     let user_uuid = user_id.into_inner();
 
     // ✅ Get DB connection
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -237,7 +237,7 @@ async fn delete_users(
 ) {
     println!("🪪 Authentication header: {}", authentication.as_str());
 
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -284,8 +284,8 @@ async fn delete_users(
                 id: current_user.id,
                 email: current_user.username.clone(),
                 full_name: current_user.full_name.clone(),
-                created_at: current_user.created_at.clone(),
-                updated_at: current_user.updated_at.clone(),
+                created_at: current_user.created_at,
+                updated_at: current_user.updated_at,
             }));
         }
     }
@@ -304,7 +304,7 @@ async fn get_posts_by_users(
 ) {
     println!("🪪 Authentication header: {}", authentication.as_str());
 
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
 
     let current_user: &users::Model = depot.get::<users::Model>("user").unwrap();
@@ -325,7 +325,7 @@ async fn get_posts_by_users(
     println!("👤 Current user: {:?}", current_user);
 
     let all_posts: Vec<posts::Model> = Posts::find()
-        .filter(PostColumn::UserId.eq(current_user.id.clone()))
+        .filter(PostColumn::UserId.eq(current_user.id))
         .all(db)
         .await
         .expect("Error to loading posts");
@@ -344,7 +344,7 @@ async fn get_access_token(
     user_credentials: JsonBody<UserCredentials>,
     depot: &mut Depot,
 ) {
-    let connection = depot.obtain::<Arc<DbPool>>().unwrap();
+    let connection = depot.get_typed::<Arc<DbPool>>().unwrap();
     let db = &**connection;
     // ✅ Query user by ID
 
@@ -359,19 +359,16 @@ async fn get_access_token(
         print!("no existing users");
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("🚫 Invalid username or password"),
+            detail: "🚫 Invalid username or password".to_owned(),
         }));
         return;
     };
 
-    if !verify_password(
-        &user_credentials.password.clone().as_str(),
-        &user.password.clone().as_str(),
-    ) {
+    if !verify_password(user_credentials.password.as_str(), user.password.as_str()) {
         println!("🚫 Bad password");
         res.status_code(StatusCode::BAD_REQUEST);
         res.render(Json(ErrorResponseModel {
-            detail: format!("🚫 Invalid username or password"),
+            detail: "🚫 Invalid username or password".to_owned(),
         }));
         return;
     }
@@ -390,7 +387,7 @@ async fn get_access_token(
     res.status_code(StatusCode::OK);
     res.render(Json(TokenResponseModel {
         token_type: String::from("Bearer"),
-        token: String::from(token.unwrap()),
+        token: token.unwrap(),
     }));
 }
 

--- a/examples/db-postgres-sea-orm/src/tests/endpoints_test.rs
+++ b/examples/db-postgres-sea-orm/src/tests/endpoints_test.rs
@@ -36,15 +36,13 @@ pub async fn route() -> Router {
         .allow_headers("authentication")
         .into_handler();
 
-    let router = Router::new()
+    Router::new()
         .hoop(cors)
         .hoop(affix_state::inject(connection))
         .get(hello_world)
         .push(Router::with_path("hello").get(hello))
         .push(get_users_router())
-        .push(get_users_router());
-
-    router
+        .push(get_users_router())
 }
 
 pub fn service(router: Router) -> Service {

--- a/examples/db-sea-orm/src/main.rs
+++ b/examples/db-sea-orm/src/main.rs
@@ -28,7 +28,7 @@ struct AppState {
 #[handler]
 async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) -> Result<()> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     // Parse form data into post model
     let form = req
@@ -53,7 +53,7 @@ async fn create(req: &mut Request, depot: &mut Depot, res: &mut Response) -> Res
 #[handler]
 async fn list(req: &mut Request, depot: &mut Depot) -> Result<Text<String>> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     // Get pagination parameters from query
     let page = req.query("page").unwrap_or(1);
@@ -96,7 +96,7 @@ async fn list(req: &mut Request, depot: &mut Depot) -> Result<Text<String>> {
 #[handler]
 async fn new(depot: &mut Depot) -> Result<Text<String>> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     let ctx = tera::Context::new();
     let body = state
@@ -110,7 +110,7 @@ async fn new(depot: &mut Depot) -> Result<Text<String>> {
 #[handler]
 async fn edit(req: &mut Request, depot: &mut Depot) -> Result<Text<String>> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     // Get post ID from path parameters
     let id = req.param::<i32>("id").unwrap_or_default();
@@ -136,7 +136,7 @@ async fn edit(req: &mut Request, depot: &mut Depot) -> Result<Text<String>> {
 #[handler]
 async fn update(req: &mut Request, depot: &mut Depot, res: &mut Response) -> Result<()> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     // Get post ID and form data
     let id = req.param::<i32>("id").unwrap_or_default();
@@ -162,7 +162,7 @@ async fn update(req: &mut Request, depot: &mut Depot, res: &mut Response) -> Res
 #[handler]
 async fn delete(req: &mut Request, depot: &mut Depot, res: &mut Response) -> Result<()> {
     let state = depot
-        .obtain::<AppState>()
+        .get_typed::<AppState>()
         .map_err(|_| StatusError::internal_server_error())?;
     // Get post ID and find post
     let id = req.param::<i32>("id").unwrap_or_default();

--- a/examples/oapi-generics/src/main.rs
+++ b/examples/oapi-generics/src/main.rs
@@ -20,7 +20,8 @@ struct CityDTO {
 
 /// Generic response wrapper with custom name.
 /// When instantiated as `Response<CityDTO>`, it becomes `Response<City>` in the schema.
-/// When instantiated as `Response<String>`, it becomes `Response<String>` (primitive types are shortened).
+/// When instantiated as `Response<String>`, it becomes `Response<String>` (primitive types are
+/// shortened).
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
 #[salvo(schema(name = Response))]
 struct ApiResponse<T: ToSchema + std::fmt::Debug + 'static> {

--- a/examples/otel-jaeger/src/server1.rs
+++ b/examples/otel-jaeger/src/server1.rs
@@ -25,7 +25,7 @@ fn init_tracer_provider() -> SdkTracerProvider {
 
 #[handler]
 async fn index(req: &mut Request, depot: &mut Depot) -> String {
-    let tracer = depot.obtain::<Arc<Tracer>>().unwrap();
+    let tracer = depot.get_typed::<Arc<Tracer>>().unwrap();
     let span = tracer
         .span_builder("request/server2")
         .with_kind(SpanKind::Client)

--- a/examples/todos-utoipa/src/main.rs
+++ b/examples/todos-utoipa/src/main.rs
@@ -89,7 +89,7 @@ pub async fn openapi_json(res: &mut Response) {
 
 #[handler]
 pub async fn serve_swagger(req: &mut Request, depot: &mut Depot, res: &mut Response) {
-    let config = depot.obtain::<Arc<Config>>().unwrap();
+    let config = depot.get_typed::<Arc<Config>>().unwrap();
     let path = req.uri().path();
     let tail = path.strip_prefix("/swagger-ui/").unwrap();
 

--- a/examples/unix-socket/Cargo.toml
+++ b/examples/unix-socket/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 
+[features]
+unix = ["salvo/unix"]
+
 [dependencies]
 salvo = { workspace = true, features = ["serve-static"] }
 tokio = { workspace = true, features = ["macros"] }

--- a/examples/unix-socket/src/main.rs
+++ b/examples/unix-socket/src/main.rs
@@ -11,5 +11,7 @@ async fn main() {
 #[cfg(not(all(feature = "unix", unix)))]
 #[tokio::main]
 async fn main() {
-    println!("This example requires the 'unix' feature and must be run on a Unix system (Linux, macOS, BSD)");
+    println!(
+        "This example requires the 'unix' feature and must be run on a Unix system (Linux, macOS, BSD)"
+    );
 }


### PR DESCRIPTION
## Summary

- Raise the workspace and examples MSRV metadata from Rust 1.92 to 1.94.
- Update README Rust version badges to the Rust 1.94.0 release announcement.
- Align example Docker/tooling metadata and clean up formatting plus clippy warnings exposed by the stricter validation run.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly fmt --all -- --check` in `examples/`
- `cargo +1.94.0 check --all --bins --examples --tests`
- `cargo +1.94.0 clippy --all --bins --examples --tests -- -D warnings`
- `cargo +1.94.0 check --all --bins --examples --tests` in `examples/`
- `cargo +1.94.0 clippy --all --bins --examples --tests -- -D warnings` in `examples/`
- `git diff --check`
