### PR TITLE
Add deprecated StatusError aliases

### DIFF
--- a/crates/core/src/http/errors/status_error.rs
+++ b/crates/core/src/http/errors/status_error.rs
@@ -220,6 +220,26 @@ impl StatusError {
         /// [[RFC6585](https://tools.ietf.org/html/rfc6585)]
         network_authentication_required,    StatusCode::NETWORK_AUTHENTICATION_REQUIRED, "Network Authentication Required", "the client needs to authenticate to gain network access."
     }
+
+    /// Deprecated alias for [`Self::request_header_fields_too_large`].
+    #[must_use]
+    #[deprecated(
+        since = "0.94.0",
+        note = "use `StatusError::request_header_fields_too_large` instead"
+    )]
+    pub fn request_header_fields_toolarge() -> StatusError {
+        Self::request_header_fields_too_large()
+    }
+
+    /// Deprecated alias for [`Self::unavailable_for_legal_reasons`].
+    #[must_use]
+    #[deprecated(
+        since = "0.94.0",
+        note = "use `StatusError::unavailable_for_legal_reasons` instead"
+    )]
+    pub fn unavailable_for_legalreasons() -> StatusError {
+        Self::unavailable_for_legal_reasons()
+    }
 }
 
 impl StdError for StatusError {
@@ -342,5 +362,18 @@ mod tests {
         assert_eq!(source.to_string(), "disk offline");
 
         assert!(StatusError::internal_server_error().source().is_none());
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn legacy_status_error_aliases_match_new_names() {
+        assert_eq!(
+            StatusError::request_header_fields_toolarge().code,
+            StatusError::request_header_fields_too_large().code
+        );
+        assert_eq!(
+            StatusError::unavailable_for_legalreasons().code,
+            StatusError::unavailable_for_legal_reasons().code
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add deprecated `StatusError` aliases for the old `request_header_fields_toolarge` and `unavailable_for_legalreasons` spellings.
- Keep current `main` APIs unchanged; no `StraightStream::new` rename/signature shim and no fuse compatibility layer.

## Notes

Compared current `main` against the latest release tag, `v0.93.0`. Several remaining semver findings are intentionally outside this PR, including fuse removals and API shape changes where a deprecated overload would require changing the current API.

## Validation

- `cargo check -p salvo_core`
- `cargo test -p salvo_core legacy_status_error_aliases_match_new_names`
- `cargo semver-checks check-release --manifest-path crates/core/Cargo.toml --baseline-rev v0.93.0 --default-features` (expected remaining failures outside this shim set)