### PR TITLE
Clarify form_data size-limit docs for FilePart

### DIFF
--- a/crates/core/src/http/form.rs
+++ b/crates/core/src/http/form.rs
@@ -183,15 +183,21 @@ impl FilePart {
     /// # Security
     ///
     /// This streams the entire field to a temporary file with **no size limit
-    /// of its own** — it writes until the field ends. Reached through
-    /// [`Request::form_data`](crate::http::Request::form_data) the body is
-    /// already bounded by the request's secure-max-size limit (configurable via
+    /// of its own** — it writes until the field ends. When the body is read for
+    /// the first time through
+    /// [`Request::form_data`](crate::http::Request::form_data) it is bounded by
+    /// the request's secure-max-size limit (configurable via
     /// [`Request::set_secure_max_size`](crate::http::Request::set_secure_max_size),
     /// the [`set_global_secure_max_size`](crate::http::request::set_global_secure_max_size)
-    /// default, or the `SecureMaxSize` middleware). If you instead call this
-    /// directly on an otherwise unbounded `Field`, a client can fill the
-    /// temporary directory's disk (denial of service), so bound the request
-    /// body yourself first.
+    /// default, or the `SecureMaxSize` middleware).
+    ///
+    /// That guarantee only covers the **first** read of the body: if the body
+    /// was already consumed and cached by an earlier `payload`/`payload_with_max_size`
+    /// call (possibly under a larger limit or none), `form_data` reuses the
+    /// cached payload without re-applying the limit. In that case, or when
+    /// calling `create` directly on an otherwise unbounded `Field`, a client can
+    /// fill the temporary directory's disk (denial of service), so make sure the
+    /// request body is bounded before the first read.
     pub async fn create(field: &mut Field<'_>) -> Result<Self, ParseError> {
         // Setup a file to capture the contents.
         // Map the `JoinError` to a `ParseError` instead of panicking, so a


### PR DESCRIPTION
## What

Clarifies the `FilePart::create` security docs around `Request::form_data` size limits.

The secure max-size limit applies when `form_data` performs the first body read. If an earlier `payload` or `payload_with_max_size` call already cached the body under a larger limit or no limit, `form_data` reuses those cached bytes and does not re-apply the smaller form limit.

## Why

The existing wording says the `form_data` path is already bounded, which is too broad for handlers or middleware that read and cache the body before form parsing.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo doc -p salvo_core --no-deps` passed with pre-existing rustdoc warnings in `crates/core/src/conn.rs` and `crates/core/src/routing/path_params.rs`.
- Attempted strict `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p salvo_core --no-deps`; it failed on pre-existing optional TLS/QUIC links in `crates/core/src/conn.rs`, unrelated to this change.