### PR TITLE
Resolve duplicate Vary header and improve HEAD request preformance for `StaticDir`

### DIFF
--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -72,9 +72,9 @@ use std::sync::LazyLock;
 use indexmap::IndexMap;
 use salvo_core::http::body::ResBody;
 use salvo_core::http::header::{
-    ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, VARY,
+    ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue,
 };
-use salvo_core::http::{self, Mime, StatusCode, mime};
+use salvo_core::http::{self, Mime, StatusCode, append_vary_header, mime};
 use salvo_core::{Depot, FlowCtrl, Handler, Request, Response, async_trait};
 
 mod encoder;
@@ -520,13 +520,13 @@ impl Handler for Compression {
             }
         }
         res.headers_mut().remove(CONTENT_LENGTH);
-        res.headers_mut()
-            .append(VARY, HeaderValue::from_static("accept-encoding"));
+        append_vary_header(res.headers_mut(), "accept-encoding");
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use salvo_core::http::header::VARY;
     use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
@@ -758,6 +758,36 @@ mod tests {
             .await;
         let count = res.headers().get_all(CONTENT_ENCODING).iter().count();
         assert_eq!(count, 1, "must have exactly one Content-Encoding header");
+    }
+
+    #[tokio::test]
+    async fn test_vary_accept_encoding_is_not_duplicated() {
+        #[handler]
+        async fn hello_with_vary(res: &mut Response) {
+            res.headers_mut()
+                .insert(VARY, HeaderValue::from_static("Accept-Encoding"));
+            res.render(Text::Plain("hello"));
+        }
+
+        let comp_handler = Compression::new().min_length(1);
+        let router =
+            Router::with_hoop(comp_handler).push(Router::with_path("hello").get(hello_with_vary));
+
+        let res = TestClient::get("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(router)
+            .await;
+
+        assert_eq!(res.headers().get(CONTENT_ENCODING).unwrap(), "gzip");
+        let vary_accept_encoding_count = res
+            .headers()
+            .get_all(VARY)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .filter(|value| value.trim().eq_ignore_ascii_case("accept-encoding"))
+            .count();
+        assert_eq!(vary_accept_encoding_count, 1);
     }
 
     #[tokio::test]

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -331,8 +331,8 @@ impl Compression {
     /// Sets minimum compression size, if body is less than this value, no compression.
     /// Default is 1kb.
     ///
-    /// Only effective for bodies with a known length (`Once`/`Chunks`); streaming
-    /// bodies (`Hyper`/`Stream`) are always compressed regardless of this value.
+    /// Streaming bodies with an explicit `Content-Length` also respect this threshold. Streaming
+    /// bodies with an unknown length are always compressed.
     #[inline]
     #[must_use]
     pub fn min_length(mut self, size: usize) -> Self {
@@ -353,6 +353,19 @@ impl Compression {
     pub fn content_types(mut self, content_types: &[Mime]) -> Self {
         self.content_types = content_types.to_vec();
         self
+    }
+
+    fn content_length_is_below_minimum(&self, res: &Response) -> bool {
+        if self.min_length == 0 {
+            return false;
+        }
+        let Some(ContentLength(length)) = res.headers().typed_get::<ContentLength>() else {
+            return false;
+        };
+        match u64::try_from(self.min_length) {
+            Ok(min_length) => length < min_length,
+            Err(_) => true,
+        }
     }
 
     fn negotiate(
@@ -474,6 +487,9 @@ impl Handler for Compression {
                 if res.headers().typed_get::<ContentLength>().is_none() {
                     return;
                 }
+                if self.content_length_is_below_minimum(res) {
+                    return;
+                }
                 if let Some((algo, _level)) = self.negotiate(req, res) {
                     res.headers_mut().insert(CONTENT_ENCODING, algo.into());
                 } else {
@@ -510,6 +526,10 @@ impl Handler for Compression {
                 }
             }
             ResBody::Hyper(body) => {
+                if self.content_length_is_below_minimum(res) {
+                    res.body(ResBody::Hyper(body));
+                    return;
+                }
                 if let Some((algo, level)) = self.negotiate(req, res) {
                     res.stream(EncodeStream::new(algo, level, body));
                     res.headers_mut().insert(CONTENT_ENCODING, algo.into());
@@ -520,6 +540,10 @@ impl Handler for Compression {
             }
             ResBody::Stream(body) => {
                 let body = body.into_inner();
+                if self.content_length_is_below_minimum(res) {
+                    res.body(ResBody::stream(body));
+                    return;
+                }
                 if let Some((algo, level)) = self.negotiate(req, res) {
                     res.stream(EncodeStream::new(algo, level, body));
                     res.headers_mut().insert(CONTENT_ENCODING, algo.into());
@@ -805,7 +829,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_head_preserves_streamed_get_compression_headers_below_min_length() {
+    async fn test_head_matches_streamed_get_compression_threshold() {
         #[handler]
         async fn hello_stream(res: &mut Response) {
             res.status_code(StatusCode::OK);
@@ -827,12 +851,79 @@ mod tests {
                 .insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
         }
 
-        let comp_handler = Compression::new().min_length(10);
-        let router = Router::with_hoop(comp_handler).push(
+        let compressed_router = Router::with_hoop(Compression::new().min_length(1)).push(
             Router::with_path("hello")
                 .get(hello_stream)
                 .head(hello_head),
         );
+        let compressed_service = Service::new(compressed_router);
+
+        let compressed_get = TestClient::get("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&compressed_service)
+            .await;
+        let mut compressed_head = TestClient::head("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&compressed_service)
+            .await;
+
+        assert_eq!(
+            compressed_get.headers().get(CONTENT_ENCODING).unwrap(),
+            "gzip"
+        );
+        assert_eq!(
+            compressed_head.headers().get(CONTENT_ENCODING),
+            compressed_get.headers().get(CONTENT_ENCODING)
+        );
+        assert_eq!(
+            compressed_head.headers().get(VARY),
+            compressed_get.headers().get(VARY)
+        );
+        assert!(compressed_head.headers().get(CONTENT_LENGTH).is_none());
+        assert_eq!(compressed_head.take_string().await.unwrap(), "");
+
+        let uncompressed_router = Router::with_hoop(Compression::new().min_length(10)).push(
+            Router::with_path("hello")
+                .get(hello_stream)
+                .head(hello_head),
+        );
+        let uncompressed_service = Service::new(uncompressed_router);
+
+        let uncompressed_get = TestClient::get("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&uncompressed_service)
+            .await;
+        let mut uncompressed_head = TestClient::head("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&uncompressed_service)
+            .await;
+
+        assert!(uncompressed_get.headers().get(CONTENT_ENCODING).is_none());
+        assert!(uncompressed_head.headers().get(CONTENT_ENCODING).is_none());
+        assert_eq!(
+            uncompressed_head.headers().get(VARY),
+            uncompressed_get.headers().get(VARY)
+        );
+        assert_eq!(
+            uncompressed_head.headers().get(CONTENT_LENGTH),
+            uncompressed_get.headers().get(CONTENT_LENGTH)
+        );
+        assert_eq!(uncompressed_head.take_string().await.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_head_matches_buffered_get_below_min_length() {
+        #[handler]
+        async fn hello_head(res: &mut Response) {
+            res.status_code(StatusCode::OK);
+            res.headers_mut()
+                .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+            res.headers_mut()
+                .insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
+        }
+
+        let router = Router::with_hoop(Compression::new().min_length(10))
+            .push(Router::with_path("hello").get(hello).head(hello_head));
         let service = Service::new(router);
 
         let get = TestClient::get("http://127.0.0.1:5801/hello")
@@ -844,13 +935,10 @@ mod tests {
             .send(&service)
             .await;
 
-        assert_eq!(get.headers().get(CONTENT_ENCODING).unwrap(), "gzip");
-        assert_eq!(
-            head.headers().get(CONTENT_ENCODING),
-            get.headers().get(CONTENT_ENCODING)
-        );
+        assert!(get.headers().get(CONTENT_ENCODING).is_none());
+        assert!(head.headers().get(CONTENT_ENCODING).is_none());
         assert_eq!(head.headers().get(VARY), get.headers().get(VARY));
-        assert!(head.headers().get(CONTENT_LENGTH).is_none());
+        assert_eq!(head.headers().get(CONTENT_LENGTH).unwrap(), "5");
         assert_eq!(head.take_string().await.unwrap(), "");
     }
 

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -74,6 +74,7 @@ use salvo_core::http::body::ResBody;
 use salvo_core::http::header::{
     ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue,
 };
+use salvo_core::http::headers::{ContentLength, HeaderMapExt};
 use salvo_core::http::{self, Method, Mime, StatusCode, append_vary_header, mime};
 use salvo_core::{Depot, FlowCtrl, Handler, Request, Response, async_trait};
 
@@ -470,15 +471,7 @@ impl Handler for Compression {
                 if req.method() != Method::HEAD {
                     return;
                 }
-                let Some(length) = res
-                    .headers()
-                    .get(CONTENT_LENGTH)
-                    .and_then(|value| value.to_str().ok())
-                    .and_then(|value| value.parse::<usize>().ok())
-                else {
-                    return;
-                };
-                if self.min_length > 0 && length < self.min_length {
+                if res.headers().typed_get::<ContentLength>().is_none() {
                     return;
                 }
                 if let Some((algo, _level)) = self.negotiate(req, res) {
@@ -812,7 +805,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_head_preserves_get_compression_headers_without_body() {
+    async fn test_head_preserves_streamed_get_compression_headers_below_min_length() {
+        #[handler]
+        async fn hello_stream(res: &mut Response) {
+            res.status_code(StatusCode::OK);
+            res.headers_mut()
+                .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+            res.headers_mut()
+                .insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
+            res.stream(futures_util::stream::once(async {
+                Ok::<_, std::io::Error>("hello")
+            }));
+        }
+
         #[handler]
         async fn hello_head(res: &mut Response) {
             res.status_code(StatusCode::OK);
@@ -822,9 +827,12 @@ mod tests {
                 .insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
         }
 
-        let comp_handler = Compression::new().min_length(1);
-        let router = Router::with_hoop(comp_handler)
-            .push(Router::with_path("hello").get(hello).head(hello_head));
+        let comp_handler = Compression::new().min_length(10);
+        let router = Router::with_hoop(comp_handler).push(
+            Router::with_path("hello")
+                .get(hello_stream)
+                .head(hello_head),
+        );
         let service = Service::new(router);
 
         let get = TestClient::get("http://127.0.0.1:5801/hello")
@@ -836,6 +844,7 @@ mod tests {
             .send(&service)
             .await;
 
+        assert_eq!(get.headers().get(CONTENT_ENCODING).unwrap(), "gzip");
         assert_eq!(
             head.headers().get(CONTENT_ENCODING),
             get.headers().get(CONTENT_ENCODING)

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -74,7 +74,7 @@ use salvo_core::http::body::ResBody;
 use salvo_core::http::header::{
     ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue,
 };
-use salvo_core::http::{self, Mime, StatusCode, append_vary_header, mime};
+use salvo_core::http::{self, Method, Mime, StatusCode, append_vary_header, mime};
 use salvo_core::{Depot, FlowCtrl, Handler, Request, Response, async_trait};
 
 mod encoder;
@@ -464,7 +464,28 @@ impl Handler for Compression {
 
         match res.take_body() {
             ResBody::None => {
-                return;
+                // A HEAD-aware handler can intentionally omit the body before this middleware
+                // runs. Preserve the representation headers that the equivalent GET response
+                // would receive when its uncompressed length is known.
+                if req.method() != Method::HEAD {
+                    return;
+                }
+                let Some(length) = res
+                    .headers()
+                    .get(CONTENT_LENGTH)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.parse::<usize>().ok())
+                else {
+                    return;
+                };
+                if self.min_length > 0 && length < self.min_length {
+                    return;
+                }
+                if let Some((algo, _level)) = self.negotiate(req, res) {
+                    res.headers_mut().insert(CONTENT_ENCODING, algo.into());
+                } else {
+                    return;
+                }
             }
             ResBody::Once(bytes) => {
                 if self.min_length > 0 && bytes.len() < self.min_length {
@@ -788,6 +809,40 @@ mod tests {
             .filter(|value| value.trim().eq_ignore_ascii_case("accept-encoding"))
             .count();
         assert_eq!(vary_accept_encoding_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_head_preserves_get_compression_headers_without_body() {
+        #[handler]
+        async fn hello_head(res: &mut Response) {
+            res.status_code(StatusCode::OK);
+            res.headers_mut()
+                .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+            res.headers_mut()
+                .insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
+        }
+
+        let comp_handler = Compression::new().min_length(1);
+        let router = Router::with_hoop(comp_handler)
+            .push(Router::with_path("hello").get(hello).head(hello_head));
+        let service = Service::new(router);
+
+        let get = TestClient::get("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&service)
+            .await;
+        let mut head = TestClient::head("http://127.0.0.1:5801/hello")
+            .add_header(ACCEPT_ENCODING, "gzip", true)
+            .send(&service)
+            .await;
+
+        assert_eq!(
+            head.headers().get(CONTENT_ENCODING),
+            get.headers().get(CONTENT_ENCODING)
+        );
+        assert_eq!(head.headers().get(VARY), get.headers().get(VARY));
+        assert!(head.headers().get(CONTENT_LENGTH).is_none());
+        assert_eq!(head.take_string().await.unwrap(), "");
     }
 
     #[tokio::test]

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -649,7 +649,19 @@ impl NamedFile {
         }
     }
     /// Consume self and send content to [`Response`].
-    pub async fn send(mut self, req_headers: &HeaderMap, res: &mut Response) {
+    pub async fn send(self, req_headers: &HeaderMap, res: &mut Response) {
+        self.send_inner(req_headers, res, true).await;
+    }
+
+    /// Consume self and send only the headers to [`Response`].
+    ///
+    /// This follows the same conditional and range handling as [`Self::send`], but does not attach
+    /// a response body.
+    pub async fn send_head(self, req_headers: &HeaderMap, res: &mut Response) {
+        self.send_inner(req_headers, res, false).await;
+    }
+
+    async fn send_inner(mut self, req_headers: &HeaderMap, res: &mut Response, send_body: bool) {
         let etag = if self.flags.contains(Flag::Etag) {
             self.etag()
         } else {
@@ -779,8 +791,12 @@ impl NamedFile {
             }
             res.headers_mut().typed_insert(ContentLength(total_size));
 
+            if !send_body {
+                return;
+            }
+
             // Fast path: slice from preread bytes if available
-            if let Some(preread) = self.preread {
+            if let Some(preread) = self.preread.take() {
                 let end = cmp::min(offset.saturating_add(total_size) as usize, preread.len());
                 let start = cmp::min(offset as usize, end);
                 res.replace_body(ResBody::Once(preread.slice(start..end)));
@@ -799,8 +815,12 @@ impl NamedFile {
             res.status_code(StatusCode::OK);
             res.headers_mut().typed_insert(ContentLength(length));
 
+            if !send_body {
+                return;
+            }
+
             // Fast path: send preread bytes directly — zero spawn_blocking calls
-            if let Some(preread) = self.preread {
+            if let Some(preread) = self.preread.take() {
                 res.replace_body(ResBody::Once(preread));
             } else {
                 let reader = ChunkedFile {
@@ -1012,6 +1032,38 @@ mod tests {
             Some("utf-8")
         );
         assert!(named.preread.is_none());
+    }
+
+    #[tokio::test]
+    async fn send_head_sets_headers_without_body() {
+        use crate::http::header::{ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_TYPE};
+        use crate::http::{HeaderMap, Response};
+
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("hello.txt");
+        std::fs::write(&path, b"hello").expect("write file");
+
+        let named = NamedFile::builder(&path)
+            .content_type(mime::TEXT_PLAIN)
+            .preload_threshold(0)
+            .build()
+            .await
+            .expect("build named file");
+        let mut res = Response::new();
+        named.send_head(&HeaderMap::new(), &mut res).await;
+
+        assert_eq!(res.status_code, Some(StatusCode::OK));
+        assert_eq!(res.headers().get(CONTENT_LENGTH).unwrap(), "5");
+        assert_eq!(res.headers().get(ACCEPT_RANGES).unwrap(), "bytes");
+        assert!(
+            res.headers()
+                .get(CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("text/plain")
+        );
+        assert!(res.body.is_none());
     }
 
     #[tokio::test]

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -78,6 +78,25 @@ pub use mime::Mime;
 pub use response::Response;
 
 #[doc(hidden)]
+pub fn append_vary_header(headers: &mut HeaderMap, vary_by: &'static str) {
+    if headers.contains_key(header::VARY) {
+        let already_varies = headers
+            .get_all(header::VARY)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|value| {
+                let value = value.trim();
+                value == "*" || value.eq_ignore_ascii_case(vary_by)
+            });
+        if already_varies {
+            return;
+        }
+    }
+    headers.append(header::VARY, HeaderValue::from_static(vary_by));
+}
+
+#[doc(hidden)]
 #[must_use]
 pub fn parse_accept_encoding(header: &str) -> Vec<(String, u8)> {
     let mut vec = header

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -10,9 +10,9 @@ use std::time::SystemTime;
 
 use salvo_core::fs::NamedFile;
 use salvo_core::handler::Handler;
-use salvo_core::http::header::{ACCEPT_ENCODING, VARY};
+use salvo_core::http::header::ACCEPT_ENCODING;
 use salvo_core::http::{
-    self, HeaderMap, HeaderValue, Request, Response, StatusCode, StatusError, mime,
+    self, HeaderValue, Method, Request, Response, StatusCode, StatusError, append_vary_header, mime,
 };
 use salvo_core::routing::{
     decode_url_path, encode_url_path, normalize_url_path, redirect_to_dir_url,
@@ -73,21 +73,6 @@ impl From<CompressionAlgo> for HeaderValue {
             CompressionAlgo::Gzip => Self::from_static("gzip"),
             CompressionAlgo::Zstd => Self::from_static("zstd"),
         }
-    }
-}
-
-fn append_vary_accept_encoding(headers: &mut HeaderMap) {
-    let already_varies = headers
-        .get_all(VARY)
-        .iter()
-        .filter_map(|value| value.to_str().ok())
-        .flat_map(|value| value.split(','))
-        .any(|value| {
-            let value = value.trim();
-            value == "*" || value.eq_ignore_ascii_case("accept-encoding")
-        });
-    if !already_varies {
-        headers.append(VARY, HeaderValue::from_static("Accept-Encoding"));
     }
 }
 
@@ -158,6 +143,32 @@ where
 ///             .defaults("index.html")
 ///             .auto_list(true),
 ///     ),
+/// );
+/// ```
+///
+/// `HEAD` requests are supported when the route is configured to match them. This lets clients
+/// and caches check file metadata such as `Content-Length`, `ETag`, and `Last-Modified` without
+/// downloading the response body.
+///
+/// **Security note**: a `HEAD` request still follows the same file lookup and metadata path as
+/// `GET`. A client can send a very small request that makes the server touch the filesystem.
+/// Enable `HEAD` at your own risk.
+///
+/// You can match both methods with a composed method filter:
+///
+/// ```
+/// use salvo_core::prelude::*;
+/// use salvo_core::routing::{Filter, filters};
+/// use salvo_serve_static::StaticDir;
+///
+/// let router = Router::new().push(
+///     Router::with_path("static/{**}")
+///         .filter(filters::get().or(filters::head()))
+///         .goal(
+///             StaticDir::new(["assets", "static"])
+///                 .defaults("index.html")
+///                 .auto_list(true),
+///         ),
 /// );
 /// ```
 #[non_exhaustive]
@@ -594,6 +605,9 @@ impl Handler for StaticDir {
                 if let Some(threshold) = self.preload_threshold {
                     builder = builder.preload_threshold(threshold);
                 }
+                if req.method() == Method::HEAD {
+                    builder = builder.preload_threshold(0);
+                }
                 if let Some(content_type) = content_type {
                     builder = builder.content_type(content_type);
                 }
@@ -601,9 +615,13 @@ impl Handler for StaticDir {
             };
             if let Ok(named_file) = builder.build().await {
                 let headers = req.headers();
-                named_file.send(headers, res).await;
+                if req.method() == Method::HEAD {
+                    named_file.send_head(headers, res).await;
+                } else {
+                    named_file.send(headers, res).await;
+                }
                 if varies_on_accept_encoding {
-                    append_vary_accept_encoding(res.headers_mut());
+                    append_vary_header(res.headers_mut(), "accept-encoding");
                 }
             } else {
                 res.render(StatusError::internal_server_error().brief("read file failed"));

--- a/crates/serve-static/src/file.rs
+++ b/crates/serve-static/src/file.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use salvo_core::fs::{NamedFile, NamedFileBuilder};
-use salvo_core::http::{Request, Response, StatusError};
-use salvo_core::{Depot, FlowCtrl, Handler, Writer, async_trait};
+use salvo_core::http::{Method, Request, Response, StatusError};
+use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 
 /// `StaticFile` is a handler that serves a single static file.
 ///
@@ -66,12 +66,13 @@ impl Handler for StaticFile {
     async fn handle(
         &self,
         req: &mut Request,
-        depot: &mut Depot,
+        _depot: &mut Depot,
         res: &mut Response,
         ctrl: &mut FlowCtrl,
     ) {
         match self.0.clone().build().await {
-            Ok(file) => file.write(req, depot, res).await,
+            Ok(file) if req.method() == Method::HEAD => file.send_head(req.headers(), res).await,
+            Ok(file) => file.send(req.headers(), res).await,
             Err(_) => {
                 res.render(StatusError::not_found());
             }

--- a/crates/serve-static/src/file.rs
+++ b/crates/serve-static/src/file.rs
@@ -70,7 +70,11 @@ impl Handler for StaticFile {
         res: &mut Response,
         ctrl: &mut FlowCtrl,
     ) {
-        match self.0.clone().build().await {
+        let mut builder = self.0.clone();
+        if req.method() == Method::HEAD {
+            builder = builder.preload_threshold(0);
+        }
+        match builder.build().await {
             Ok(file) if req.method() == Method::HEAD => file.send_head(req.headers(), res).await,
             Ok(file) => file.send(req.headers(), res).await,
             Err(_) => {

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -44,8 +44,11 @@ mod tests {
     use std::path::Path;
 
     use salvo_core::http::HeaderValue;
-    use salvo_core::http::header::{CONTENT_ENCODING, VARY};
+    use salvo_core::http::header::{
+        ACCEPT_RANGES, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, VARY,
+    };
     use salvo_core::prelude::*;
+    use salvo_core::routing::{Filter, filters};
     use salvo_core::test::{ResponseExt, TestClient};
 
     use crate::*;
@@ -187,11 +190,13 @@ mod tests {
     async fn test_serve_static_file() {
         let router = Router::new()
             .push(
-                Router::with_path("test1.txt").get(
-                    StaticFile::new("test/static/test1.txt")
-                        .chunk_size(1024)
-                        .preload_threshold(0),
-                ),
+                Router::with_path("test1.txt")
+                    .filter(filters::get().or(filters::head()))
+                    .goal(
+                        StaticFile::new("test/static/test1.txt")
+                            .chunk_size(1024)
+                            .preload_threshold(0),
+                    ),
             )
             .push(
                 Router::with_path("notexist.txt").get(StaticFile::new("test/static/notexist.txt")),
@@ -204,10 +209,59 @@ mod tests {
         assert_eq!(response.status_code.unwrap(), StatusCode::OK);
         assert_eq!(response.take_string().await.unwrap(), "copy1");
 
+        let response = TestClient::head("http://127.0.0.1:5801/test1.txt")
+            .send(&service)
+            .await;
+        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert_eq!(response.headers().get(CONTENT_LENGTH).unwrap(), "5");
+        assert_eq!(response.headers().get(ACCEPT_RANGES).unwrap(), "bytes");
+        assert!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("text/plain")
+        );
+
         let response = TestClient::get("http://127.0.0.1:5801/notexist.txt")
             .send(&service)
             .await;
         assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_serve_static_dir_head_matches_get_headers_without_body() {
+        let router = Router::with_path("{*path}")
+            .filter(filters::get().or(filters::head()))
+            .goal(StaticDir::new(vec!["test/static"]));
+        let service = Service::new(router);
+
+        let get_response = TestClient::get("http://127.0.0.1:5801/test1.txt")
+            .send(&service)
+            .await;
+        let mut response = TestClient::head("http://127.0.0.1:5801/test1.txt")
+            .send(&service)
+            .await;
+
+        assert_eq!(response.status_code.unwrap(), StatusCode::OK);
+        assert!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("text/plain")
+        );
+        assert_eq!(
+            response.headers().get(CONTENT_LENGTH),
+            get_response.headers().get(CONTENT_LENGTH)
+        );
+        assert_eq!(response.headers().get(CONTENT_LENGTH).unwrap(), "5");
+        assert_eq!(response.headers().get(ACCEPT_RANGES).unwrap(), "bytes");
+        assert_eq!(response.take_string().await.unwrap(), "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
When serving a website via `StaticDir`, the server returns a duplicated `Vary` header:

`vary: Accept-Encoding, accept-encoding`

<img width="1086" height="507" alt="console" src="https://github.com/user-attachments/assets/84c10102-b796-4b69-a632-b7a73a0a60d3" />

**Changes made in this PR**:
- Fix duplicated `accept-encoding` in `Vary` header
- Skip sending response body for `HEAD` requests instead of using `res.stream(reader)` and `res.take_body()`
- Add documentation for `HEAD` support