### PR TITLE
Add support for OsString and PathBuf

### DIFF
--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -81,7 +81,7 @@ impl SchemaType<'_> {
             feature = "compact_str"
         )))]
         {
-            is_primitive(name)
+            is_primitive(name) || is_std_string_type(path)
         }
 
         #[cfg(any(
@@ -95,7 +95,7 @@ impl SchemaType<'_> {
             feature = "compact_str"
         ))]
         {
-            let mut primitive = is_primitive(name);
+            let mut primitive = is_primitive(name) || is_std_string_type(path);
 
             #[cfg(feature = "chrono")]
             if !primitive {
@@ -201,11 +201,25 @@ fn is_primitive(name: &str) -> bool {
             | "f64"
             | "Ipv4Addr"
             | "Ipv6Addr"
-            | "OsStr"
-            | "OsString"
-            | "Path"
-            | "PathBuf"
     )
+}
+
+#[inline]
+fn is_std_string_type(path: &Path) -> bool {
+    // Match the full path so user-defined types with these common names remain object schemas.
+    let mut segments = path.segments.iter();
+    let (Some(root), Some(module), Some(name), None) = (
+        segments.next(),
+        segments.next(),
+        segments.next(),
+        segments.next(),
+    ) else {
+        return false;
+    };
+
+    root.ident == "std"
+        && ((module.ident == "ffi" && (name.ident == "OsStr" || name.ident == "OsString"))
+            || (module.ident == "path" && (name.ident == "Path" || name.ident == "PathBuf")))
 }
 
 impl TryToTokens for SchemaType<'_> {
@@ -236,8 +250,13 @@ impl TryToTokens for SchemaType<'_> {
             }
         }
 
+        if is_std_string_type(self.path) {
+            schema_type_tokens(tokens, &oapi, SchemaTypeInner::String, self.nullable);
+            return Ok(());
+        }
+
         match name {
-            "String" | "str" | "char" | "OsStr" | "OsString" | "Path" | "PathBuf" => {
+            "String" | "str" | "char" => {
                 schema_type_tokens(tokens, &oapi, SchemaTypeInner::String, self.nullable)
             }
             "bool" => schema_type_tokens(tokens, &oapi, SchemaTypeInner::Boolean, self.nullable),
@@ -964,9 +983,30 @@ mod tests {
     #[test]
     fn test_schema_type_is_primitive() {
         let primitives = [
-            "String", "str", "char", "bool", "usize", "u8", "u16", "u32", "u64", "u128", "isize",
-            "i8", "i16", "i32", "i64", "i128", "f32", "f64", "Ipv4Addr", "Ipv6Addr", "OsStr",
-            "OsString", "Path", "PathBuf",
+            "String",
+            "str",
+            "char",
+            "bool",
+            "usize",
+            "u8",
+            "u16",
+            "u32",
+            "u64",
+            "u128",
+            "isize",
+            "i8",
+            "i16",
+            "i32",
+            "i64",
+            "i128",
+            "f32",
+            "f64",
+            "Ipv4Addr",
+            "Ipv6Addr",
+            "std::ffi::OsStr",
+            "std::ffi::OsString",
+            "std::path::Path",
+            "std::path::PathBuf",
         ];
         for ty in primitives {
             let path = make_path(ty);
@@ -1116,11 +1156,34 @@ mod tests {
         assert!(is_primitive("i32"));
         assert!(is_primitive("bool"));
         assert!(is_primitive("Ipv4Addr"));
-        assert!(is_primitive("OsStr"));
-        assert!(is_primitive("OsString"));
-        assert!(is_primitive("Path"));
-        assert!(is_primitive("PathBuf"));
+        assert!(!is_primitive("OsStr"));
+        assert!(!is_primitive("OsString"));
+        assert!(!is_primitive("Path"));
+        assert!(!is_primitive("PathBuf"));
         assert!(!is_primitive("CustomType"));
+    }
+
+    #[test]
+    fn test_is_std_string_type() {
+        for ty in [
+            "std::ffi::OsStr",
+            "std::ffi::OsString",
+            "std::path::Path",
+            "std::path::PathBuf",
+            "::std::path::PathBuf",
+        ] {
+            assert!(
+                is_std_string_type(&make_path(ty)),
+                "Expected {ty} to be a standard string type"
+            );
+        }
+
+        for ty in ["OsStr", "OsString", "Path", "PathBuf", "custom::Path"] {
+            assert!(
+                !is_std_string_type(&make_path(ty)),
+                "Expected {ty} to remain a custom type"
+            );
+        }
     }
 
     // ==================== is_known_format helper Tests ====================

--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -201,6 +201,10 @@ fn is_primitive(name: &str) -> bool {
             | "f64"
             | "Ipv4Addr"
             | "Ipv6Addr"
+            | "OsStr"
+            | "OsString"
+            | "Path"
+            | "PathBuf"
     )
 }
 
@@ -233,7 +237,7 @@ impl TryToTokens for SchemaType<'_> {
         }
 
         match name {
-            "String" | "str" | "char" => {
+            "String" | "str" | "char" | "OsStr" | "OsString" | "Path" | "PathBuf" => {
                 schema_type_tokens(tokens, &oapi, SchemaTypeInner::String, self.nullable)
             }
             "bool" => schema_type_tokens(tokens, &oapi, SchemaTypeInner::Boolean, self.nullable),
@@ -961,7 +965,8 @@ mod tests {
     fn test_schema_type_is_primitive() {
         let primitives = [
             "String", "str", "char", "bool", "usize", "u8", "u16", "u32", "u64", "u128", "isize",
-            "i8", "i16", "i32", "i64", "i128", "f32", "f64", "Ipv4Addr", "Ipv6Addr",
+            "i8", "i16", "i32", "i64", "i128", "f32", "f64", "Ipv4Addr", "Ipv6Addr", "OsStr",
+            "OsString", "Path", "PathBuf",
         ];
         for ty in primitives {
             let path = make_path(ty);
@@ -1111,6 +1116,10 @@ mod tests {
         assert!(is_primitive("i32"));
         assert!(is_primitive("bool"));
         assert!(is_primitive("Ipv4Addr"));
+        assert!(is_primitive("OsStr"));
+        assert!(is_primitive("OsString"));
+        assert!(is_primitive("Path"));
+        assert!(is_primitive("PathBuf"));
         assert!(!is_primitive("CustomType"));
     }
 

--- a/crates/oapi-macros/src/schema_type.rs
+++ b/crates/oapi-macros/src/schema_type.rs
@@ -169,7 +169,7 @@ impl SchemaType<'_> {
     }
 
     pub(crate) fn is_string(&self) -> bool {
-        matches!(&*self.last_segment_to_string(), "str" | "String")
+        matches!(&*self.last_segment_to_string(), "str" | "String") || is_std_string_type(self.path)
     }
 
     pub(crate) fn is_byte(&self) -> bool {
@@ -918,7 +918,14 @@ mod tests {
 
     #[test]
     fn test_schema_type_is_string() {
-        for ty in ["str", "String"] {
+        for ty in [
+            "str",
+            "String",
+            "std::ffi::OsStr",
+            "std::ffi::OsString",
+            "std::path::Path",
+            "std::path::PathBuf",
+        ] {
             let path = make_path(ty);
             let schema_type = SchemaType {
                 path: &path,
@@ -930,7 +937,16 @@ mod tests {
 
     #[test]
     fn test_schema_type_is_string_false() {
-        for ty in ["i32", "bool", "Vec"] {
+        for ty in [
+            "i32",
+            "bool",
+            "Vec",
+            "OsStr",
+            "OsString",
+            "Path",
+            "PathBuf",
+            "custom::Path",
+        ] {
             let path = make_path(ty);
             let schema_type = SchemaType {
                 path: &path,

--- a/crates/oapi-macros/tests/derive_to_schema_tests.rs
+++ b/crates/oapi-macros/tests/derive_to_schema_tests.rs
@@ -62,9 +62,13 @@ fn test_std_string_types_in_derived_schema() {
     #[allow(dead_code)]
     #[derive(ToSchema)]
     struct StdTypes {
+        #[salvo(schema(max_length = 255))]
         os_str: &'static std::ffi::OsStr,
+        #[salvo(schema(max_length = 255))]
         os_string: std::ffi::OsString,
+        #[salvo(schema(max_length = 255))]
         path: &'static std::path::Path,
+        #[salvo(schema(max_length = 255))]
         path_buf: std::path::PathBuf,
     }
 
@@ -78,7 +82,38 @@ fn test_std_string_types_in_derived_schema() {
         .unwrap();
 
     for property in ["os_str", "os_string", "path", "path_buf"] {
-        assert_json_eq!(std_types["properties"][property], json!({"type": "string"}));
+        assert_json_eq!(
+            std_types["properties"][property],
+            json!({"type": "string", "maxLength": 255})
+        );
+    }
+}
+
+#[test]
+fn test_std_string_newtypes_support_string_validators() {
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    #[salvo(schema(max_length = 255))]
+    struct ValidatedOsString(std::ffi::OsString);
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    #[salvo(schema(max_length = 255))]
+    struct ValidatedPathBuf(std::path::PathBuf);
+
+    let mut components = salvo::oapi::Components::new();
+    ValidatedOsString::to_schema(&mut components);
+    ValidatedPathBuf::to_schema(&mut components);
+    let components = serde_json::to_value(components).unwrap();
+    let schemas = components["schemas"].as_object().unwrap();
+    let validated_schemas = schemas
+        .values()
+        .filter(|schema| schema.get("maxLength").is_some())
+        .collect::<Vec<_>>();
+
+    assert_eq!(validated_schemas.len(), 2);
+    for schema in validated_schemas {
+        assert_json_eq!(schema, json!({"type": "string", "maxLength": 255}));
     }
 }
 

--- a/crates/oapi-macros/tests/derive_to_schema_tests.rs
+++ b/crates/oapi-macros/tests/derive_to_schema_tests.rs
@@ -6,6 +6,83 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 #[test]
+fn test_std_string_types_do_not_shadow_custom_types() {
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct OsStr {
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct OsString {
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct Path {
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct PathBuf {
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct CustomTypes {
+        os_str: OsStr,
+        os_string: OsString,
+        path: Path,
+        path_buf: PathBuf,
+    }
+
+    let mut components = salvo::oapi::Components::new();
+    CustomTypes::to_schema(&mut components);
+    let components = serde_json::to_value(components).unwrap();
+    let schemas = components["schemas"].as_object().unwrap();
+    let custom_types = schemas
+        .values()
+        .find(|schema| schema.pointer("/properties/os_str").is_some())
+        .unwrap();
+
+    for property in ["os_str", "os_string", "path", "path_buf"] {
+        assert!(
+            custom_types["properties"][property].get("$ref").is_some(),
+            "custom {property} type should remain a component reference: {custom_types}"
+        );
+    }
+}
+
+#[test]
+fn test_std_string_types_in_derived_schema() {
+    #[allow(dead_code)]
+    #[derive(ToSchema)]
+    struct StdTypes {
+        os_str: &'static std::ffi::OsStr,
+        os_string: std::ffi::OsString,
+        path: &'static std::path::Path,
+        path_buf: std::path::PathBuf,
+    }
+
+    let mut components = salvo::oapi::Components::new();
+    StdTypes::to_schema(&mut components);
+    let components = serde_json::to_value(components).unwrap();
+    let schemas = components["schemas"].as_object().unwrap();
+    let std_types = schemas
+        .values()
+        .find(|schema| schema.pointer("/properties/os_str").is_some())
+        .unwrap();
+
+    for property in ["os_str", "os_string", "path", "path_buf"] {
+        assert_json_eq!(std_types["properties"][property], json!({"type": "string"}));
+    }
+}
+
+#[test]
 fn test_derive_to_schema_generics() {
     #[derive(Serialize, Deserialize, ToSchema, Debug)]
     #[salvo(schema(aliases(MyI32 = MyObject<i32>, MyStr = MyObject<String>)))]

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -324,6 +324,15 @@ impl_to_schema!(&str);
 impl_to_schema!(std::net::Ipv4Addr);
 impl_to_schema!(std::net::Ipv6Addr);
 
+impl_to_schema_primitive!(
+    std::ffi::OsStr,
+    std::ffi::OsString,
+    std::path::Path,
+    std::path::PathBuf
+);
+impl_to_schema!(&std::ffi::OsStr);
+impl_to_schema!(&std::path::Path);
+
 impl ToSchema for std::net::IpAddr {
     fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
         crate::RefOr::Type(Schema::OneOf(
@@ -1264,6 +1273,36 @@ mod tests {
             (
                 "char",
                 char::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "OsStr",
+                std::ffi::OsStr::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "&OsStr",
+                <&std::ffi::OsStr>::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "OsString",
+                std::ffi::OsString::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "Path",
+                std::path::Path::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "&Path",
+                <&std::path::Path>::to_schema(&mut components),
+                json!({"type": "string"}),
+            ),
+            (
+                "PathBuf",
+                std::path::PathBuf::to_schema(&mut components),
                 json!({"type": "string"}),
             ),
             (


### PR DESCRIPTION
`OsString` and `PathBuf` are used by many serializable structs, in order to allow reusable code in projects where already have models created and just want to allow support to create open api schemas in Salvo, as is my case, this pr is useful. 