### PR TITLE
Fix JWT crypto provider feature selection

### DIFF
--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -62,7 +62,7 @@ salvo = { path = "../salvo", default-features = false, features = [
     "http1",
     "server",
     "test",
-    "jwt-auth",
+    "_jwt-auth",
     "anyhow",
 ] }
 time.workspace = true

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -26,9 +26,18 @@ oidc = [
     "hyper-rustls",
     "dep:hyper-util",
     "dep:http-body-util",
+    "dep:rustls",
 ]
-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "jsonwebtoken/aws_lc_rs"]
-ring = ["hyper-rustls?/ring", "jsonwebtoken/rust_crypto"]
+aws-lc-rs = [
+    "hyper-rustls?/aws-lc-rs",
+    "rustls?/aws-lc-rs",
+    "jsonwebtoken/aws_lc_rs",
+]
+ring = [
+    "hyper-rustls?/ring",
+    "rustls?/ring",
+    "jsonwebtoken/rust_crypto",
+]
 
 [dependencies]
 base64 = { workspace = true }
@@ -49,6 +58,7 @@ hyper-util = { workspace = true, optional = true, features = [
     "http2",
     "tokio",
 ] }
+rustls = { workspace = true, optional = true }
 salvo_core = { workspace = true, features = ["cookie"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -19,22 +19,21 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
-full = ["oidc", "ring"]
+default = ["aws-lc-rs"]
+full = ["oidc"]
 oidc = [
     "dep:bytes",
     "hyper-rustls",
     "dep:hyper-util",
     "dep:http-body-util",
-    "ring",
 ]
-# aws-lc-rs = ["hyper-rustls?/aws-lc-rs"]
-ring = ["hyper-rustls?/ring"]
+aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "jsonwebtoken/aws_lc_rs"]
+ring = ["hyper-rustls?/ring", "jsonwebtoken/rust_crypto"]
 
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true, optional = true }
-jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
+jsonwebtoken = { workspace = true }
 http-body-util = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, optional = true, features = [
     "native-tokio",
@@ -59,8 +58,9 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow.workspace = true
-salvo = { path = "../salvo", features = [
+salvo = { path = "../salvo", default-features = false, features = [
     "http1",
+    "server",
     "test",
     "jwt-auth",
     "anyhow",

--- a/crates/jwt-auth/Cargo.toml
+++ b/crates/jwt-auth/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["aws-lc-rs"]
-full = ["oidc"]
+full = ["oidc", "aws-lc-rs"]
 oidc = [
     "dep:bytes",
     "hyper-rustls",

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -71,9 +71,10 @@ salvo = { version = "*", default-features = false, features = [
 ] }
 ```
 
-Do not enable both `jwt-auth` and `jwt-auth-ring` in the same application.
-Cargo features are additive, and `jsonwebtoken` requires exactly one
-cryptography provider.
+Do not enable both `jwt-auth` and `jwt-auth-ring` unless required by an
+`--all-features` build. Cargo features are additive; when both providers are
+enabled, `salvo-jwt-auth` selects AWS-LC unless the application has already
+installed a process-wide `jsonwebtoken` provider explicitly.
 
 ## Quick Start
 

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -59,21 +59,21 @@ salvo = { version = "*", features = ["jwt-auth"] }
 
 Salvo uses `aws-lc-rs` as its default cryptography provider. To use the
 RustCrypto provider for JWTs instead, disable Salvo's default features and
-select the existing `ring` provider feature together with the features your
-application needs:
+select `jwt-auth-ring`. The separate `ring` feature selects ring for Salvo's
+rustls integration:
 
 ```toml
 salvo = { version = "*", default-features = false, features = [
     "server",
     "http1",
     "ring",
-    "jwt-auth",
+    "jwt-auth-ring",
 ] }
 ```
 
-Do not enable both `aws-lc-rs` and `ring` in the same application. Cargo
-features are additive, and `jsonwebtoken` requires exactly one cryptography
-provider.
+Do not enable both `jwt-auth` and `jwt-auth-ring` in the same application.
+Cargo features are additive, and `jsonwebtoken` requires exactly one
+cryptography provider.
 
 ## Quick Start
 

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -57,6 +57,24 @@ This is an official crate, so you can enable it in `Cargo.toml`:
 salvo = { version = "*", features = ["jwt-auth"] }
 ```
 
+Salvo uses `aws-lc-rs` as its default cryptography provider. To use the
+RustCrypto provider for JWTs instead, disable Salvo's default features and
+select the existing `ring` provider feature together with the features your
+application needs:
+
+```toml
+salvo = { version = "*", default-features = false, features = [
+    "server",
+    "http1",
+    "ring",
+    "jwt-auth",
+] }
+```
+
+Do not enable both `aws-lc-rs` and `ring` in the same application. Cargo
+features are additive, and `jsonwebtoken` requires exactly one cryptography
+provider.
+
 ## Quick Start
 
 Use `HeaderFinder` for the standard `Authorization: Bearer <token>` header.

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -71,10 +71,24 @@ salvo = { version = "*", default-features = false, features = [
 ] }
 ```
 
-Do not enable both `jwt-auth` and `jwt-auth-ring` unless required by an
-`--all-features` build. Cargo features are additive; when both providers are
-enabled, `salvo-jwt-auth` selects AWS-LC unless the application has already
-installed a process-wide `jsonwebtoken` provider explicitly.
+Enable only one of `jwt-auth` and `jwt-auth-ring` in normal builds. Cargo
+features are additive, so an `--all-features` build or another dependency can
+still enable both `jsonwebtoken` providers. In that case, install Salvo's
+selected provider at the very start of the process, before any direct
+`jsonwebtoken::encode` or `jsonwebtoken::decode` call:
+
+```rust
+fn main() {
+    salvo::jwt_auth::install_crypto_provider()
+        .expect("install the JWT crypto provider before first use");
+
+    // Initialize the rest of the application here.
+}
+```
+
+AWS-LC takes precedence when both Salvo JWT provider features are enabled. If
+the application uses a custom process-wide `jsonwebtoken` provider, install
+that provider itself instead of calling `install_crypto_provider`.
 
 ## Quick Start
 

--- a/crates/jwt-auth/README.md
+++ b/crates/jwt-auth/README.md
@@ -74,8 +74,10 @@ salvo = { version = "*", default-features = false, features = [
 Enable only one of `jwt-auth` and `jwt-auth-ring` in normal builds. Cargo
 features are additive, so an `--all-features` build or another dependency can
 still enable both `jsonwebtoken` providers. In that case, install Salvo's
-selected provider at the very start of the process, before any direct
-`jsonwebtoken::encode` or `jsonwebtoken::decode` call:
+selected provider at the very start of the process, before any JWT operation.
+This includes validation performed internally by `JwtAuth`, `ConstDecoder`, or
+`OidcDecoder`, as well as direct `jsonwebtoken::encode` or
+`jsonwebtoken::decode` calls:
 
 ```rust
 fn main() {
@@ -97,7 +99,7 @@ Use `HeaderFinder` for the standard `Authorization: Bearer <token>` header.
 decide how to respond to authorized, unauthorized, and forbidden states.
 
 ```rust
-use salvo::jwt_auth::{ConstDecoder, HeaderFinder, JwtAuthState};
+use salvo::jwt_auth::{ConstDecoder, HeaderFinder, JwtAuthState, install_crypto_provider};
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -123,6 +125,9 @@ async fn me(depot: &mut Depot, res: &mut Response) {
 
 #[tokio::main]
 async fn main() {
+    install_crypto_provider()
+        .expect("install the JWT crypto provider before first use");
+
     let auth = JwtAuth::<Claims, _>::new(ConstDecoder::from_secret(SECRET))
         .finders(vec![Box::new(HeaderFinder::new())])
         .force_passed(true);

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use jsonwebtoken::errors::Error as JwtError;
-use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, decode};
+use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation};
 use salvo_core::Depot;
 use serde::Deserialize;
 
@@ -74,6 +74,7 @@ impl ConstDecoder {
     /// Creates a new decoder with the given decoding key and custom validation parameters.
     #[must_use]
     pub fn with_validation(decoding_key: DecodingKey, validation: Validation) -> Self {
+        crate::install_default_crypto_provider();
         Self {
             decoding_key,
             validation,
@@ -181,7 +182,7 @@ impl JwtAuthDecoder for ConstDecoder {
     where
         C: for<'de> Deserialize<'de> + Clone,
     {
-        decode::<C>(token, &self.decoding_key, &self.validation)
+        crate::decode::<C>(token, &self.decoding_key, &self.validation)
     }
 }
 

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -65,10 +65,7 @@ impl ConstDecoder {
     /// Creates a new decoder with the given decoding key and default validation.
     #[must_use]
     pub fn new(decoding_key: DecodingKey) -> Self {
-        Self {
-            decoding_key,
-            validation: Validation::default(),
-        }
+        Self::with_validation(decoding_key, Validation::default())
     }
 
     /// Creates a new decoder with the given decoding key and custom validation parameters.

--- a/crates/jwt-auth/src/decoder.rs
+++ b/crates/jwt-auth/src/decoder.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use jsonwebtoken::errors::Error as JwtError;
-use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation};
+use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, decode};
 use salvo_core::Depot;
 use serde::Deserialize;
 
@@ -71,7 +71,6 @@ impl ConstDecoder {
     /// Creates a new decoder with the given decoding key and custom validation parameters.
     #[must_use]
     pub fn with_validation(decoding_key: DecodingKey, validation: Validation) -> Self {
-        crate::install_default_crypto_provider();
         Self {
             decoding_key,
             validation,
@@ -179,7 +178,7 @@ impl JwtAuthDecoder for ConstDecoder {
     where
         C: for<'de> Deserialize<'de> + Clone,
     {
-        crate::decode::<C>(token, &self.decoding_key, &self.validation)
+        decode::<C>(token, &self.decoding_key, &self.validation)
     }
 }
 

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -12,6 +12,13 @@
 //! - OpenID Connect support (behind the `oidc` feature flag)
 //! - Seamless integration with Salvo's middleware system
 //!
+//! # Crypto Providers
+//!
+//! Enable exactly one provider feature in normal builds: `aws-lc-rs` (the
+//! default) or `ring` for RustCrypto. If dependency feature unification enables
+//! both providers, call [`install_crypto_provider`] before any direct
+//! `jsonwebtoken` encode or decode operation.
+//!
 //! # Security Considerations
 //!
 //! **Warning: avoid passing JWT tokens in URL query parameters in production.**
@@ -142,7 +149,9 @@ use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 
 #[doc(no_inline)]
-pub use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, errors::Error as JwtError};
+pub use jsonwebtoken::{
+    Algorithm, DecodingKey, TokenData, Validation, decode, errors::Error as JwtError,
+};
 #[cfg(feature = "oidc")]
 use salvo_core::http::StatusCode;
 use salvo_core::http::{Method, Request, Response, StatusError};
@@ -150,32 +159,32 @@ use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 
-fn install_default_crypto_provider() {
-    #[cfg(feature = "aws-lc-rs")]
-    let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
-    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
-    let _ = jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default();
-}
-
-#[cfg(feature = "oidc")]
-fn install_default_rustls_crypto_provider() {
-    #[cfg(feature = "aws-lc-rs")]
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
-/// Decodes a JWT using the configured cryptography provider.
+/// Installs the crypto provider selected by this crate for the current process.
 ///
-/// When both provider features are enabled, AWS-LC is selected unless the
-/// application has already installed a process-wide provider explicitly.
-pub fn decode<T: DeserializeOwned>(
-    token: &str,
-    key: &DecodingKey,
-    validation: &Validation,
-) -> Result<TokenData<T>, JwtError> {
-    install_default_crypto_provider();
-    jsonwebtoken::decode(token, key, validation)
+/// Call this at the start of `main`, before any `jsonwebtoken` operation, when
+/// dependency feature unification enables both JWT provider backends. AWS-LC
+/// takes precedence when both this crate's provider features are enabled.
+///
+/// Applications that install a custom [`jsonwebtoken::crypto::CryptoProvider`]
+/// should do that instead and must not call this function afterwards.
+///
+/// # Errors
+///
+/// Returns the provider this function attempted to install if a process-wide
+/// provider was already installed or initialized. Since `jsonwebtoken` only
+/// permits one installation, an error means this function was not called early
+/// enough or another provider was intentionally installed first.
+pub fn install_crypto_provider() -> Result<(), &'static jsonwebtoken::crypto::CryptoProvider> {
+    #[cfg(feature = "aws-lc-rs")]
+    {
+        jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default()
+    }
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    {
+        jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default()
+    }
+    #[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+    unreachable!("a crypto provider feature is required")
 }
 
 mod finder;
@@ -403,7 +412,6 @@ where
     #[inline]
     #[must_use]
     pub fn new(decoder: D) -> Self {
-        install_default_crypto_provider();
         Self {
             force_passed: false,
             decoder,
@@ -506,7 +514,7 @@ mod tests {
     }
 
     fn encode_test_token<T: Serialize>(claims: &T, key: &EncodingKey) -> String {
-        install_default_crypto_provider();
+        let _ = install_crypto_provider();
         jsonwebtoken::encode(&jsonwebtoken::Header::default(), claims, key).unwrap()
     }
 

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -157,6 +157,14 @@ fn install_default_crypto_provider() {
     let _ = jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default();
 }
 
+#[cfg(feature = "oidc")]
+fn install_default_rustls_crypto_provider() {
+    #[cfg(feature = "aws-lc-rs")]
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 /// Decodes a JWT using the configured cryptography provider.
 ///
 /// When both provider features are enabled, AWS-LC is selected unless the

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -133,6 +133,11 @@
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+compile_error!(
+    "salvo-jwt-auth requires a crypto provider; enable either the `aws-lc-rs` (default) or `ring` feature"
+);
+
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -473,17 +473,24 @@ mod tests {
         exp: i64,
     }
 
+    fn encode_test_token<T: Serialize>(claims: &T, key: &EncodingKey) -> String {
+        #[cfg(feature = "aws-lc-rs")]
+        let _ = jsonwebtoken::crypto::CryptoProvider::install_default(
+            &jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER,
+        );
+        #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+        let _ = jsonwebtoken::crypto::CryptoProvider::install_default(
+            &jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER,
+        );
+        jsonwebtoken::encode(&jsonwebtoken::Header::default(), claims, key).unwrap()
+    }
+
     fn create_test_token(secret: &[u8], exp_days: i64) -> String {
         let claim = JwtClaims {
             user: "test_user".into(),
             exp: (OffsetDateTime::now_utc() + Duration::days(exp_days)).unix_timestamp(),
         };
-        jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(secret),
-        )
-        .unwrap()
+        encode_test_token(&claim, &EncodingKey::from_secret(secret))
     }
 
     // ==================== ConstDecoder Tests ====================
@@ -807,12 +814,7 @@ mod tests {
             exp: (OffsetDateTime::now_utc() + Duration::days(1)).unix_timestamp(),
         };
 
-        let token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(b"ABCDEF"),
-        )
-        .unwrap();
+        let token = encode_test_token(&claim, &EncodingKey::from_secret(b"ABCDEF"));
         let content = access(&service, &token).await;
         assert!(content.contains("hello"));
 
@@ -832,12 +834,7 @@ mod tests {
             .unwrap();
         assert!(content.contains("hello"));
 
-        let token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(b"ABCDEFG"),
-        )
-        .unwrap();
+        let token = encode_test_token(&claim, &EncodingKey::from_secret(b"ABCDEFG"));
         let content = access(&service, &token).await;
         assert!(content.contains("Forbidden"));
     }
@@ -937,12 +934,7 @@ mod tests {
             user: "admin".into(),
             exp: (OffsetDateTime::now_utc() + Duration::days(1)).unix_timestamp(),
         };
-        let token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(b"SECRET"),
-        )
-        .unwrap();
+        let token = encode_test_token(&claim, &EncodingKey::from_secret(b"SECRET"));
 
         let content = TestClient::get("http://127.0.0.1:5801/hello")
             .add_header("Authorization", format!("Bearer {token}"), true)
@@ -975,12 +967,7 @@ mod tests {
             user: "proxy_user".into(),
             exp: (OffsetDateTime::now_utc() + Duration::days(1)).unix_timestamp(),
         };
-        let token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(b"SECRET"),
-        )
-        .unwrap();
+        let token = encode_test_token(&claim, &EncodingKey::from_secret(b"SECRET"));
 
         let content = TestClient::get("http://127.0.0.1:5801/hello")
             .add_header("Proxy-Authorization", format!("Bearer {token}"), true)
@@ -1057,12 +1044,7 @@ mod tests {
             user: "test".into(),
             exp: (OffsetDateTime::now_utc() + Duration::days(1)).unix_timestamp(),
         };
-        let token = jsonwebtoken::encode(
-            &jsonwebtoken::Header::default(),
-            &claim,
-            &EncodingKey::from_secret(b"SECRET"),
-        )
-        .unwrap();
+        let token = encode_test_token(&claim, &EncodingKey::from_secret(b"SECRET"));
 
         // GET should not find token because the method is not allowed.
         let content = TestClient::get("http://127.0.0.1:5801/hello")

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -16,8 +16,10 @@
 //!
 //! Enable exactly one provider feature in normal builds: `aws-lc-rs` (the
 //! default) or `ring` for RustCrypto. If dependency feature unification enables
-//! both providers, call [`install_crypto_provider`] before any direct
-//! `jsonwebtoken` encode or decode operation.
+//! both providers, call [`install_crypto_provider`] at the start of `main`,
+//! before any JWT operation. This includes validation performed internally by
+//! [`JwtAuth`], [`ConstDecoder`], or `OidcDecoder`, as well
+//! as direct `jsonwebtoken` encode or decode calls.
 //!
 //! # Security Considerations
 //!
@@ -42,7 +44,7 @@
 //! ```no_run
 //! use jsonwebtoken::{self, EncodingKey};
 //! use salvo::http::{Method, StatusError};
-//! use salvo::jwt_auth::{ConstDecoder, HeaderFinder};
+//! use salvo::jwt_auth::{ConstDecoder, HeaderFinder, install_crypto_provider};
 //! use salvo::prelude::*;
 //! use serde::{Deserialize, Serialize};
 //! use time::{Duration, OffsetDateTime};
@@ -57,6 +59,9 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
+//!     install_crypto_provider()
+//!         .expect("install the JWT crypto provider before first use");
+//!
 //!     let auth_handler: JwtAuth<JwtClaims, _> = JwtAuth::new(ConstDecoder::from_secret(SECRET_KEY.as_bytes()))
 //!         .finders(vec![Box::new(HeaderFinder::new())])
 //!         .force_passed(true);
@@ -161,9 +166,11 @@ use thiserror::Error;
 
 /// Installs the crypto provider selected by this crate for the current process.
 ///
-/// Call this at the start of `main`, before any `jsonwebtoken` operation, when
-/// dependency feature unification enables both JWT provider backends. AWS-LC
-/// takes precedence when both this crate's provider features are enabled.
+/// Call this at the start of `main`, before any JWT operation, when dependency
+/// feature unification enables both JWT provider backends. This includes token
+/// validation performed internally by [`JwtAuth`], [`ConstDecoder`], or
+/// `OidcDecoder`, not only direct `jsonwebtoken` calls.
+/// AWS-LC takes precedence when both this crate's provider features are enabled.
 ///
 /// Applications that install a custom [`jsonwebtoken::crypto::CryptoProvider`]
 /// should do that instead and must not call this function afterwards.

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -142,15 +142,33 @@ use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 
 #[doc(no_inline)]
-pub use jsonwebtoken::{
-    Algorithm, DecodingKey, TokenData, Validation, decode, errors::Error as JwtError,
-};
+pub use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, errors::Error as JwtError};
 #[cfg(feature = "oidc")]
 use salvo_core::http::StatusCode;
 use salvo_core::http::{Method, Request, Response, StatusError};
 use salvo_core::{Depot, FlowCtrl, Handler, async_trait};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
+
+fn install_default_crypto_provider() {
+    #[cfg(feature = "aws-lc-rs")]
+    let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    let _ = jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default();
+}
+
+/// Decodes a JWT using the configured cryptography provider.
+///
+/// When both provider features are enabled, AWS-LC is selected unless the
+/// application has already installed a process-wide provider explicitly.
+pub fn decode<T: DeserializeOwned>(
+    token: &str,
+    key: &DecodingKey,
+    validation: &Validation,
+) -> Result<TokenData<T>, JwtError> {
+    install_default_crypto_provider();
+    jsonwebtoken::decode(token, key, validation)
+}
 
 mod finder;
 pub use finder::{CookieFinder, FormFinder, HeaderFinder, JwtTokenFinder, QueryFinder};
@@ -377,6 +395,7 @@ where
     #[inline]
     #[must_use]
     pub fn new(decoder: D) -> Self {
+        install_default_crypto_provider();
         Self {
             force_passed: false,
             decoder,
@@ -479,14 +498,7 @@ mod tests {
     }
 
     fn encode_test_token<T: Serialize>(claims: &T, key: &EncodingKey) -> String {
-        #[cfg(feature = "aws-lc-rs")]
-        let _ = jsonwebtoken::crypto::CryptoProvider::install_default(
-            &jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER,
-        );
-        #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
-        let _ = jsonwebtoken::crypto::CryptoProvider::install_default(
-            &jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER,
-        );
+        install_default_crypto_provider();
         jsonwebtoken::encode(&jsonwebtoken::Header::default(), claims, key).unwrap()
     }
 

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -128,6 +128,7 @@ where
     /// Create a new `DecoderBuilder`.
     #[must_use]
     pub fn new(issuer: T) -> Self {
+        crate::install_default_crypto_provider();
         Self {
             issuer,
             http_client: None,
@@ -467,7 +468,7 @@ impl DecodingInfo {
     where
         T: for<'de> serde::de::Deserialize<'de> + Clone,
     {
-        match jsonwebtoken::decode::<T>(token, &self.key, &self.validation) {
+        match crate::decode::<T>(token, &self.key, &self.validation) {
             Ok(data) => Ok(data),
             Err(e) => {
                 tracing::error!(error = ?e, "error decoding jwt token");

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -34,9 +34,8 @@ const OIDC_CONFIG_MAX_BYTES: usize = 64 * 1024;
 const OIDC_JWKS_MAX_BYTES: usize = 1024 * 1024;
 
 fn default_http_client() -> Result<HyperClient, JwtAuthError> {
-    crate::install_default_rustls_crypto_provider();
     let https = HttpsConnectorBuilder::new()
-        .with_native_roots()
+        .with_provider_and_native_roots(default_rustls_crypto_provider())
         .map_err(|error| JwtAuthError::NativeRootCerts(error.to_string()))?
         .https_only()
         .enable_http1()
@@ -45,6 +44,23 @@ fn default_http_client() -> Result<HyperClient, JwtAuthError> {
         .enable_http2()
         .build();
     Ok(Client::builder(TokioExecutor::new()).build(https))
+}
+
+fn default_rustls_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    if let Some(provider) = rustls::crypto::CryptoProvider::get_default() {
+        return Arc::clone(provider);
+    }
+
+    #[cfg(feature = "aws-lc-rs")]
+    {
+        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+    }
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    {
+        Arc::new(rustls::crypto::ring::default_provider())
+    }
+    #[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+    unreachable!("a crypto provider feature is required")
 }
 
 fn resolve_or_else<T, E>(
@@ -129,7 +145,6 @@ where
     /// Create a new `DecoderBuilder`.
     #[must_use]
     pub fn new(issuer: T) -> Self {
-        crate::install_default_crypto_provider();
         Self {
             issuer,
             http_client: None,
@@ -469,7 +484,7 @@ impl DecodingInfo {
     where
         T: for<'de> serde::de::Deserialize<'de> + Clone,
     {
-        match crate::decode::<T>(token, &self.key, &self.validation) {
+        match jsonwebtoken::decode::<T>(token, &self.key, &self.validation) {
             Ok(data) => Ok(data),
             Err(e) => {
                 tracing::error!(error = ?e, "error decoding jwt token");

--- a/crates/jwt-auth/src/oidc.rs
+++ b/crates/jwt-auth/src/oidc.rs
@@ -34,6 +34,7 @@ const OIDC_CONFIG_MAX_BYTES: usize = 64 * 1024;
 const OIDC_JWKS_MAX_BYTES: usize = 1024 * 1024;
 
 fn default_http_client() -> Result<HyperClient, JwtAuthError> {
+    crate::install_default_rustls_crypto_provider();
     let https = HttpsConnectorBuilder::new()
         .with_native_roots()
         .map_err(|error| JwtAuthError::NativeRootCerts(error.to_string()))?

--- a/crates/jwt-auth/tests/crypto_provider.rs
+++ b/crates/jwt-auth/tests/crypto_provider.rs
@@ -15,7 +15,7 @@ fn both_provider_features_select_aws_lc() {
 
     // Constructing a Salvo decoder selects a deterministic process-wide
     // provider before applications use jsonwebtoken to issue tokens.
-    let _decoder = ConstDecoder::from_secret(b"secret");
+    let _decoder = ConstDecoder::new(DecodingKey::from_secret(b"secret"));
     let token = jsonwebtoken::encode(
         &Header::default(),
         &Claims {

--- a/crates/jwt-auth/tests/crypto_provider.rs
+++ b/crates/jwt-auth/tests/crypto_provider.rs
@@ -1,10 +1,11 @@
 //! Crypto provider feature interaction tests.
 
 #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
-#[test]
-fn explicit_initialization_precedes_direct_jsonwebtoken_use() {
-    use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
-    use salvo_jwt_auth::{ConstDecoder, decode, install_crypto_provider};
+#[tokio::test]
+async fn explicit_initialization_precedes_direct_and_salvo_jwt_use() {
+    use jsonwebtoken::{DecodingKey, EncodingKey, Header};
+    use salvo_core::Depot;
+    use salvo_jwt_auth::{ConstDecoder, JwtAuthDecoder, install_crypto_provider};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13,8 +14,7 @@ fn explicit_initialization_precedes_direct_jsonwebtoken_use() {
         exp: u64,
     }
 
-    install_crypto_provider()
-        .expect("the provider must be installed before direct jsonwebtoken use");
+    install_crypto_provider().expect("the provider must be installed before any JWT use");
 
     // Applications commonly issue a token before constructing the decoder.
     let token = jsonwebtoken::encode(
@@ -27,12 +27,10 @@ fn explicit_initialization_precedes_direct_jsonwebtoken_use() {
     )
     .expect("AWS-LC should be selected when both provider features are enabled");
 
-    let _decoder = ConstDecoder::new(DecodingKey::from_secret(b"secret"));
-    let decoded = decode::<Claims>(
-        &token,
-        &DecodingKey::from_secret(b"secret"),
-        &Validation::default(),
-    )
-    .expect("AWS-LC should verify tokens when both provider features are enabled");
+    let decoder = ConstDecoder::new(DecodingKey::from_secret(b"secret"));
+    let decoded = decoder
+        .decode::<Claims>(&token, &mut Depot::new())
+        .await
+        .expect("AWS-LC should verify tokens when both provider features are enabled");
     assert_eq!(decoded.claims.sub, "test");
 }

--- a/crates/jwt-auth/tests/crypto_provider.rs
+++ b/crates/jwt-auth/tests/crypto_provider.rs
@@ -2,9 +2,9 @@
 
 #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
 #[test]
-fn both_provider_features_select_aws_lc() {
+fn explicit_initialization_precedes_direct_jsonwebtoken_use() {
     use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
-    use salvo_jwt_auth::{ConstDecoder, decode};
+    use salvo_jwt_auth::{ConstDecoder, decode, install_crypto_provider};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13,9 +13,10 @@ fn both_provider_features_select_aws_lc() {
         exp: u64,
     }
 
-    // Constructing a Salvo decoder selects a deterministic process-wide
-    // provider before applications use jsonwebtoken to issue tokens.
-    let _decoder = ConstDecoder::new(DecodingKey::from_secret(b"secret"));
+    install_crypto_provider()
+        .expect("the provider must be installed before direct jsonwebtoken use");
+
+    // Applications commonly issue a token before constructing the decoder.
     let token = jsonwebtoken::encode(
         &Header::default(),
         &Claims {
@@ -26,6 +27,7 @@ fn both_provider_features_select_aws_lc() {
     )
     .expect("AWS-LC should be selected when both provider features are enabled");
 
+    let _decoder = ConstDecoder::new(DecodingKey::from_secret(b"secret"));
     let decoded = decode::<Claims>(
         &token,
         &DecodingKey::from_secret(b"secret"),

--- a/crates/jwt-auth/tests/crypto_provider.rs
+++ b/crates/jwt-auth/tests/crypto_provider.rs
@@ -1,0 +1,36 @@
+//! Crypto provider feature interaction tests.
+
+#[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+#[test]
+fn both_provider_features_select_aws_lc() {
+    use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
+    use salvo_jwt_auth::{ConstDecoder, decode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    struct Claims {
+        sub: String,
+        exp: u64,
+    }
+
+    // Constructing a Salvo decoder selects a deterministic process-wide
+    // provider before applications use jsonwebtoken to issue tokens.
+    let _decoder = ConstDecoder::from_secret(b"secret");
+    let token = jsonwebtoken::encode(
+        &Header::default(),
+        &Claims {
+            sub: "test".into(),
+            exp: 4_000_000_000,
+        },
+        &EncodingKey::from_secret(b"secret"),
+    )
+    .expect("AWS-LC should be selected when both provider features are enabled");
+
+    let decoded = decode::<Claims>(
+        &token,
+        &DecodingKey::from_secret(b"secret"),
+        &Validation::default(),
+    )
+    .expect("AWS-LC should verify tokens when both provider features are enabled");
+    assert_eq!(decoded.claims.sub, "test");
+}

--- a/crates/jwt-auth/tests/custom_crypto_provider.rs
+++ b/crates/jwt-auth/tests/custom_crypto_provider.rs
@@ -1,0 +1,48 @@
+//! Application-selected crypto provider tests.
+
+#[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+#[test]
+fn preserves_an_explicitly_installed_provider() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use jsonwebtoken::crypto::{CryptoProvider, JwkUtils, JwtSigner, JwtVerifier};
+    use jsonwebtoken::errors::{ErrorKind, Result};
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
+    use salvo_jwt_auth::ConstDecoder;
+
+    static CUSTOM_PROVIDER_USED: AtomicBool = AtomicBool::new(false);
+
+    fn signer_factory(_: &Algorithm, _: &EncodingKey) -> Result<Box<dyn JwtSigner>> {
+        CUSTOM_PROVIDER_USED.store(true, Ordering::SeqCst);
+        Err(ErrorKind::InvalidAlgorithm.into())
+    }
+
+    fn verifier_factory(_: &Algorithm, _: &DecodingKey) -> Result<Box<dyn JwtVerifier>> {
+        Err(ErrorKind::InvalidAlgorithm.into())
+    }
+
+    static CUSTOM_PROVIDER: CryptoProvider = CryptoProvider {
+        signer_factory,
+        verifier_factory,
+        jwk_utils: JwkUtils::new_unimplemented(),
+    };
+
+    CUSTOM_PROVIDER
+        .install_default()
+        .expect("the integration test process should not have a provider yet");
+
+    let _decoder = ConstDecoder::from_secret(b"secret");
+    let result = jsonwebtoken::encode(
+        &Header::default(),
+        &Claims { sub: "test" },
+        &EncodingKey::from_secret(b"secret"),
+    );
+
+    assert!(result.is_err());
+    assert!(CUSTOM_PROVIDER_USED.load(Ordering::SeqCst));
+}
+
+#[derive(serde::Serialize)]
+struct Claims {
+    sub: &'static str,
+}

--- a/crates/jwt-auth/tests/custom_crypto_provider.rs
+++ b/crates/jwt-auth/tests/custom_crypto_provider.rs
@@ -12,11 +12,13 @@ fn preserves_an_explicitly_installed_provider() {
 
     static CUSTOM_PROVIDER_USED: AtomicBool = AtomicBool::new(false);
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn signer_factory(_: &Algorithm, _: &EncodingKey) -> Result<Box<dyn JwtSigner>> {
         CUSTOM_PROVIDER_USED.store(true, Ordering::SeqCst);
         Err(ErrorKind::InvalidAlgorithm.into())
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn verifier_factory(_: &Algorithm, _: &DecodingKey) -> Result<Box<dyn JwtVerifier>> {
         Err(ErrorKind::InvalidAlgorithm.into())
     }
@@ -42,6 +44,7 @@ fn preserves_an_explicitly_installed_provider() {
     assert!(CUSTOM_PROVIDER_USED.load(Ordering::SeqCst));
 }
 
+#[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
 #[derive(serde::Serialize)]
 struct Claims {
     sub: &'static str,

--- a/crates/jwt-auth/tests/custom_oidc_crypto_provider.rs
+++ b/crates/jwt-auth/tests/custom_oidc_crypto_provider.rs
@@ -1,0 +1,23 @@
+//! Application-selected OIDC rustls provider tests.
+
+#[cfg(all(feature = "oidc", feature = "aws-lc-rs", feature = "ring"))]
+#[tokio::test]
+async fn preserves_an_explicitly_installed_rustls_provider() {
+    use salvo_jwt_auth::oidc::DecoderBuilder;
+
+    let provider = rustls::crypto::ring::default_provider();
+    let expected_secure_random = provider.secure_random;
+    provider
+        .install_default()
+        .expect("the integration test process should not have a rustls provider yet");
+
+    let result = DecoderBuilder::new("https://")
+        .audience("test-client")
+        .build()
+        .await;
+    assert!(result.is_err());
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .expect("the application-selected rustls provider should remain installed");
+    assert!(std::ptr::eq(provider.secure_random, expected_secure_random));
+}

--- a/crates/jwt-auth/tests/oidc_crypto_provider.rs
+++ b/crates/jwt-auth/tests/oidc_crypto_provider.rs
@@ -2,10 +2,10 @@
 
 #[cfg(all(feature = "oidc", feature = "aws-lc-rs", feature = "ring"))]
 #[tokio::test]
-async fn both_provider_features_select_aws_lc_for_oidc() {
+async fn default_oidc_client_does_not_install_a_process_provider() {
     use salvo_jwt_auth::oidc::DecoderBuilder;
 
-    let expected_secure_random = rustls::crypto::aws_lc_rs::default_provider().secure_random;
+    assert!(rustls::crypto::CryptoProvider::get_default().is_none());
 
     // The invalid issuer lets the build fail immediately after constructing
     // the default HTTPS client, without making a network request.
@@ -15,7 +15,5 @@ async fn both_provider_features_select_aws_lc_for_oidc() {
         .await;
     assert!(result.is_err());
 
-    let provider = rustls::crypto::CryptoProvider::get_default()
-        .expect("OIDC should install a deterministic rustls provider");
-    assert!(std::ptr::eq(provider.secure_random, expected_secure_random));
+    assert!(rustls::crypto::CryptoProvider::get_default().is_none());
 }

--- a/crates/jwt-auth/tests/oidc_crypto_provider.rs
+++ b/crates/jwt-auth/tests/oidc_crypto_provider.rs
@@ -1,0 +1,21 @@
+//! OIDC rustls provider feature interaction tests.
+
+#[cfg(all(feature = "oidc", feature = "aws-lc-rs", feature = "ring"))]
+#[tokio::test]
+async fn both_provider_features_select_aws_lc_for_oidc() {
+    use salvo_jwt_auth::oidc::DecoderBuilder;
+
+    let expected_secure_random = rustls::crypto::aws_lc_rs::default_provider().secure_random;
+
+    // The invalid issuer lets the build fail immediately after constructing
+    // the default HTTPS client, without making a network request.
+    let result = DecoderBuilder::new("https://")
+        .audience("test-client")
+        .build()
+        .await;
+    assert!(result.is_err());
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .expect("OIDC should install a deterministic rustls provider");
+    assert!(std::ptr::eq(provider.secure_random, expected_secure_random));
+}

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -143,7 +143,7 @@ salvo_core = { workspace = true }
 salvo_extra = { workspace = true, features = ["full"], optional = true }
 salvo-acme = { workspace = true, features = ["full"], optional = true }
 salvo-compression = { workspace = true, features = ["full"], optional = true }
-salvo-jwt-auth = { workspace = true, features = ["oidc"], optional = true }
+salvo-jwt-auth = { workspace = true, default-features = false, features = ["oidc"], optional = true }
 salvo-cache = { workspace = true, features = ["full"], optional = true }
 salvo-cors = { workspace = true, optional = true }
 salvo-csrf = { workspace = true, features = ["full"], optional = true }

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -104,7 +104,9 @@ affix-state = ["salvo_extra/affix-state"]
 basic-auth = ["salvo_extra/basic-auth"]
 craft = ["dep:salvo-craft"]
 force-https = ["salvo_extra/force-https"]
-jwt-auth = ["dep:salvo-jwt-auth"]
+_jwt-auth = ["dep:salvo-jwt-auth"]
+jwt-auth = ["_jwt-auth", "salvo-jwt-auth/aws-lc-rs"]
+jwt-auth-ring = ["_jwt-auth", "salvo-jwt-auth/ring"]
 catch-panic = ["salvo_extra/catch-panic"]
 compression = ["dep:salvo-compression"]
 logging = ["salvo_extra/logging"]
@@ -129,10 +131,9 @@ otel = ["dep:salvo-otel"]
 oapi = ["dep:salvo-oapi"]
 aws-lc-rs = [
     "salvo_core/aws-lc-rs",
-    "salvo-jwt-auth?/aws-lc-rs",
     "salvo-proxy?/aws-lc-rs",
 ]
-ring = ["salvo_core/ring", "salvo-jwt-auth?/ring", "salvo-proxy?/ring"]
+ring = ["salvo_core/ring", "salvo-proxy?/ring"]
 matched-path = ["salvo_core/matched-path"]
 tls12 = ["salvo_core/tls12"]
 tus = ["dep:salvo-tus"]

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -127,8 +127,12 @@ session = ["dep:salvo-session"]
 serve-static = ["dep:salvo-serve-static"]
 otel = ["dep:salvo-otel"]
 oapi = ["dep:salvo-oapi"]
-aws-lc-rs = ["salvo_core/aws-lc-rs", "salvo-proxy?/aws-lc-rs"]
-ring = ["salvo_core/ring", "salvo-proxy?/ring"]
+aws-lc-rs = [
+    "salvo_core/aws-lc-rs",
+    "salvo-jwt-auth?/aws-lc-rs",
+    "salvo-proxy?/aws-lc-rs",
+]
+ring = ["salvo_core/ring", "salvo-jwt-auth?/ring", "salvo-proxy?/ring"]
 matched-path = ["salvo_core/matched-path"]
 tls12 = ["salvo_core/tls12"]
 tus = ["dep:salvo-tus"]

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -142,7 +142,7 @@ salvo_core = { workspace = true }
 salvo_extra = { workspace = true, features = ["full"], optional = true }
 salvo-acme = { workspace = true, features = ["full"], optional = true }
 salvo-compression = { workspace = true, features = ["full"], optional = true }
-salvo-jwt-auth = { workspace = true, features = ["full"], optional = true }
+salvo-jwt-auth = { workspace = true, features = ["oidc"], optional = true }
 salvo-cache = { workspace = true, features = ["full"], optional = true }
 salvo-cors = { workspace = true, optional = true }
 salvo-csrf = { workspace = true, features = ["full"], optional = true }

--- a/crates/salvo/src/lib.rs
+++ b/crates/salvo/src/lib.rs
@@ -163,7 +163,7 @@ cfg_feature! {
     pub use salvo_flash as flash;
 }
 cfg_feature! {
-    #![feature = "jwt-auth"]
+    #![feature = "_jwt-auth"]
     #[doc(no_inline)]
     pub use salvo_jwt_auth as jwt_auth;
 }
@@ -247,7 +247,7 @@ pub mod prelude {
         pub use salvo_extra::force_https::ForceHttps;
     }
     cfg_feature! {
-        #![feature = "jwt-auth"]
+        #![feature = "_jwt-auth"]
         pub use salvo_jwt_auth::{JwtAuthDepotExt, JwtAuth, JwtAuthState};
     }
     cfg_feature! {


### PR DESCRIPTION
## Summary

- make `jwt-auth` select AWS-LC and add `jwt-auth-ring` as the independent RustCrypto entry point
- fail at compile time when `salvo-jwt-auth` has no crypto provider
- expose `salvo::jwt_auth::install_crypto_provider()` for applications where Cargo unifies both JWT backends
- remove constructor-time provider installation and document that explicit initialization must happen before any JWT operation
- give the private OIDC HTTPS client a concrete rustls provider without mutating process-global state

## Root cause

`salvo-jwt-auth` previously enabled `jsonwebtoken/aws_lc_rs` unconditionally. If an application or another dependency also enabled `jsonwebtoken/rust_crypto`, Cargo's additive feature unification compiled both providers.

`jsonwebtoken` stores its provider in a one-shot process-wide `OnceLock`. It can infer a provider only when exactly one backend is compiled. The earlier compatibility fixes attempted to install AWS-LC from Salvo constructors, but that remained order-dependent: a direct `jsonwebtoken::encode` or `decode` call could initialize the ambiguous fallback before any Salvo constructor ran, and a later `install_default()` could not replace it. Moving that implicit install between constructors only covered individual call paths rather than the provider lifecycle.

The new model is:

- normal builds select exactly one backend through `jwt-auth` or `jwt-auth-ring`;
- dual-provider/all-feature builds call `install_crypto_provider()` at the very start of `main`, before any JWT operation;
- custom-provider applications install their own provider and Salvo does not overwrite it;
- OIDC passes an explicit provider into its private rustls client, preferring an application-installed rustls provider and otherwise using Salvo's selected backend, without installing a global default.

Fixes #1665.

## Validation

- `cargo test -p salvo-jwt-auth`
- `cargo test -p salvo-jwt-auth --no-default-features --features ring`
- `cargo test -p salvo-jwt-auth --all-features`
- `cargo check -p salvo --features "jwt-auth,ring"`
- `cargo check -p salvo --no-default-features --features "server,http1,ring,jwt-auth-ring"`
- `cargo check -p salvo --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p salvo-jwt-auth --all-features --no-deps`
- `cargo clippy -p salvo-jwt-auth --all-features --all-targets --no-deps -- -D warnings -A clippy::useless-borrows-in-formatting`
- verified provider-less builds fail with the intended compile-time diagnostic
- verified dependency trees for the AWS-LC-only and RustCrypto-only top-level Salvo configurations
- ran two downstream black-box fixtures where Salvo and a direct `jsonwebtoken` dependency deliberately enable opposite backends; both pass explicit initialization → direct encode → Salvo decoder
- verified OIDC default-client construction neither installs nor replaces the process-wide rustls provider

A full workspace-dependency Clippy run is still blocked by four unrelated existing Rust 1.97 lints in `salvo_core`; the JWT crate has no new warnings after allowing its pre-existing `useless_borrows_in_formatting` lint.