### PR TITLE
Fix WebTransport session handoff

### DIFF
--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -18,6 +18,21 @@ use crate::http::Method;
 use crate::http::body::{H3ReqBody, ReqBody};
 use crate::proto::WebTransportSession;
 
+fn take_unique_arc_extension<T>(
+    extensions: &mut http::Extensions,
+    name: &'static str,
+) -> IoResult<Option<T>>
+where
+    T: Send + Sync + 'static,
+{
+    match extensions.remove::<Arc<T>>() {
+        Some(value) => Arc::into_inner(value)
+            .map(Some)
+            .ok_or_else(|| IoError::other(format!("{name} is still shared"))),
+        None => Ok(None),
+    }
+}
+
 /// Builder used to serve HTTP/3 connections.
 pub struct Builder {
     inner: salvo_http3::server::Builder,
@@ -255,9 +270,9 @@ async fn process_web_transport(
 
     let conn;
     let stream;
-    if let Some(session) = response
-        .extensions_mut()
-        .remove::<WebTransportSession<salvo_http3::quinn::Connection, Bytes>>()
+    if let Some(session) = take_unique_arc_extension::<
+        WebTransportSession<salvo_http3::quinn::Connection, Bytes>,
+    >(response.extensions_mut(), "WebTransport session")?
     {
         let (server_conn, connect_stream) = session.split();
 
@@ -268,24 +283,20 @@ async fn process_web_transport(
         );
         stream = Some(connect_stream);
     } else {
-        conn = response
-            .extensions_mut()
-            .remove::<Arc<Mutex<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>>>()
+        conn = take_unique_arc_extension::<
+            Mutex<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>,
+        >(response.extensions_mut(), "HTTP/3 connection")?
             .map(|c| {
-                Arc::into_inner(c).expect("HTTP/3 connection must exist").into_inner()
-                    .map_err(|e| IoError::other( format!("failed to get conn : {e}")))
+                c.into_inner()
+                    .map_err(|e| IoError::other(format!("failed to get conn : {e}")))
             })
             .transpose()?;
-        stream =
-            response
-                .extensions_mut()
-                .remove::<Arc<
-                    salvo_http3::server::RequestStream<
-                        salvo_http3::quinn::BidiStream<Bytes>,
-                        Bytes,
-                    >,
-                >>()
-                .and_then(Arc::into_inner);
+        stream = take_unique_arc_extension::<
+            salvo_http3::server::RequestStream<
+                salvo_http3::quinn::BidiStream<Bytes>,
+                Bytes,
+            >,
+        >(response.extensions_mut(), "WebTransport request stream")?;
     }
 
     let Some(conn) = conn else {
@@ -389,4 +400,37 @@ where
     tx.finish()
         .await
         .map_err(|e| IoError::other(format!("failed to finish stream : {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct NonClone(&'static str);
+
+    #[test]
+    fn take_unique_arc_extension_returns_owned_value() {
+        let mut extensions = http::Extensions::new();
+        extensions.insert(Arc::new(NonClone("session")));
+
+        let value = take_unique_arc_extension::<NonClone>(&mut extensions, "test value")
+            .expect("unique Arc should be unwrapped");
+
+        assert_eq!(value, Some(NonClone("session")));
+        assert!(extensions.get::<Arc<NonClone>>().is_none());
+    }
+
+    #[test]
+    fn take_unique_arc_extension_rejects_shared_value() {
+        let mut extensions = http::Extensions::new();
+        let value = Arc::new(NonClone("session"));
+        let _shared = value.clone();
+        extensions.insert(value);
+
+        let error = take_unique_arc_extension::<NonClone>(&mut extensions, "test value")
+            .expect_err("shared Arc should not be silently discarded");
+
+        assert_eq!(error.to_string(), "test value is still shared");
+    }
 }

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -700,8 +700,10 @@ impl Request {
 
         /// Try to get a WebTransport session from the request.
         pub async fn web_transport_mut(&mut self) -> Result<&mut crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>, crate::Error> {
+            type Session = crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>;
+
             if self.is_wt_connect() {
-                if self.extensions.get::<crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>>().is_none() {
+                if self.extensions.get::<Arc<Session>>().is_none() {
                     let conn = self.extensions.remove::<Arc<std::sync::Mutex<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>>>();
                     let stream = self.extensions.remove::<Arc<salvo_http3::server::RequestStream<salvo_http3::quinn::BidiStream<Bytes>, Bytes>>>();
                     match (conn, stream) {
@@ -711,7 +713,7 @@ impl Request {
                                     if let Some(stream) = Arc::into_inner(stream) {
                                         let session =  crate::proto::WebTransportSession::accept(stream, conn).await?;
                                         self.extensions.insert(Arc::new(session));
-                                        if let Some(session) = self.extensions.get_mut::<Arc<crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>>>() {
+                                        if let Some(session) = self.extensions.get_mut::<Arc<Session>>() {
                                             if let Some(session) = Arc::get_mut(session) {
                                                 Ok(session)
                                             } else {
@@ -740,8 +742,8 @@ impl Request {
                         }
                         (None, None) => Err(crate::Error::Other("invalid web transport without connection and stream".into())),
                     }
-                } else if let Some(session) = self.extensions.get_mut::<crate::proto::WebTransportSession<salvo_http3::quinn::Connection, Bytes>>() {
-                    Ok(session)
+                } else if let Some(session) = self.extensions.get_mut::<Arc<Session>>() {
+                    Arc::get_mut(session).ok_or_else(|| crate::Error::Other("web transport session should not used twice".into()))
                 } else {
                     Err(crate::Error::Other("invalid web transport".into()))
                 }


### PR DESCRIPTION
## Summary

- keep WebTransport sessions consistently stored as `Arc<WebTransportSession>` in request and response extensions
- uniquely unwrap session, connection, and request-stream extensions before returning ownership to the HTTP/3 connection loop
- return a clear error when an extension is still shared instead of silently dropping or panicking
- cover successful unique ownership recovery and accidental shared ownership with regression tests

## Root cause

`web_transport_mut()` stored an `Arc<WebTransportSession>`, and the service forwarded that same type to the response. The HTTP/3 connection driver attempted to remove a bare `WebTransportSession`, so the type-key lookup never matched and `WebTransportSession::split()` was skipped. The request-side existence check had the same bare-versus-`Arc` mismatch.

## Impact

Accepted WebTransport sessions can now be recovered from the response and split so the underlying HTTP/3 connection and CONNECT stream return to the connection driver. Repeated mutable access uses the same `Arc` type consistently.

## Validation

- `cargo test -p salvo_core --features quinn` (249 unit tests and 57 doc tests passed)
- `cargo check -p salvo_core --features quinn`
- `cargo clippy -p salvo_core --features quinn --all-targets -- -D warnings -A clippy::useless_borrows_in_formatting -A clippy::question_mark -A clippy::redundant_clone`
