### PR TITLE
Skip duplicate WebTransport response writes

### DIFF
--- a/crates/core/src/conn/quinn/builder.rs
+++ b/crates/core/src/conn/quinn/builder.rs
@@ -268,36 +268,34 @@ async fn process_web_transport(
         .await
         .map_err(|e| IoError::other(format!("failed to call hyper service : {e}")))?;
 
-    let conn;
-    let stream;
     if let Some(session) = take_unique_arc_extension::<
         WebTransportSession<salvo_http3::quinn::Connection, Bytes>,
     >(response.extensions_mut(), "WebTransport session")?
     {
-        let (server_conn, connect_stream) = session.split();
-
-        conn = Some(
-            server_conn
-                .into_inner()
-                .map_err(|e| IoError::other(format!("failed to get conn : {e}")))?,
-        );
-        stream = Some(connect_stream);
-    } else {
-        conn = take_unique_arc_extension::<
-            Mutex<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>,
-        >(response.extensions_mut(), "HTTP/3 connection")?
-            .map(|c| {
-                c.into_inner()
-                    .map_err(|e| IoError::other(format!("failed to get conn : {e}")))
-            })
-            .transpose()?;
-        stream = take_unique_arc_extension::<
-            salvo_http3::server::RequestStream<
-                salvo_http3::quinn::BidiStream<Bytes>,
-                Bytes,
-            >,
-        >(response.extensions_mut(), "WebTransport request stream")?;
+        // `WebTransportSession::accept` already sent the successful CONNECT response. Restore the
+        // connection without passing its stream through the normal response writer, which would
+        // send a second response on the accepted CONNECT stream.
+        let (server_conn, _connect_stream) = session.split();
+        let conn = server_conn
+            .into_inner()
+            .map_err(|e| IoError::other(format!("failed to get conn : {e}")))?;
+        return Ok(Some(conn));
     }
+
+    let conn = take_unique_arc_extension::<
+        Mutex<salvo_http3::server::Connection<salvo_http3::quinn::Connection, Bytes>>,
+    >(response.extensions_mut(), "HTTP/3 connection")?
+        .map(|c| {
+            c.into_inner()
+                .map_err(|e| IoError::other(format!("failed to get conn : {e}")))
+        })
+        .transpose()?;
+    let stream = take_unique_arc_extension::<
+        salvo_http3::server::RequestStream<
+            salvo_http3::quinn::BidiStream<Bytes>,
+            Bytes,
+        >,
+    >(response.extensions_mut(), "WebTransport request stream")?;
 
     let Some(conn) = conn else {
         return Ok(None);


### PR DESCRIPTION
## Summary

- return the recovered HTTP/3 connection immediately after an accepted WebTransport session ends
- keep the accepted CONNECT stream out of the normal HTTP/3 response writer
- preserve the existing response path for WebTransport requests that were not accepted

## Root cause

Follow-up to #1671 and its P2 review. `WebTransportSession::accept()` sends the successful CONNECT response before the session is stored in response extensions. After recovering the session, `process_web_transport` reused its CONNECT stream in the common response path, which attempted to send another response and then finish the stream.

## Impact

Accepted WebTransport sessions now restore the server connection without sending duplicate response headers, body frames, trailers, or a second explicit finish through the normal response path.

## Validation

- `cargo test -p salvo_core --features quinn` (249 unit tests and 57 doctests passed)
- `cargo check -p salvo_core --features quinn`
- `cargo check --manifest-path examples/webtransport/Cargo.toml`
- `cargo check --manifest-path examples/webtransport-acme-http01/Cargo.toml`
- `cargo clippy -p salvo_core --features quinn --all-targets -- -D warnings -A clippy::useless_borrows_in_formatting -A clippy::question_mark -A clippy::redundant_clone`
- `cargo fmt --all -- --check`
- `git diff --check`

The three allowed Clippy lint classes are pre-existing warnings on `main` and are unrelated to this change.