### PR TITLE
Document JWT crypto provider features

### DIFF
--- a/crates/salvo/src/lib.rs
+++ b/crates/salvo/src/lib.rs
@@ -48,7 +48,8 @@
 //! | `cors` | CORS middleware | ❌ |
 //! | `csrf` | CSRF protection middleware | ❌ |
 //! | `flash` | Flash messages middleware | ❌ |
-//! | `jwt-auth` | JWT authentication middleware | ❌ |
+//! | `jwt-auth` | JWT authentication middleware using the AWS-LC provider | ❌ |
+//! | `jwt-auth-ring` | JWT authentication middleware using the RustCrypto provider | ❌ |
 //! | `oapi` | OpenAPI 3 generation and Swagger/RapiDoc/ReDoc/Scalar UIs | ❌ |
 //! | `otel` | OpenTelemetry integration | ❌ |
 //! | `proxy` | Reverse-proxy middleware | ❌ |
@@ -56,6 +57,11 @@
 //! | `serve-static` | Static file / directory serving | ❌ |
 //! | `session` | Cookie-based session middleware | ❌ |
 //! | `tus` | [tus.io](https://tus.io) resumable upload protocol | ❌ |
+//!
+//! `jwt-auth` and `jwt-auth-ring` enable the same middleware with different
+//! cryptography providers. Enable only one in normal builds. If Cargo feature
+//! unification enables both, call `jwt_auth::install_crypto_provider()` before
+//! any JWT operation.
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
## Summary

- document the `jwt-auth-ring` feature in the top-level `salvo` feature table
- clarify that `jwt-auth` selects AWS-LC while `jwt-auth-ring` selects RustCrypto
- warn that normal builds should enable only one JWT provider and point dual-provider builds to `install_crypto_provider()`

## Why

The feature exists in `crates/salvo/Cargo.toml`, but the manually maintained feature table rendered on docs.rs only listed `jwt-auth`. That made the RustCrypto configuration difficult to discover and left the distinction between the two provider features unclear.

The internal `_jwt-auth` capability feature is intentionally left unchanged. Both public provider features use it to share the optional dependency and re-export gates, and `salvo-jwt-auth` development tests use it to enable the Salvo integration without forcing either provider backend.

## Validation

- `RUSTDOCFLAGS="-D warnings" cargo doc -p salvo --all-features --no-deps`
- verified the generated `target/doc/salvo/index.html` contains the new feature row and provider guidance