### PR TITLE
Document core HTTP types and validate ranges

### DIFF
--- a/crates/core/src/http/body.rs
+++ b/crates/core/src/http/body.rs
@@ -64,7 +64,9 @@ use crate::http::HeaderMap;
 /// A frame contains either body data or trailer headers. Use [`BytesFrame::data`]
 /// to create a data frame, and [`BytesFrame::into_data`] or
 /// [`BytesFrame::into_trailers`] to distinguish the two frame kinds without
-/// losing the original frame on a mismatch.
+/// losing the original frame on a mismatch. Converting a `BytesFrame` directly
+/// into [`Bytes`] returns an empty buffer for a trailers frame, so use
+/// [`BytesFrame::into_data`] when that distinction matters.
 #[derive(Debug)]
 pub struct BytesFrame(
     /// The wrapped HTTP body frame.

--- a/crates/core/src/http/body.rs
+++ b/crates/core/src/http/body.rs
@@ -59,27 +59,35 @@ pub use channel::{BodyReceiver, BodySender};
 
 use crate::http::HeaderMap;
 
-/// Frame with its DATA type as [`Bytes`].
+/// An HTTP body frame whose data payload type is [`Bytes`].
+///
+/// A frame contains either body data or trailer headers. Use [`BytesFrame::data`]
+/// to create a data frame, and [`BytesFrame::into_data`] or
+/// [`BytesFrame::into_trailers`] to distinguish the two frame kinds without
+/// losing the original frame on a mismatch.
 #[derive(Debug)]
-pub struct BytesFrame(pub Frame<Bytes>);
+pub struct BytesFrame(
+    /// The wrapped HTTP body frame.
+    pub Frame<Bytes>,
+);
 impl BytesFrame {
-    /// Create a DATA frame with the provided [`Bytes`].
+    /// Creates a data frame from a value convertible into [`Bytes`].
     pub fn data(buf: impl Into<Bytes>) -> Self {
         Self(Frame::data(buf.into()))
     }
 
-    /// Consumes self into the buf of the DATA frame.
+    /// Returns the payload of a data frame.
     ///
-    /// Returns an [`Err`] containing the original [`Frame`] when frame is not a DATA frame.
-    /// `Frame::is_data` can also be used to determine if the frame is a DATA frame.
+    /// Returns `Err` containing the original frame when this is a trailers
+    /// frame. [`Frame::is_data`] can be used to inspect it without consuming it.
     pub fn into_data(self) -> Result<Bytes, Self> {
         self.0.into_data().map_err(Self)
     }
 
-    /// Consumes self into the buf of the trailers frame.
+    /// Returns the headers of a trailers frame.
     ///
-    /// Returns an [`Err`] containing the original [`Frame`] when frame is not a trailers frame.
-    /// `Frame::is_trailers` can also be used to determine if the frame is a trailers frame.
+    /// Returns `Err` containing the original frame when this is a data frame.
+    /// [`Frame::is_trailers`] can be used to inspect it without consuming it.
     pub fn into_trailers(self) -> Result<HeaderMap, Self> {
         self.0.into_trailers().map_err(Self)
     }

--- a/crates/core/src/http/body/channel.rs
+++ b/crates/core/src/http/body/channel.rs
@@ -7,19 +7,19 @@ use bytes::Bytes;
 use futures_channel::{mpsc, oneshot};
 use hyper::HeaderMap;
 
-/// A sender half created through [`ResBody::Channel`](super::ResBody::Channel).
+/// The producer half of a channel-backed response body.
 ///
-/// Useful when wanting to stream chunks from another thread.
+/// Create a sender and its corresponding [`ResBody`](super::ResBody) with
+/// [`ResBody::channel`](super::ResBody::channel). Sending data waits for the
+/// receiver to become ready, providing backpressure to the producing task.
 ///
-/// ## Body Closing
+/// # Closing the body
 ///
-/// **Note**: The request body will always be closed normally when the sender is dropped (meaning
-/// that the empty terminating chunk will be sent to the remote). If you desire to close the
-/// connection with an incomplete response (e.g. in the case of an error during asynchronous
-/// processing), call the [`Sender::abort()`] method to abort the body in an abnormal fashion.
-///
-/// [`Body::channel()`]: struct.Body.html#method.channel
-/// [`Sender::abort()`]: struct.Sender.html#method.abort
+/// Dropping the sender ends the response body normally once queued data has
+/// been consumed. [`BodySender::close`] and [`BodySender::disconnect`] close
+/// only the data channel; after calling either one, send trailers or drop the
+/// sender so the trailer channel is resolved as well. Call
+/// [`BodySender::send_error`] to report a stream error.
 #[must_use = "Sender does nothing unless sent on"]
 pub struct BodySender {
     pub(crate) data_tx: mpsc::Sender<Result<Bytes, IoError>>,
@@ -33,16 +33,22 @@ impl BodySender {
             .map_err(|e| IoError::other(format!("failed to poll ready: {e}")))
     }
 
-    /// Returns whether this channel is closed without needing a context.
+    /// Returns whether the receiving half has been closed.
     #[must_use]
     pub fn is_closed(&self) -> bool {
         self.data_tx.is_closed()
     }
-    /// Closes this channel from the sender side, preventing any new messages.
+    /// Closes the data channel, preventing any new data from being sent.
+    ///
+    /// This does not close the separate trailer channel. Send trailers or drop
+    /// the sender afterward to let the response body finish.
     pub fn close(&mut self) {
         self.data_tx.close_channel();
     }
-    /// Disconnects this sender from the channel, closing it if there are no more senders left.
+    /// Disconnects this sender from the data channel.
+    ///
+    /// The data channel closes when no other senders remain. This does not
+    /// resolve the separate trailer channel.
     pub fn disconnect(&mut self) {
         self.data_tx.disconnect();
     }
@@ -51,7 +57,7 @@ impl BodySender {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
-    /// Send data on data channel when it is ready.
+    /// Sends a data chunk once the receiver is ready.
     pub async fn send_data(&mut self, chunk: impl Into<Bytes> + Send) -> IoResult<()> {
         self.ready().await?;
         self.data_tx
@@ -59,7 +65,11 @@ impl BodySender {
             .map_err(|e| IoError::other(format!("failed to send data: {e}")))
     }
 
-    /// Send trailers on trailers channel.
+    /// Sends the response trailer headers.
+    ///
+    /// Trailers can be sent only once. A second call, or a call after the
+    /// receiver has been dropped, returns an error. Sending trailers does not
+    /// close the data channel.
     pub async fn send_trailers(&mut self, trailers: HeaderMap) -> IoResult<()> {
         let Some(tx) = self.trailers_tx.take() else {
             return Err(IoError::other("failed to send trailers"));
@@ -68,7 +78,7 @@ impl BodySender {
             .map_err(|_| IoError::other("failed to send trailers"))
     }
 
-    /// Send error on data channel.
+    /// Ends the data stream with an I/O error.
     pub fn send_error(&mut self, err: IoError) {
         let _ = self
             .data_tx
@@ -160,7 +170,11 @@ impl Debug for BodySender {
     }
 }
 
-/// A receiver for [`ResBody`](super::ResBody).
+/// The consumer half of a channel-backed response body.
+///
+/// This type is normally wrapped in [`ResBody::Channel`](super::ResBody::Channel)
+/// by [`ResBody::channel`](super::ResBody::channel), rather than constructed or
+/// consumed directly.
 pub struct BodyReceiver {
     pub(crate) data_rx: mpsc::Receiver<Result<Bytes, IoError>>,
     pub(crate) trailers_rx: oneshot::Receiver<HeaderMap>,

--- a/crates/core/src/http/body/channel.rs
+++ b/crates/core/src/http/body/channel.rs
@@ -20,7 +20,7 @@ use hyper::HeaderMap;
 /// only the data channel; after calling either one, send trailers or drop the
 /// sender so the trailer channel is resolved as well. Call
 /// [`BodySender::send_error`] to report a stream error.
-#[must_use = "Sender does nothing unless sent on"]
+#[must_use = "a BodySender does nothing unless it is used"]
 pub struct BodySender {
     pub(crate) data_tx: mpsc::Sender<Result<Bytes, IoError>>,
     pub(crate) trailers_tx: Option<oneshot::Sender<HeaderMap>>,
@@ -78,7 +78,7 @@ impl BodySender {
             .map_err(|_| IoError::other("failed to send trailers"))
     }
 
-    /// Ends the data stream with an I/O error.
+    /// Sends an I/O error on the data channel.
     pub fn send_error(&mut self, err: IoError) {
         let _ = self
             .data_tx

--- a/crates/core/src/http/body/channel.rs
+++ b/crates/core/src/http/body/channel.rs
@@ -33,7 +33,11 @@ impl BodySender {
             .map_err(|e| IoError::other(format!("failed to poll ready: {e}")))
     }
 
-    /// Returns whether the receiving half has been closed.
+    /// Returns whether this sender's data channel is closed.
+    ///
+    /// This becomes `true` when the receiver is dropped, after
+    /// [`BodySender::close`] closes the channel locally, or after this sender
+    /// calls [`BodySender::disconnect`].
     #[must_use]
     pub fn is_closed(&self) -> bool {
         self.data_tx.is_closed()

--- a/crates/core/src/http/body/req.rs
+++ b/crates/core/src/http/body/req.rs
@@ -74,27 +74,32 @@ pub(crate) type BoxedBody =
     Pin<Box<dyn Body<Data = Bytes, Error = BoxedError> + Send + Sync + 'static>>;
 pub(crate) type PollFrame = Poll<Option<Result<Frame<Bytes>, IoError>>>;
 
-/// Body for HTTP request.
+/// The body of an incoming HTTP request.
+///
+/// `ReqBody` implements [`Body`] and can represent an empty body, already
+/// buffered bytes, Hyper's network body, or another boxed body implementation.
+/// Applications normally access it through [`Request`](crate::http::Request)
+/// instead of constructing variants directly.
 #[non_exhaustive]
 #[derive(Default)]
 pub enum ReqBody {
-    /// None body.
+    /// An empty or already-consumed body.
     #[default]
     None,
-    /// Once bytes body.
+    /// A body held in one in-memory byte buffer.
     Once(Bytes),
-    /// Hyper default body.
+    /// A streaming body received by Hyper.
     Hyper {
-        /// Inner body.
+        /// The underlying Hyper body.
         inner: Incoming,
-        /// Request-body timeout state.
+        /// Internal request-body timeout state derived from the connection fuse.
         fuse_config: Option<BodyTimeout>,
     },
-    /// Boxed body.
+    /// A type-erased custom streaming body.
     Boxed {
-        /// Inner body.
+        /// The underlying boxed body.
         inner: BoxedBody,
-        /// Request-body timeout state.
+        /// Internal request-body timeout state derived from the connection fuse.
         fuse_config: Option<BodyTimeout>,
     },
 }

--- a/crates/core/src/http/body/res.rs
+++ b/crates/core/src/http/body/res.rs
@@ -14,26 +14,31 @@ use crate::error::BoxedError;
 use crate::http::body::{BodyReceiver, BodySender, BytesFrame};
 use crate::prelude::StatusError;
 
-/// Body for HTTP response.
+/// The body of an outgoing HTTP response.
+///
+/// Small, known bodies can be stored as one buffer or a queue of buffers.
+/// Bodies whose size is not known up front can be backed by Hyper, a boxed
+/// [`Body`], a [`Stream`], or the sender/receiver pair created by
+/// [`ResBody::channel`].
 #[non_exhaustive]
 #[derive(Default)]
 pub enum ResBody {
-    /// None body.
+    /// No response body.
     #[default]
     None,
-    /// Once bytes body.
+    /// A response body held in one byte buffer.
     Once(Bytes),
-    /// Chunks body.
+    /// An ordered queue of byte buffers.
     Chunks(VecDeque<Bytes>),
-    /// Hyper default body.
+    /// Hyper's incoming streaming body, typically used when proxying a response.
     Hyper(Incoming),
-    /// Boxed body.
+    /// A type-erased custom body implementation.
     Boxed(Pin<Box<dyn Body<Data = Bytes, Error = BoxedError> + Send + Sync + 'static>>),
-    /// Stream body.
+    /// A stream of data or trailer frames.
     Stream(SyncWrapper<BoxStream<'static, Result<BytesFrame, BoxedError>>>),
-    /// Channel body.
+    /// The receiver half of a body channel created by [`ResBody::channel`].
     Channel(BodyReceiver),
-    /// Error body will be process in catcher.
+    /// An error deferred to the service's catcher instead of sent as body data.
     Error(StatusError),
 }
 impl ResBody {
@@ -77,7 +82,11 @@ impl ResBody {
         matches!(*self, Self::Error(_))
     }
 
-    /// Wrap a futures `Stream` in a box inside `Body`.
+    /// Creates a response body from a stream of frames.
+    ///
+    /// Stream items may be data values convertible into [`BytesFrame`] or
+    /// explicit trailer frames. Stream errors are converted into
+    /// [`BoxedError`].
     pub fn stream<S, O, E>(stream: S) -> Self
     where
         S: Stream<Item = Result<O, E>> + Send + 'static,
@@ -88,9 +97,10 @@ impl ResBody {
         Self::Stream(SyncWrapper::new(Box::pin(mapped)))
     }
 
-    /// Create a `Body` stream with an associated sender half.
+    /// Creates a channel-backed body and its sender half.
     ///
-    /// Useful when wanting to stream chunks from another thread.
+    /// The returned [`BodySender`] applies backpressure while another task
+    /// produces chunks or trailers.
     pub fn channel() -> (BodySender, Self) {
         let (data_tx, data_rx) = mpsc::channel(0);
         let (trailers_tx, trailers_rx) = oneshot::channel();
@@ -107,7 +117,10 @@ impl ResBody {
         (tx, rx)
     }
 
-    /// Get body's size.
+    /// Returns the exact body size when it is known without consuming the body.
+    ///
+    /// Streaming, channel, boxed, Hyper, and deferred-error bodies return
+    /// `None`.
     #[inline]
     pub fn size(&self) -> Option<u64> {
         match self {
@@ -122,7 +135,7 @@ impl ResBody {
         }
     }
 
-    /// Set body to none and returns current body.
+    /// Replaces this body with [`ResBody::None`] and returns the previous body.
     #[inline]
     #[must_use]
     pub fn take(&mut self) -> Self {

--- a/crates/core/src/http/range.rs
+++ b/crates/core/src/http/range.rs
@@ -1,22 +1,46 @@
 use crate::http::ParseError;
 
-/// HTTP Range header representation.
+/// A normalized, satisfiable byte range from an HTTP `Range` header.
+///
+/// The range covers `start..start + length`: `start` is zero-based and
+/// `length` is the number of bytes in the range. Open-ended and suffix ranges
+/// are resolved against the representation size by [`HttpRange::parse`].
 #[derive(Clone, Debug, Copy)]
 #[non_exhaustive]
 pub struct HttpRange {
-    /// Start position.
+    /// Zero-based offset of the first byte in the range.
     pub start: u64,
-    /// Total length.
+    /// Number of bytes in the range.
     pub length: u64,
 }
 
 static PREFIX: &str = "bytes=";
 
 impl HttpRange {
-    /// Parses Range HTTP header string as per RFC 2616.
+    /// Parses and normalizes the value of an HTTP byte `Range` header.
     ///
-    /// `header` is HTTP Range header (e.g. `bytes=0-9`).
-    /// `size` is full size of response (file).
+    /// `header` must use the `bytes` range unit, for example `bytes=0-9`.
+    /// `size` is the complete representation length. Explicit end positions
+    /// beyond `size` are clamped, and suffix ranges are converted to absolute
+    /// offsets.
+    ///
+    /// An empty header produces an empty vector. Malformed ranges, and a header
+    /// with no range that overlaps the representation, return
+    /// [`ParseError::InvalidRange`]. If at least one range is satisfiable,
+    /// other non-overlapping ranges are ignored.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use salvo_core::http::HttpRange;
+    ///
+    /// let ranges = HttpRange::parse("bytes=2-5,-2", 10)?;
+    /// assert_eq!(ranges[0].start, 2);
+    /// assert_eq!(ranges[0].length, 4);
+    /// assert_eq!(ranges[1].start, 8);
+    /// assert_eq!(ranges[1].length, 2);
+    /// # Ok::<(), salvo_core::http::ParseError>(())
+    /// ```
     pub fn parse(header: &str, size: u64) -> Result<Vec<Self>, ParseError> {
         if header.is_empty() {
             return Ok(Vec::new());

--- a/crates/core/src/http/range.rs
+++ b/crates/core/src/http/range.rs
@@ -20,14 +20,16 @@ impl HttpRange {
     /// Parses and normalizes the value of an HTTP byte `Range` header.
     ///
     /// `header` must use the `bytes` range unit, for example `bytes=0-9`.
-    /// `size` is the complete representation length. Explicit end positions
-    /// beyond `size` are clamped, and suffix ranges are converted to absolute
-    /// offsets.
+    /// `size` is the complete representation length. Values above
+    /// [`i64::MAX`] are treated as `i64::MAX`. Explicit end positions beyond
+    /// the effective size are clamped, and suffix ranges are converted to
+    /// absolute offsets.
     ///
-    /// An empty header produces an empty vector. Malformed ranges, and a header
-    /// with no range that overlaps the representation, return
-    /// [`ParseError::InvalidRange`]. If at least one range is satisfiable,
-    /// other non-overlapping ranges are ignored.
+    /// An empty header, or one containing only empty comma-separated members,
+    /// produces an empty vector. A malformed non-empty range, or a header whose
+    /// non-empty ranges do not overlap the representation, returns
+    /// [`ParseError::InvalidRange`]. If at least one range is satisfiable, other
+    /// non-overlapping ranges are ignored.
     ///
     /// # Example
     ///
@@ -65,6 +67,9 @@ impl HttpRange {
 
                 let start_str = start_end_iter.next().ok_or(())?.trim();
                 let end_str = start_end_iter.next().ok_or(())?.trim();
+                if start_end_iter.next().is_some() {
+                    return Err(());
+                }
 
                 if start_str.is_empty() {
                     // If no start is specified, end specifies the
@@ -75,6 +80,11 @@ impl HttpRange {
                     // and is unsatisfiable per RFC 7233; treat it like a range
                     // that does not overlap the representation.
                     if length <= 0 {
+                        no_overlap = true;
+                        return Ok(None);
+                    }
+
+                    if size_sig == 0 {
                         no_overlap = true;
                         return Ok(None);
                     }
@@ -404,5 +414,23 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn parse_rejects_ranges_with_extra_hyphens() {
+        for header in ["bytes=0-1-2", "bytes=0--1", "bytes=--1"] {
+            assert!(
+                matches!(HttpRange::parse(header, 10), Err(ParseError::InvalidRange)),
+                "{header} should be rejected as malformed"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_suffix_range_for_empty_representation() {
+        assert!(matches!(
+            HttpRange::parse("bytes=-1", 0),
+            Err(ParseError::InvalidRange)
+        ));
     }
 }

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -32,15 +32,18 @@ use crate::{Depot, Error, FlowCtrl, Handler, async_trait};
 
 static GLOBAL_SECURE_MAX_SIZE: AtomicUsize = AtomicUsize::new(64 * 1024);
 
-/// Get global secure maximum size, default value is 64KB.
+/// Returns the process-wide fallback limit for bounded request-body reads.
 ///
-/// **Note**: The security maximum value applies to request body reads and form parsing,
-/// including multipart file uploads. Increase the limit if you need to accept large uploads.
+/// The initial value is 64 KiB. A request-specific limit set by [`SecureMaxSize`]
+/// or [`Request::set_secure_max_size`] takes precedence over this value.
+///
+/// The limit applies to request body reads and form parsing, including multipart
+/// file uploads.
 pub fn global_secure_max_size() -> usize {
     GLOBAL_SECURE_MAX_SIZE.load(Ordering::Relaxed)
 }
 
-/// Set secure maximum size globally.
+/// Sets the process-wide fallback limit for bounded request-body reads.
 ///
 /// This sets the process-wide fallback limit for every request that does not
 /// have a route-specific or request-specific limit. Treat this value as a
@@ -51,24 +54,47 @@ pub fn global_secure_max_size() -> usize {
 /// [`Request::set_secure_max_size`] when only specific routes or handlers need
 /// to accept larger bodies.
 ///
-/// **Note**: The security maximum value applies to request body reads and form parsing,
-/// including multipart file uploads. Increase the limit if you need to accept large uploads.
+/// The value is expressed in bytes and applies to request body reads and form
+/// parsing, including multipart file uploads.
 pub fn set_global_secure_max_size(size: usize) {
     GLOBAL_SECURE_MAX_SIZE.store(size, Ordering::Relaxed);
 }
 
-/// Middleware to set the secure maximum size of the request body.
+/// Middleware that sets the maximum body size accepted by Salvo's parsing helpers.
 ///
-/// Use this when only part of an application needs a different body limit. It
-/// avoids changing the process-wide fallback set by
+/// The limit is expressed in bytes and is used by body-reading and parsing
+/// methods such as [`Request::payload`], [`Request::form_data`],
+/// [`Request::parse_json`], and [`Request::parse_body`]. This middleware only
+/// records the limit on the request; it does not consume the body or reject a
+/// request based on its `Content-Length` by itself.
+///
+/// Install it before any middleware or handler that reads the body. An already
+/// cached body is not checked again, and code that reads [`Request::body_mut`]
+/// directly bypasses this helper-level limit. Middleware that must also bound
+/// direct streaming reads can call [`Request::limit_body`].
+///
+/// Use this type when only part of an application needs a different limit,
+/// rather than changing the process-wide fallback with
 /// [`set_global_secure_max_size()`].
 ///
-/// **Note**: The security maximum value applies to request body reads and form parsing,
-/// including multipart file uploads. Increase the limit if you need to accept large uploads.
+/// # Example
+///
+/// ```
+/// use salvo_core::Router;
+/// use salvo_core::http::request::SecureMaxSize;
+///
+/// // Requests routed through this subtree may buffer up to 10 MiB.
+/// let uploads = Router::with_path("uploads")
+///     .hoop(SecureMaxSize::new(10 * 1024 * 1024));
+/// # let _ = uploads;
+/// ```
 #[derive(Debug, Clone, Copy)]
-pub struct SecureMaxSize(pub usize);
+pub struct SecureMaxSize(
+    /// The maximum number of bytes that Salvo's bounded body helpers may read.
+    pub usize,
+);
 impl SecureMaxSize {
-    /// Create a new `SecureMaxSize` instance.
+    /// Creates middleware with the given byte limit.
     #[must_use]
     pub fn new(size: usize) -> Self {
         Self(size)

--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -83,7 +83,7 @@ pub fn set_global_secure_max_size(size: usize) {
 /// use salvo_core::Router;
 /// use salvo_core::http::request::SecureMaxSize;
 ///
-/// // Requests routed through this subtree may buffer up to 10 MiB.
+/// // Body-reading helpers in this subtree may accept up to 10 MiB.
 /// let uploads = Router::with_path("uploads")
 ///     .hoop(SecureMaxSize::new(10 * 1024 * 1024));
 /// # let _ = uploads;


### PR DESCRIPTION
## Summary

- expand `SecureMaxSize` and global request-size-limit documentation with precedence, middleware ordering, caching, and direct-stream caveats
- document `HttpRange` normalization and parsing behavior with executable examples
- clarify `BytesFrame`, `ReqBody`, `ResBody`, `BodySender`, and `BodyReceiver` semantics
- replace stale `BodySender` links and explain data/trailer channel shutdown behavior
- reject range members with extra hyphens and suffix ranges against an empty representation

## Why

Several public HTTP types had only terse labels, while the `BodySender` comments referenced APIs that no longer exist. During review, the documented malformed-range contract also exposed two parser gaps: trailing hyphen-separated components were ignored, and a suffix range over an empty representation produced a zero-length range.

The updated documentation makes the security boundary and body/range APIs easier to use correctly, while the parser changes keep its validation behavior consistent with that contract.

## Impact

Malformed byte ranges such as `bytes=0-1-2` and suffix ranges against an empty representation now return `ParseError::InvalidRange`. Valid range behavior and the remaining HTTP APIs are unchanged.

## Validation

- `cargo test -p salvo_core --lib` — 248 passed
- `cargo test -p salvo_core --doc` — 59 passed, 29 ignored
- `cargo fmt -p salvo_core -- --check`
- `git diff --check`
- `cargo clippy -p salvo_core --all-targets -- -D warnings` with four unrelated pre-existing lint categories allowed
- `cargo doc -p salvo_core --no-deps` — completed; reports eight pre-existing warnings outside the edited HTTP files
