### PR TITLE
Apply nightly rustfmt to HTTP docs

### DIFF
--- a/crates/core/src/http/request.rs
+++ b/crates/core/src/http/request.rs
@@ -84,8 +84,7 @@ pub fn set_global_secure_max_size(size: usize) {
 /// use salvo_core::http::request::SecureMaxSize;
 ///
 /// // Body-reading helpers in this subtree may accept up to 10 MiB.
-/// let uploads = Router::with_path("uploads")
-///     .hoop(SecureMaxSize::new(10 * 1024 * 1024));
+/// let uploads = Router::with_path("uploads").hoop(SecureMaxSize::new(10 * 1024 * 1024));
 /// # let _ = uploads;
 /// ```
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Summary

- apply nightly rustfmt to the `SecureMaxSize` documentation example

## Why

The repository enables the nightly-only `format_code_in_doc_comments` rustfmt option. Stable rustfmt ignores that option, so the example introduced by #1682 passed local stable formatting but failed the `Format Code` workflow on `main`.

Nightly rustfmt collapses the chained `Router` expression to one line, matching the CI formatter.

## Impact

Formatting-only change with no API or runtime behavior impact.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p salvo_core --doc` — 59 passed, 29 ignored
- `git diff --check`

Fixes the formatting failure in [run 30446871925](https://github.com/salvo-rs/salvo/actions/runs/30446871925/job/90559290935).
