### PR TITLE
Add QUERY method routing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 h3-datagram = "0.0.2"
 headers = "0.4"
-http = "1"
+http = "1.5"
 http-body-util = "0.1"
 hmac = "0.13"
 hex = "0.4"

--- a/crates/cache/src/skipper.rs
+++ b/crates/cache/src/skipper.rs
@@ -34,6 +34,11 @@ impl MethodSkipper {
     pub fn skip_put(self, value: bool) -> Self {
         self.skip_method(Method::PUT, value)
     }
+    /// Add the [`Method::QUERY`] method to skipped methods.
+    #[must_use]
+    pub fn skip_query(self, value: bool) -> Self {
+        self.skip_method(Method::QUERY, value)
+    }
     /// Add the [`Method::DELETE`] method to skipped methods.
     #[must_use]
     pub fn skip_delete(self, value: bool) -> Self {
@@ -87,6 +92,7 @@ impl MethodSkipper {
             Method::OPTIONS,
             Method::CONNECT,
             Method::TRACE,
+            Method::QUERY,
         ]
         .into_iter()
         .collect();
@@ -142,6 +148,15 @@ mod tests {
 
         let skipper = skipper.skip_put(false);
         assert!(!skipper.skipped_methods.contains(&Method::PUT));
+    }
+
+    #[test]
+    fn test_skip_query() {
+        let skipper = MethodSkipper::new().skip_query(true);
+        assert!(skipper.skipped_methods.contains(&Method::QUERY));
+
+        let skipper = skipper.skip_query(false);
+        assert!(!skipper.skipped_methods.contains(&Method::QUERY));
     }
 
     #[test]
@@ -210,7 +225,8 @@ mod tests {
         assert!(skipper.skipped_methods.contains(&Method::OPTIONS));
         assert!(skipper.skipped_methods.contains(&Method::CONNECT));
         assert!(skipper.skipped_methods.contains(&Method::TRACE));
-        assert_eq!(skipper.skipped_methods.len(), 9);
+        assert!(skipper.skipped_methods.contains(&Method::QUERY));
+        assert_eq!(skipper.skipped_methods.len(), 10);
     }
 
     #[test]
@@ -230,7 +246,8 @@ mod tests {
         let skipper = MethodSkipper::new().skip_all().skip_get(false);
         assert!(!skipper.skipped_methods.contains(&Method::GET));
         assert!(skipper.skipped_methods.contains(&Method::POST));
-        assert_eq!(skipper.skipped_methods.len(), 8);
+        assert!(skipper.skipped_methods.contains(&Method::QUERY));
+        assert_eq!(skipper.skipped_methods.len(), 9);
     }
 
     #[test]

--- a/crates/core/src/routing.rs
+++ b/crates/core/src/routing.rs
@@ -47,6 +47,10 @@
 //! Router::with_path("writers/{id}/articles").get(list_writer_articles);
 //! ```
 //!
+//! Salvo also supports the QUERY method for safe, idempotent requests whose query description is
+//! carried in the request content. For example, a complex search endpoint can be registered with
+//! `Router::with_path("search").query(search)`.
+//!
 //! # Write in tree way
 //!
 //! We can write router like a tree, this is also the recommended way:

--- a/crates/core/src/routing/filters.rs
+++ b/crates/core/src/routing/filters.rs
@@ -222,6 +222,16 @@ pub fn put() -> MethodFilter {
     MethodFilter(Method::PUT)
 }
 
+/// Filter requests, only allowing the QUERY method.
+///
+/// QUERY is a safe, idempotent method that can carry request content. It is useful when the
+/// description of a query is too large or complex to encode in the request URI.
+#[inline]
+#[must_use]
+pub fn query() -> MethodFilter {
+    MethodFilter(Method::QUERY)
+}
+
 /// Filter request, only allow delete method.
 #[inline]
 #[must_use]
@@ -241,6 +251,7 @@ mod tests {
         assert_eq!(post(), MethodFilter(Method::POST));
         assert_eq!(patch(), MethodFilter(Method::PATCH));
         assert_eq!(put(), MethodFilter(Method::PUT));
+        assert_eq!(query(), MethodFilter(Method::QUERY));
         assert_eq!(delete(), MethodFilter(Method::DELETE));
     }
 

--- a/crates/core/src/routing/router.rs
+++ b/crates/core/src/routing/router.rs
@@ -457,6 +457,19 @@ impl Router {
         self.push(Self::with_filter(filters::put()).goal(goal))
     }
 
+    /// Create a new child router with [`MethodFilter`] to filter QUERY method and set this child
+    /// router's handler.
+    ///
+    /// QUERY is a safe, idempotent method that can carry request content, making it suitable for
+    /// complex queries that do not fit well in a URI query string.
+    ///
+    /// [`MethodFilter`]: super::filters::MethodFilter
+    #[inline]
+    #[must_use]
+    pub fn query<H: Handler>(self, goal: H) -> Self {
+        self.push(Self::with_filter(filters::query()).goal(goal))
+    }
+
     /// Create a new child router with [`MethodFilter`] to filter delete method and set this child
     /// router's handler.
     ///
@@ -556,6 +569,7 @@ impl Debug for Router {
 #[cfg(test)]
 mod tests {
     use super::{PathState, Router};
+    use crate::http::Method;
     use crate::test::TestClient;
     use crate::{Response, handler};
 
@@ -619,6 +633,20 @@ mod tests {
         let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
         let matched = router.detect(&mut req, &mut path_state).await;
         assert!(matched.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_router_detect_query_method() {
+        let router = Router::with_path("search").query(fake_handler);
+
+        let mut req = TestClient::query("http://local.host/search").build();
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
+        assert!(router.detect(&mut req, &mut path_state).await.is_some());
+        assert_eq!(req.method(), &Method::QUERY);
+
+        let mut req = TestClient::get("http://local.host/search").build();
+        let mut path_state = PathState::from_owned_path(req.uri().path().to_owned());
+        assert!(router.detect(&mut req, &mut path_state).await.is_none());
     }
     #[tokio::test]
     async fn test_router_detect2() {

--- a/crates/core/src/test/client.rs
+++ b/crates/core/src/test/client.rs
@@ -23,6 +23,11 @@ impl TestClient {
         RequestBuilder::new(url, Method::PUT)
     }
 
+    /// Create a new `RequestBuilder` with the QUERY method and this TestClient's settings applied on it.
+    pub fn query(url: impl AsRef<str>) -> RequestBuilder {
+        RequestBuilder::new(url, Method::QUERY)
+    }
+
     /// Create a new `RequestBuilder` with the DELETE method and this TestClient's settings applied on it.
     pub fn delete(url: impl AsRef<str>) -> RequestBuilder {
         RequestBuilder::new(url, Method::DELETE)

--- a/crates/jwt-auth/src/lib.rs
+++ b/crates/jwt-auth/src/lib.rs
@@ -216,7 +216,7 @@ pub const JWT_AUTH_TOKEN_KEY: &str = "::salvo::jwt_auth::auth_token";
 /// key used to insert auth error to depot.
 pub const JWT_AUTH_ERROR_KEY: &str = "::salvo::jwt_auth::auth_error";
 
-const ALL_METHODS: [Method; 9] = [
+const ALL_METHODS: [Method; 10] = [
     Method::GET,
     Method::POST,
     Method::PUT,
@@ -226,6 +226,7 @@ const ALL_METHODS: [Method; 9] = [
     Method::CONNECT,
     Method::PATCH,
     Method::TRACE,
+    Method::QUERY,
 ];
 
 /// JwtAuthError
@@ -608,8 +609,19 @@ mod tests {
     #[test]
     fn test_header_finder_new() {
         let finder = HeaderFinder::new();
-        assert_eq!(finder.allowed_methods.len(), 9); // All methods
+        assert_eq!(finder.allowed_methods.len(), ALL_METHODS.len());
+        assert!(finder.allowed_methods.contains(&Method::QUERY));
         assert_eq!(finder.header_names.len(), 1); // Authorization
+    }
+
+    #[tokio::test]
+    async fn test_header_finder_allows_query_by_default() {
+        let finder = HeaderFinder::new();
+        let mut req = TestClient::query("http://local.host/search")
+            .add_header("Authorization", "Bearer token", true)
+            .build();
+
+        assert_eq!(finder.find_token(&mut req).await.as_deref(), Some("token"));
     }
 
     #[test]
@@ -643,7 +655,7 @@ mod tests {
     fn test_query_finder_new() {
         let finder = QueryFinder::new("token");
         assert_eq!(finder.query_name, "token");
-        assert_eq!(finder.allowed_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), ALL_METHODS.len());
     }
 
     #[test]
@@ -671,7 +683,7 @@ mod tests {
     fn test_cookie_finder_new() {
         let finder = CookieFinder::new("session");
         assert_eq!(finder.cookie_name, "session");
-        assert_eq!(finder.allowed_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), ALL_METHODS.len());
     }
 
     #[test]
@@ -693,7 +705,7 @@ mod tests {
     fn test_form_finder_new() {
         let finder = FormFinder::new("token");
         assert_eq!(finder.field_name, "token");
-        assert_eq!(finder.allowed_methods.len(), 9);
+        assert_eq!(finder.allowed_methods.len(), ALL_METHODS.len());
     }
 
     #[test]


### PR DESCRIPTION
Adds QUERY routing and filtering support through Router::query and filters::query, adds TestClient::query, and raises the minimum http dependency to 1.5. QUERY is included in JWT finder defaults, while the cache middleware continues to cache only GET by default and exposes MethodSkipper::skip_query for explicit configuration. Includes routing, JWT extraction, and cache skipper regression tests. Closes #1657. Tested with cargo test -p salvo_core, cargo test -p salvo-jwt-auth, cargo test -p salvo-cache, targeted Clippy, and cargo fmt --all -- --check.