### PR TITLE
Add OpenAPI 3.2 object model and version-aware generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Changelog established for upcoming releases.
 - Initial opt-in OpenAPI 3.2 document support in `salvo-oapi`, including the `$self` field.
+- OpenAPI 3.2 object model in `salvo-oapi`:
+  - Tag Object `summary`, `parent` and `kind`.
+  - Server Object `name`.
+  - Path Item Object `query` (via `PathItemType::Query`) and `additionalOperations`.
+  - Parameter Object `in: querystring` (`ParameterIn::QueryString`) and `style: cookie`
+    (`ParameterStyle::Cookie`).
+  - Media Type Object `itemSchema`, `prefixEncoding` and `itemEncoding`.
+  - Encoding Object nested `encoding`, `prefixEncoding` and `itemEncoding`.
+  - Example Object `dataValue` and `serializedValue`.
+  - Response Object `summary`, and `description` is now optional on input.
+  - Components Object `mediaTypes`.
+  - Discriminator Object `defaultMapping`.
+  - XML Object `nodeType` (new `XmlNodeType` enum).
+  - Security Scheme Object `deprecated` and `oauth2MetadataUrl`.
+  - OAuth Flows Object `deviceAuthorization` (new `DeviceAuthorization` flow).
+  - Info Object `summary`.
+- Header Object gained the rest of its spec surface: `required`, `deprecated`, `style`,
+  `explode`, `example`, `examples`, `content` and extensions, plus `Header::with_content`.
+- Route discovery emits `QUERY` operations and custom HTTP methods (via
+  `additionalOperations`) when the document declares OpenAPI 3.2. Documents that still declare
+  3.1 skip such routes and log a warning explaining how to opt in.
+- `#[endpoint]` parameters accept the `QueryString` location and the `Cookie` style.
+- `Content::from_ref` / `Content::ref_location`, so a `content` map entry can reference a
+  reusable Media Type Object without changing those maps to `RefOr<Content>`.
+- `examples/oapi-3-2` demonstrates emitting a 3.2 document with a `QUERY` route.
 
 ### Changed
 
-- None yet.
+- **Breaking.** Several public enums and structs gained variants or fields, which can break
+  downstream exhaustive matches and struct literals even though the wire format change is
+  purely additive:
+  - `PathItemType::Query`, `ParameterIn::QueryString`, `ParameterStyle::Cookie` and
+    `Flow::DeviceAuthorization` are new variants.
+  - `SecurityScheme::MutualTls` gained a `deprecated` field.
+  - `Header::schema` is now `Option<RefOr<Schema>>` so a header can describe its value with
+    `content` instead. `Header::default()` still yields a `String` schema, so serialized output
+    is unchanged.
+- `OpenApi` still defaults to emitting OpenAPI 3.1; 3.2 remains opt-in via
+  `OpenApi::openapi_version`.
+
+### Notes
+
+- Documentation UI compatibility with a 3.2 document, smoke-tested against the bundled Swagger
+  UI v5.32.11 and the current CDN builds of the others: all four load the document, but only
+  Swagger UI renders `query` operations. Scalar, RapiDoc and ReDoc display the rest of the
+  document and silently omit them. Their CDN URLs are deliberately left unpinned, since no
+  released build of those three renders `query` yet.
 
 ### Fixed
 
-- None yet.
+- `PathItem` no longer duplicates operations into `extensions` when deserialized, which
+  previously made a parsed path item re-serialize with repeated keys.
+- OAuth2 flows are now resolved by their flow name instead of by shape, so a
+  `clientCredentials` flow no longer deserializes as `Flow::Password`.
+- Objects whose optional fields are skipped during serialization can now be deserialized
+  again; previously round-tripping a generated document failed with `missing field` errors.
 
 ## Historical Releases
 

--- a/crates/oapi-macros/src/parameter.rs
+++ b/crates/oapi-macros/src/parameter.rs
@@ -318,20 +318,28 @@ pub(crate) struct StructParameter {
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub(crate) enum ParameterIn {
     Query,
+    /// OpenAPI 3.2 `in: querystring`.
+    QueryString,
     Path,
     Header,
     Cookie,
 }
 
 impl ParameterIn {
-    pub(crate) const VARIANTS: &'static [Self] =
-        &[Self::Query, Self::Path, Self::Header, Self::Cookie];
+    pub(crate) const VARIANTS: &'static [Self] = &[
+        Self::Query,
+        Self::QueryString,
+        Self::Path,
+        Self::Header,
+        Self::Cookie,
+    ];
 }
 
 impl Display for ParameterIn {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Query => write!(f, "Query"),
+            Self::QueryString => write!(f, "QueryString"),
             Self::Path => write!(f, "Path"),
             Self::Header => write!(f, "Header"),
             Self::Cookie => write!(f, "Cookie"),
@@ -353,6 +361,7 @@ impl Parse for ParameterIn {
         match &*style {
             "path" => Ok(Self::Path),
             "query" => Ok(Self::Query),
+            "querystring" => Ok(Self::QueryString),
             "header" => Ok(Self::Header),
             "cookie" => Ok(Self::Cookie),
             _ => Err(Error::new(input.span(), expected_style())),
@@ -366,6 +375,7 @@ impl ToTokens for ParameterIn {
         tokens.extend(match self {
             Self::Path => quote! { #oapi::oapi::parameter::ParameterIn::Path },
             Self::Query => quote! { #oapi::oapi::parameter::ParameterIn::Query },
+            Self::QueryString => quote! { #oapi::oapi::parameter::ParameterIn::QueryString },
             Self::Header => quote! { #oapi::oapi::parameter::ParameterIn::Header },
             Self::Cookie => quote! { #oapi::oapi::parameter::ParameterIn::Cookie },
         })
@@ -382,11 +392,13 @@ pub(crate) enum ParameterStyle {
     SpaceDelimited,
     PipeDelimited,
     DeepObject,
+    /// OpenAPI 3.2 `style: cookie`.
+    Cookie,
 }
 
 impl Parse for ParameterStyle {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        const EXPECTED_STYLE: &str = "unexpected style, expected one of: Matrix, Label, Form, Simple, SpaceDelimited, PipeDelimited, DeepObject";
+        const EXPECTED_STYLE: &str = "unexpected style, expected one of: Matrix, Label, Form, Simple, SpaceDelimited, PipeDelimited, DeepObject, Cookie";
         let style = input.parse::<Ident>()?;
 
         match &*style.to_string() {
@@ -397,6 +409,7 @@ impl Parse for ParameterStyle {
             "SpaceDelimited" => Ok(Self::SpaceDelimited),
             "PipeDelimited" => Ok(Self::PipeDelimited),
             "DeepObject" => Ok(Self::DeepObject),
+            "Cookie" => Ok(Self::Cookie),
             _ => Err(Error::new(style.span(), EXPECTED_STYLE)),
         }
     }
@@ -422,6 +435,9 @@ impl ToTokens for ParameterStyle {
             }
             Self::DeepObject => {
                 tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::DeepObject })
+            }
+            Self::Cookie => {
+                tokens.extend(quote! { #oapi::oapi::parameter::ParameterStyle::Cookie })
             }
         }
     }

--- a/crates/oapi-macros/src/parameter/derive.rs
+++ b/crates/oapi-macros/src/parameter/derive.rs
@@ -110,7 +110,11 @@ impl TryToTokens for ToParameters {
                 default_parameter_in
             {
                 match default_parameter_in {
-                    ParameterIn::Query => quote! { #salvo::extract::metadata::SourceFrom::Query },
+                    // `querystring` describes the whole query string as one value; salvo
+                    // extracts from the same place, so it shares `SourceFrom::Query`.
+                    ParameterIn::Query | ParameterIn::QueryString => {
+                        quote! { #salvo::extract::metadata::SourceFrom::Query }
+                    }
                     ParameterIn::Header => quote! { #salvo::extract::metadata::SourceFrom::Header },
                     ParameterIn::Path => quote! { #salvo::extract::metadata::SourceFrom::Param },
                     ParameterIn::Cookie => quote! { #salvo::extract::metadata::SourceFrom::Cookie },
@@ -478,7 +482,12 @@ impl Parameter<'_> {
         });
         if let Some(parameter_in) = param_features.pop_parameter_in_feature() {
             let source = match parameter_in {
-                attributes::ParameterIn(crate::parameter::ParameterIn::Query) => {
+                // `querystring` describes the whole query string as one value; salvo extracts
+                // from the same place, so it shares `SourceFrom::Query`.
+                attributes::ParameterIn(
+                    crate::parameter::ParameterIn::Query
+                    | crate::parameter::ParameterIn::QueryString,
+                ) => {
                     quote! { #salvo::extract::metadata::Source::new(#salvo::extract::metadata::SourceFrom::Query, #salvo::extract::metadata::SourceParser::Smart) }
                 }
                 attributes::ParameterIn(crate::parameter::ParameterIn::Header) => {

--- a/crates/oapi/docs/endpoint.md
+++ b/crates/oapi/docs/endpoint.md
@@ -328,7 +328,8 @@ tuples separated by commas:
 
 * `in` _**Must be placed after name or parameter_type**_. Define the place of the parameter.
   This must be one of the variants of [`parameter::ParameterIn`][in_enum].
-  E.g. _`Path, Query, Header, Cookie`_
+  E.g. _`Path, Query, QueryString, Header, Cookie`_. _`QueryString`_ requires an
+  OpenAPI 3.2 document.
 
 * `deprecated` Define whether the parameter is deprecated or not. Can optionally be defined
   with explicit `bool` value as _`deprecated = bool`_.

--- a/crates/oapi/src/openapi.rs
+++ b/crates/oapi/src/openapi.rs
@@ -52,9 +52,9 @@ pub use self::schema::{
 pub use self::security::{SecurityRequirement, SecurityScheme};
 pub use self::server::{Server, ServerVariable, ServerVariables, Servers};
 pub use self::tag::Tag;
-pub use self::xml::Xml;
+pub use self::xml::{Xml, XmlNodeType};
 use crate::Endpoint;
-use crate::routing::NormNode;
+use crate::routing::{NormNode, OperationSlot};
 
 static PATH_PARAMETER_NAME_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\{([^}:]+)").expect("invalid regex"));
@@ -107,7 +107,7 @@ pub struct OpenApi {
     /// This is implicitly one server with `url` set to `/`.
     ///
     /// See more details at <https://spec.openapis.org/oas/latest.html#server-object>.
-    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub servers: BTreeSet<Server>,
 
     /// Available paths and operations for the API.
@@ -129,7 +129,7 @@ pub struct OpenApi {
     /// Few of these elements are security schemas and object schemas.
     ///
     /// See more details at <https://spec.openapis.org/oas/latest.html#components-object>.
-    #[serde(skip_serializing_if = "Components::is_empty")]
+    #[serde(default, skip_serializing_if = "Components::is_empty")]
     pub components: Components,
 
     /// Declaration of global security mechanisms that can be used across the API. The individual
@@ -137,13 +137,13 @@ pub struct OpenApi {
     /// if you wish to make security optional by adding it to the list of securities.
     ///
     /// See more details at <https://spec.openapis.org/oas/latest.html#security-requirement-object>.
-    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub security: BTreeSet<SecurityRequirement>,
 
     /// List of tags can be used to add additional documentation to matching tags of operations.
     ///
     /// See more details at <https://spec.openapis.org/oas/latest.html#tag-object>.
-    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub tags: BTreeSet<Tag>,
 
     /// Global additional documentation reference.
@@ -203,6 +203,24 @@ impl OpenApi {
     /// Set the OpenAPI Specification version used by this document.
     ///
     /// New documents default to OpenAPI 3.1. Use this method to opt in to OpenAPI 3.2.
+    ///
+    /// # Version-aware generation
+    ///
+    /// [`OpenApi::merge_router`] only emits constructs the declared version supports: `QUERY`
+    /// routes and custom HTTP methods (which need the 3.2 `query` field and
+    /// `additionalOperations` respectively) are skipped with a warning while the document
+    /// declares 3.1.
+    ///
+    /// Fields you set by hand are *not* validated against the declared version — building a
+    /// [`Tag`] with `kind` and leaving the document at 3.1 produces a 3.1 document carrying a
+    /// 3.2 field. Set the version first.
+    ///
+    /// # Documentation UI support
+    ///
+    /// All four bundled UIs load a 3.2 document, but their support for the new `query`
+    /// operation differs. As of Swagger UI v5.32.11 (vendored in this crate) `query` operations
+    /// render correctly; Scalar, RapiDoc and ReDoc — which load from a CDN at runtime — display
+    /// the rest of the document but omit `query` operations.
     ///
     /// # Examples
     ///
@@ -634,7 +652,32 @@ impl OpenApi {
         if let Some(handler_type_id) = &node.handler_type_id
             && let Some(creator) = crate::EndpointRegistry::find(handler_type_id)
         {
-            if let Some(method) = node.method {
+            // `query` operations and `additionalOperations` were both added in OpenAPI 3.2.
+            // Emitting either into a document that still declares 3.1 would make it invalid,
+            // so drop the slot and tell the user how to opt in.
+            let slot = node.method.clone().filter(|slot| {
+                let requires_3_2 = match slot {
+                    OperationSlot::Standard(PathItemType::Query) => Some("QUERY"),
+                    OperationSlot::Additional(method) => Some(&**method),
+                    OperationSlot::Standard(_) => None,
+                };
+                match requires_3_2 {
+                    Some(method) if self.openapi == OpenApiVersion::Version3_1 => {
+                        tracing::warn!(
+                            path,
+                            method,
+                            handler_name = node.handler_type_name,
+                            "HTTP method has no OpenAPI 3.1 representation; skipping in the \
+                             generated document. Call `OpenApi::openapi_version` with \
+                             `OpenApiVersion::Version3_2` to emit it"
+                        );
+                        false
+                    }
+                    _ => true,
+                }
+            });
+
+            if let Some(slot) = slot {
                 let Endpoint {
                     mut operation,
                     mut components,
@@ -674,18 +717,31 @@ impl OpenApi {
                     }
                 }
                 let path_item = self.paths.entry(path.clone()).or_default();
-                if path_item.operations.contains_key(&method) {
+                let occupied = match &slot {
+                    OperationSlot::Standard(method) => path_item.operations.contains_key(method),
+                    OperationSlot::Additional(method) => {
+                        path_item.additional_operations.contains_key(method)
+                    }
+                };
+                if occupied {
                     tracing::warn!(
                         "path `{}` already contains operation for method `{:?}`",
                         path,
-                        method
+                        slot
                     );
                 } else {
-                    path_item.operations.insert(method, operation);
+                    match slot {
+                        OperationSlot::Standard(method) => {
+                            path_item.operations.insert(method, operation);
+                        }
+                        OperationSlot::Additional(method) => {
+                            path_item.additional_operations.insert(method, operation);
+                        }
+                    }
                 }
                 self.components.append(&mut components);
-            } else {
-                // No method filter on this route: OpenAPI 3.1 has no "any-method"
+            } else if node.method.is_none() {
+                // No method filter on this route: OpenAPI has no "any-method"
                 // operation slot, so attaching the same handler to GET/POST/PUT/PATCH
                 // would lie about the API. Skip and warn so the user can attach a
                 // method filter (`.get(handler)`, `.post(handler)`, ...) explicitly.
@@ -1524,6 +1580,64 @@ mod tests {
     }
 
     #[test]
+    fn merge_router_emits_query_operation_only_for_3_2() {
+        #[salvo_oapi::endpoint]
+        async fn search() -> &'static str {
+            "ok"
+        }
+
+        let router = Router::with_path("/search").query(search);
+
+        // `query` is an OpenAPI 3.2 Path Item field, so a 3.1 document must not carry it.
+        let doc_3_1 = OpenApi::new("test api", "0.0.1").merge_router(&router);
+        assert!(
+            !doc_3_1.paths.contains_key("/search"),
+            "QUERY must not be emitted into a 3.1 document"
+        );
+
+        let doc_3_2 = OpenApi::new("test api", "0.0.1")
+            .openapi_version(OpenApiVersion::Version3_2)
+            .merge_router(&router);
+        let path_item = doc_3_2
+            .paths
+            .get("/search")
+            .expect("/search entry should exist");
+        assert!(path_item.operations.contains_key(&PathItemType::Query));
+    }
+
+    #[test]
+    fn merge_router_emits_custom_method_as_additional_operation() {
+        use salvo_core::http::Method;
+
+        #[salvo_oapi::endpoint]
+        async fn purge() -> &'static str {
+            "ok"
+        }
+
+        let router = Router::with_path("/cache")
+            .filter(salvo_core::routing::filters::MethodFilter(
+                Method::from_bytes(b"PURGE").expect("valid method"),
+            ))
+            .goal(purge);
+
+        let doc_3_1 = OpenApi::new("test api", "0.0.1").merge_router(&router);
+        assert!(
+            !doc_3_1.paths.contains_key("/cache"),
+            "custom methods must not be emitted into a 3.1 document"
+        );
+
+        let doc_3_2 = OpenApi::new("test api", "0.0.1")
+            .openapi_version(OpenApiVersion::Version3_2)
+            .merge_router(&router);
+        let path_item = doc_3_2
+            .paths
+            .get("/cache")
+            .expect("/cache entry should exist");
+        assert!(path_item.operations.is_empty());
+        assert!(path_item.additional_operations.contains_key("PURGE"));
+    }
+
+    #[test]
     fn merge_router_attaches_only_to_explicit_method() {
         #[salvo_oapi::endpoint]
         async fn delete_thing() -> &'static str {
@@ -1557,7 +1671,13 @@ mod tests {
                 "api_key",
                 SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("todo_apikey"))),
             )
-            .extend_security_schemes([("TLS", SecurityScheme::MutualTls { description: None })])
+            .extend_security_schemes([(
+                "TLS",
+                SecurityScheme::MutualTls {
+                    description: None,
+                    deprecated: None,
+                },
+            )])
             .add_schema("example", Schema::object(Object::new()))
             .extend_schemas([("", Schema::from(Object::new()))])
             .response("200", Response::new("OK"))

--- a/crates/oapi/src/openapi/components.rs
+++ b/crates/oapi/src/openapi/components.rs
@@ -5,8 +5,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Callback, Example, Header, Link, Parameter, PathItem, PropMap, RefOr, RequestBody, Response,
-    Responses, Schema, Schemas, SecurityScheme,
+    Callback, Content, Example, Header, Link, Parameter, PathItem, PropMap, RefOr, RequestBody,
+    Response, Responses, Schema, Schemas, SecurityScheme,
 };
 
 /// Implements [OpenAPI Components Object][components] which holds supported
@@ -82,6 +82,15 @@ pub struct Components {
     /// [path_item]: https://spec.openapis.org/oas/v3.1.0#path-item-object
     #[serde(skip_serializing_if = "PropMap::is_empty", default)]
     pub path_items: PropMap<String, RefOr<PathItem>>,
+
+    /// Map of reusable [OpenAPI Media Type Object][media_type]s, indexed by name. Added in
+    /// OpenAPI 3.2; entries here can be referenced from any `content` map via [`RefOr::Ref`].
+    ///
+    /// Note that the key is a component name (matching `^[a-zA-Z0-9\.\-_]+$`), not a media type.
+    ///
+    /// [media_type]: https://spec.openapis.org/oas/v3.2.0.html#media-type-object
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub media_types: PropMap<String, RefOr<Content>>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -284,6 +293,21 @@ impl Components {
         self
     }
 
+    /// Insert a reusable media type (or a [`Ref`](crate::Ref) to one) and return `self`.
+    ///
+    /// Reusable Media Type Objects were introduced in OpenAPI 3.2. `name` is a component name,
+    /// not a media type; entries are referenced as
+    /// `#/components/mediaTypes/{name}` from a `content` map.
+    #[must_use]
+    pub fn add_media_type<N: Into<String>, C: Into<RefOr<Content>>>(
+        mut self,
+        name: N,
+        media_type: C,
+    ) -> Self {
+        self.media_types.insert(name.into(), media_type.into());
+        self
+    }
+
     /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
     /// If a key from `other` is already present in `self`, the existing value is kept and
@@ -338,6 +362,11 @@ impl Components {
         self.path_items.append(&mut other.path_items);
 
         other
+            .media_types
+            .retain(|name, _| !self.media_types.contains_key(name));
+        self.media_types.append(&mut other.media_types);
+
+        other
             .extensions
             .retain(|name, _| !self.extensions.contains_key(name));
         self.extensions.append(&mut other.extensions);
@@ -363,6 +392,7 @@ impl Components {
             && self.links.is_empty()
             && self.callbacks.is_empty()
             && self.path_items.is_empty()
+            && self.media_types.is_empty()
             && self.extensions.is_empty()
     }
 }

--- a/crates/oapi/src/openapi/content.rs
+++ b/crates/oapi/src/openapi/content.rs
@@ -8,11 +8,36 @@ use super::{PropMap, RefOr, Schema};
 
 /// Content holds request body content or response content.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Content {
+    /// Reference to a reusable Media Type Object, e.g. one defined under
+    /// `components.mediaTypes`. Added in OpenAPI 3.2.
+    ///
+    /// `content` maps are typed as [`Content`] rather than `RefOr<Content>` so that existing
+    /// callers keep compiling; a [`Content`] carrying only this field serializes exactly as a
+    /// Reference Object. As with any Reference Object, sibling fields are ignored by consumers.
+    ///
+    /// ```
+    /// # use salvo_oapi::Content;
+    /// let content = Content::from_ref("#/components/mediaTypes/FramePayload");
+    /// ```
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none", default)]
+    pub ref_location: Option<String>,
+
     /// Schema used in response body or request body.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<RefOr<Schema>>,
+
+    /// Schema describing each item within a sequential media type, e.g. `text/event-stream` or
+    /// `application/jsonl`. Added in OpenAPI 3.2.
+    ///
+    /// Unlike [`Content::schema`], which applies to the complete content, `item_schema` applies
+    /// to each item in the stream independently. Both may be used together.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#media-type-object>.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub item_schema: Option<RefOr<Schema>>,
 
     /// Example for request body or response body.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,7 +47,7 @@ pub struct Content {
     /// media type and specified schema if present. [`Content::examples`] and
     /// [`Content::example`] are mutually exclusive. If both are defined `examples` will
     /// override value in `example`.
-    #[serde(skip_serializing_if = "PropMap::is_empty")]
+    #[serde(default, skip_serializing_if = "PropMap::is_empty")]
     pub examples: PropMap<String, RefOr<Example>>,
 
     /// A map between a property name and its encoding information.
@@ -33,8 +58,27 @@ pub struct Content {
     ///
     /// The encoding object SHALL only apply to `request_body` objects when the media type is
     /// multipart or `application/x-www-form-urlencoded`.
+    ///
+    /// Must not be combined with [`Content::prefix_encoding`] or [`Content::item_encoding`].
     #[serde(skip_serializing_if = "PropMap::is_empty", default)]
     pub encoding: PropMap<String, Encoding>,
+
+    /// Positional encoding information, applied to the array item at the same index. Added in
+    /// OpenAPI 3.2 and only applicable to `multipart` media types.
+    ///
+    /// Requires either [`Content::item_schema`] or an array [`Content::schema`] to be present,
+    /// and must not be combined with [`Content::encoding`].
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub prefix_encoding: Vec<Encoding>,
+
+    /// A single encoding applied to all array items not covered by
+    /// [`Content::prefix_encoding`]. Added in OpenAPI 3.2 and only applicable to `multipart`
+    /// media types.
+    ///
+    /// Requires either [`Content::item_schema`] or an array [`Content::schema`] to be present,
+    /// and must not be combined with [`Content::encoding`].
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub item_encoding: Option<Encoding>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -51,10 +95,35 @@ impl Content {
         }
     }
 
+    /// Construct a [`Content`] that is purely a reference to a reusable Media Type Object.
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn from_ref<S: Into<String>>(ref_location: S) -> Self {
+        Self {
+            ref_location: Some(ref_location.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Set the `$ref` location for this [`Content`] and return `self`. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn ref_location<S: Into<String>>(mut self, ref_location: S) -> Self {
+        self.ref_location = Some(ref_location.into());
+        self
+    }
+
     /// Add schema.
     #[must_use]
     pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
         self.schema = Some(component.into());
+        self
+    }
+
+    /// Add the schema describing each item of a sequential media type.
+    /// See [`Content::item_schema`]. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn item_schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
+        self.item_schema = Some(component.into());
         self
     }
 
@@ -112,6 +181,21 @@ impl Content {
         encoding: E,
     ) -> Self {
         self.encoding.insert(property_name.into(), encoding.into());
+        self
+    }
+
+    /// Set the positional encodings. See [`Content::prefix_encoding`]. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn prefix_encoding<I: IntoIterator<Item = Encoding>>(mut self, prefix_encoding: I) -> Self {
+        self.prefix_encoding = prefix_encoding.into_iter().collect();
+        self
+    }
+
+    /// Set the encoding applied to remaining array items. See [`Content::item_encoding`].
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn item_encoding<E: Into<Encoding>>(mut self, item_encoding: E) -> Self {
+        self.item_encoding = Some(item_encoding.into());
         self
     }
 }
@@ -192,5 +276,40 @@ mod tests {
               }
             })
         );
+    }
+
+    #[test]
+    fn content_ref_serializes_as_a_reference_object() {
+        let content = Content::from_ref("#/components/mediaTypes/FramePayload");
+        let value = serde_json::to_value(&content).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({ "$ref": "#/components/mediaTypes/FramePayload" })
+        );
+
+        let parsed: Content = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, content);
+        assert!(parsed.schema.is_none());
+    }
+
+    #[test]
+    fn test_content_openapi_3_2_streaming_fields() {
+        let content = Content::default()
+            .item_schema(crate::Ref::from_schema_name("Frame"))
+            .prefix_encoding([Encoding::default().content_type("text/html")])
+            .item_encoding(Encoding::default().content_type("image/*"));
+
+        let value = serde_json::to_value(&content).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({
+              "itemSchema": { "$ref": "#/components/schemas/Frame" },
+              "prefixEncoding": [ { "contentType": "text/html" } ],
+              "itemEncoding": { "contentType": "image/*" }
+            })
+        );
+
+        let parsed: Content = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, content);
     }
 }

--- a/crates/oapi/src/openapi/encoding.rs
+++ b/crates/oapi/src/openapi/encoding.rs
@@ -22,7 +22,7 @@ pub struct Encoding {
     /// A map allowing additional information to be provided as headers, for example
     /// Content-Disposition. Content-Type is described separately and SHALL be ignored in this
     /// section. This property SHALL be ignored if the request body media type is not a multipart.
-    #[serde(skip_serializing_if = "PropMap::is_empty")]
+    #[serde(default, skip_serializing_if = "PropMap::is_empty")]
     pub headers: PropMap<String, Header>,
 
     /// Describes how a specific property value will be serialized depending on its type. See
@@ -40,12 +40,38 @@ pub struct Encoding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explode: Option<bool>,
 
-    /// Determines whether the parameter value SHOULD allow reserved characters, as defined by
-    /// RFC3986 `:/?#[]@!$&'()*+,;=` to be included without percent-encoding. The default value is
-    /// false. This property SHALL be ignored if the request body media type is not
-    /// `application/x-www-form-urlencoded`.
+    /// When this is true, values are serialized using reserved expansion, letting RFC3986's
+    /// reserved character set `:/?#[]@!$&'()*+,;=` pass through unchanged. The default value is
+    /// false.
+    ///
+    /// In OpenAPI 3.1 this only applied to `application/x-www-form-urlencoded` request bodies;
+    /// OpenAPI 3.2 generalizes it to RFC6570-style serialization, and it has no effect for
+    /// `multipart/form-data`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_reserved: Option<bool>,
+
+    /// Nested encoding applied by property name, mirroring the [`Content::encoding`] field of the
+    /// enclosing media type. Added in OpenAPI 3.2.
+    ///
+    /// Must not be combined with [`Encoding::prefix_encoding`] or [`Encoding::item_encoding`].
+    ///
+    /// [`Content::encoding`]: crate::openapi::Content::encoding
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub encoding: PropMap<String, Encoding>,
+
+    /// Nested positional encoding, mirroring the [`Content::prefix_encoding`] field of the
+    /// enclosing media type. Added in OpenAPI 3.2.
+    ///
+    /// [`Content::prefix_encoding`]: crate::openapi::Content::prefix_encoding
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub prefix_encoding: Vec<Encoding>,
+
+    /// Nested encoding applied to every remaining array item, mirroring the
+    /// [`Content::item_encoding`] field of the enclosing media type. Added in OpenAPI 3.2.
+    ///
+    /// [`Content::item_encoding`]: crate::openapi::Content::item_encoding
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub item_encoding: Option<Box<Encoding>>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -86,6 +112,34 @@ impl Encoding {
     #[must_use]
     pub fn allow_reserved(mut self, allow_reserved: bool) -> Self {
         self.allow_reserved = Some(allow_reserved);
+        self
+    }
+
+    /// Add a nested [`Encoding`] by property name. See [`Encoding::encoding`].
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn encoding<S: Into<String>, E: Into<Self>>(
+        mut self,
+        property_name: S,
+        encoding: E,
+    ) -> Self {
+        self.encoding.insert(property_name.into(), encoding.into());
+        self
+    }
+
+    /// Set the nested positional encodings. See [`Encoding::prefix_encoding`].
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn prefix_encoding<I: IntoIterator<Item = Self>>(mut self, prefix_encoding: I) -> Self {
+        self.prefix_encoding = prefix_encoding.into_iter().collect();
+        self
+    }
+
+    /// Set the nested encoding applied to remaining array items. See [`Encoding::item_encoding`].
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn item_encoding<E: Into<Self>>(mut self, item_encoding: E) -> Self {
+        self.item_encoding = Some(Box::new(item_encoding.into()));
         self
     }
 
@@ -135,5 +189,28 @@ mod tests {
               "allowReserved": false
             })
         );
+    }
+
+    #[test]
+    fn test_nested_encoding_openapi_3_2() {
+        let encoding = Encoding::default()
+            .content_type("multipart/mixed")
+            .prefix_encoding([Encoding::default().content_type("text/html")])
+            .item_encoding(Encoding::default().content_type("image/*"))
+            .encoding("thumbnail", Encoding::default().content_type("image/png"));
+
+        let value = serde_json::to_value(&encoding).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({
+              "contentType": "multipart/mixed",
+              "encoding": { "thumbnail": { "contentType": "image/png" } },
+              "prefixEncoding": [ { "contentType": "text/html" } ],
+              "itemEncoding": { "contentType": "image/*" }
+            })
+        );
+
+        let parsed: Encoding = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, encoding);
     }
 }

--- a/crates/oapi/src/openapi/example.rs
+++ b/crates/oapi/src/openapi/example.rs
@@ -16,23 +16,40 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct Example {
     /// Short description for the [`Example`].
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub summary: String,
 
     /// Long description for the [`Example`]. Value supports markdown syntax for rich text
     /// representation.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 
     /// Embedded literal example value. [`Example::value`] and [`Example::external_value`] are
     /// mutually exclusive.
+    ///
+    /// Deprecated for non-JSON serialization targets in OpenAPI 3.2; prefer
+    /// [`Example::data_value`] and/or [`Example::serialized_value`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>,
+
+    /// An example of the data structure, which must be valid against the relevant schema. Added
+    /// in OpenAPI 3.2. When present, [`Example::value`] must be absent.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#example-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_value: Option<serde_json::Value>,
+
+    /// An example of the serialized form of the value, including encoding and escaping. Added
+    /// in OpenAPI 3.2.
+    ///
+    /// When [`Example::data_value`] is present this should be the serialization of that data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serialized_value: Option<String>,
 
     /// An URI that points to a literal example value. [`Example::external_value`] provides the
     /// capability to references an example that cannot be easily included in JSON or YAML.
     /// [`Example::value`] and [`Example::external_value`] are mutually exclusive.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub external_value: String,
 }
 
@@ -66,6 +83,22 @@ impl Example {
     #[must_use]
     pub fn value(mut self, value: serde_json::Value) -> Self {
         self.value = Some(value);
+        self
+    }
+
+    /// Add or change the structured example data. Requires OpenAPI 3.2.
+    ///
+    /// [`Example::data_value`] and [`Example::value`] are mutually exclusive.
+    #[must_use]
+    pub fn data_value(mut self, data_value: serde_json::Value) -> Self {
+        self.data_value = Some(data_value);
+        self
+    }
+
+    /// Add or change the serialized form of the example. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn serialized_value<S: Into<String>>(mut self, serialized_value: S) -> Self {
+        self.serialized_value = Some(serialized_value.into());
         self
     }
 
@@ -109,5 +142,24 @@ mod tests {
             example.value.unwrap(),
             serde_json::Value::String("value".to_owned())
         );
+    }
+
+    #[test]
+    fn example_openapi_3_2_fields_round_trip() {
+        let example = Example::new()
+            .data_value(serde_json::json!({ "lat": 10, "long": 60 }))
+            .serialized_value(r#"{"lat":10,"long":60}"#);
+
+        let value = serde_json::to_value(&example).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "dataValue": { "lat": 10, "long": 60 },
+                "serializedValue": r#"{"lat":10,"long":60}"#
+            })
+        );
+
+        let parsed: Example = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, example);
     }
 }

--- a/crates/oapi/src/openapi/header.rs
+++ b/crates/oapi/src/openapi/header.rs
@@ -3,21 +3,66 @@
 //! [header]: https://spec.openapis.org/oas/latest.html#header-object
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-use super::{BasicType, Object, RefOr, Schema};
+use super::parameter::ParameterStyle;
+use super::{BasicType, Content, Deprecated, Example, Object, PropMap, RefOr, Schema};
 
-/// Implements [OpenAPI Header Object][header] for response headers.
+/// Implements [OpenAPI Header Object][header] for response headers and for individual parts in
+/// `multipart` representations.
+///
+/// A Header Object follows the structure of the [`Parameter`](crate::Parameter) object minus
+/// `name` and `in`, and describes its value either through [`Header::schema`] or through
+/// [`Header::content`].
 ///
 /// [header]: https://spec.openapis.org/oas/latest.html#header-object
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Header {
-    /// Schema of header type.
-    pub schema: RefOr<Schema>,
-
     /// Additional description of the header value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Determines whether this header is mandatory. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+
+    /// Declares the header deprecated and to be transitioned out of usage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<Deprecated>,
+
+    /// Schema of header type. Mutually exclusive with [`Header::content`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<RefOr<Schema>>,
+
+    /// Describes how the header value is serialized. The only legal value for headers is
+    /// [`ParameterStyle::Simple`], which is also the default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<ParameterStyle>,
+
+    /// When `true`, `array` or `object` header values generate a single header whose value is a
+    /// comma-separated list. Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explode: Option<bool>,
+
+    /// Example of the header's potential value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<Value>,
+
+    /// Examples of the header's potential value, indexed by name. Mutually exclusive with
+    /// [`Header::example`].
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub examples: PropMap<String, RefOr<Example>>,
+
+    /// A map containing the representations for the header, keyed by media type. Per spec the
+    /// map must contain exactly one entry. Mutually exclusive with [`Header::schema`].
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub content: PropMap<String, Content>,
+
+    /// Optional extensions "x-something"
+    #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
+    pub extensions: PropMap<String, serde_json::Value>,
 }
 
 impl Header {
@@ -40,14 +85,34 @@ impl Header {
     #[must_use]
     pub fn new<C: Into<RefOr<Schema>>>(component: C) -> Self {
         Self {
-            schema: component.into(),
+            schema: Some(component.into()),
             ..Default::default()
         }
     }
+
+    /// Construct a [`Header`] that describes its value with a media type instead of a schema.
+    ///
+    /// ```
+    /// # use salvo_oapi::{Content, Header, Object, BasicType};
+    /// let header = Header::with_content(
+    ///     "application/linkset",
+    ///     Content::new(Object::with_type(BasicType::String)),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_content<S: Into<String>, C: Into<Content>>(media_type: S, content: C) -> Self {
+        let mut header = Self {
+            schema: None,
+            ..Default::default()
+        };
+        header.content.insert(media_type.into(), content.into());
+        header
+    }
+
     /// Add schema of header.
     #[must_use]
     pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
-        self.schema = component.into();
+        self.schema = Some(component.into());
         self
     }
 
@@ -57,13 +122,84 @@ impl Header {
         self.description = Some(description.into());
         self
     }
+
+    /// Declare whether the header is mandatory.
+    #[must_use]
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = Some(required);
+        self
+    }
+
+    /// Declare the header deprecated.
+    #[must_use]
+    pub fn deprecated<D: Into<Deprecated>>(mut self, deprecated: D) -> Self {
+        self.deprecated = Some(deprecated.into());
+        self
+    }
+
+    /// Set the serialization style of the header. Only [`ParameterStyle::Simple`] is legal.
+    #[must_use]
+    pub fn style(mut self, style: ParameterStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    /// Define whether `array` or `object` header values are exploded.
+    #[must_use]
+    pub fn explode(mut self, explode: bool) -> Self {
+        self.explode = Some(explode);
+        self
+    }
+
+    /// Add an example of the header's potential value.
+    #[must_use]
+    pub fn example(mut self, example: Value) -> Self {
+        self.example = Some(example);
+        self
+    }
+
+    /// Insert a named [`Example`] (or a [`Ref`](crate::Ref) to one) into [`Header::examples`].
+    #[must_use]
+    pub fn add_example<N: Into<String>, E: Into<RefOr<Example>>>(
+        mut self,
+        name: N,
+        example: E,
+    ) -> Self {
+        self.examples.insert(name.into(), example.into());
+        self
+    }
+
+    /// Insert a single media-type entry into [`Header::content`].
+    ///
+    /// Per spec the `content` map must contain exactly one entry. Mutually exclusive with
+    /// [`Header::schema`].
+    #[must_use]
+    pub fn content<S: Into<String>, C: Into<Content>>(mut self, media_type: S, content: C) -> Self {
+        self.content.insert(media_type.into(), content.into());
+        self
+    }
+
+    /// Add openapi extension (`x-something`) for [`Header`].
+    #[must_use]
+    pub fn add_extension<K: Into<String>>(mut self, key: K, value: serde_json::Value) -> Self {
+        self.extensions.insert(key.into(), value);
+        self
+    }
 }
 
 impl Default for Header {
     fn default() -> Self {
         Self {
             description: Default::default(),
-            schema: Object::with_type(BasicType::String).into(),
+            required: Default::default(),
+            deprecated: Default::default(),
+            schema: Some(Object::with_type(BasicType::String).into()),
+            style: Default::default(),
+            explode: Default::default(),
+            example: Default::default(),
+            examples: Default::default(),
+            content: Default::default(),
+            extensions: Default::default(),
         }
     }
 }
@@ -99,5 +235,56 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn header_full_surface_round_trips() {
+        let header = Header::new(Object::with_type(BasicType::String))
+            .description("rate limit")
+            .required(true)
+            .deprecated(crate::Deprecated::False)
+            .style(ParameterStyle::Simple)
+            .explode(false)
+            .example(json!("100"))
+            .add_extension("x-vendor", json!("acme"));
+
+        let value = serde_json::to_value(&header).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({
+                "description": "rate limit",
+                "required": true,
+                "deprecated": false,
+                "schema": { "type": "string" },
+                "style": "simple",
+                "explode": false,
+                "example": "100",
+                "x-vendor": "acme"
+            })
+        );
+
+        let parsed: Header = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, header);
+    }
+
+    #[test]
+    fn header_with_content_omits_schema() {
+        let header = Header::with_content(
+            "application/linkset",
+            Content::new(Object::with_type(BasicType::String)),
+        );
+
+        let value = serde_json::to_value(&header).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({
+                "content": {
+                    "application/linkset": { "schema": { "type": "string" } }
+                }
+            })
+        );
+
+        let parsed: Header = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, header);
     }
 }

--- a/crates/oapi/src/openapi/info.rs
+++ b/crates/oapi/src/openapi/info.rs
@@ -31,6 +31,12 @@ pub struct Info {
     /// Title of the API.
     pub title: String,
 
+    /// Optional short summary of the API. Added in OpenAPI 3.1.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#info-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
     /// Optional description of the API.
     ///
     /// Value supports markdown syntax.
@@ -92,6 +98,13 @@ impl Info {
     #[must_use]
     pub fn version<I: Into<String>>(mut self, version: I) -> Self {
         self.version = version.into();
+        self
+    }
+
+    /// Set the short summary of the API.
+    #[must_use]
+    pub fn summary<S: Into<String>>(mut self, summary: S) -> Self {
+        self.summary = Some(summary.into());
         self
     }
 

--- a/crates/oapi/src/openapi/link.rs
+++ b/crates/oapi/src/openapi/link.rs
@@ -43,7 +43,7 @@ pub struct Link {
     /// be any value supported by JSON or an [expression][expression] e.g. `$path.id`
     ///
     /// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
-    #[serde(skip_serializing_if = "PropMap::is_empty")]
+    #[serde(default, skip_serializing_if = "PropMap::is_empty")]
     pub parameters: PropMap<String, serde_json::Value>,
 
     /// A literal value or an [expression][expression] to be used as request body when operation is

--- a/crates/oapi/src/openapi/operation.rs
+++ b/crates/oapi/src/openapi/operation.rs
@@ -101,7 +101,7 @@ pub struct Operation {
     ///
     /// [derive_path]: ../../attr.path.html
     /// [derive_openapi]: ../../derive.OpenApi.html
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
 
     /// Short summary what [`Operation`] does.
@@ -137,7 +137,7 @@ pub struct Operation {
     pub external_docs: Option<ExternalDocs>,
 
     /// List of applicable parameters for this [`Operation`].
-    #[serde(skip_serializing_if = "Parameters::is_empty")]
+    #[serde(default, skip_serializing_if = "Parameters::is_empty")]
     pub parameters: Parameters,
 
     /// Optional request body for this [`Operation`].
@@ -164,12 +164,12 @@ pub struct Operation {
     ///
     /// Security for the [`Operation`] can be set to optional by adding empty security with
     /// [`SecurityRequirement::default`].
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "security")]
     pub securities: Vec<SecurityRequirement>,
 
     /// Alternative [`Server`]s for this [`Operation`].
-    #[serde(skip_serializing_if = "Servers::is_empty")]
+    #[serde(default, skip_serializing_if = "Servers::is_empty")]
     pub servers: Servers,
 
     /// Optional extensions "x-something"

--- a/crates/oapi/src/openapi/parameter.rs
+++ b/crates/oapi/src/openapi/parameter.rs
@@ -155,9 +155,14 @@ pub struct Parameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explode: Option<bool>,
 
-    /// Defines whether parameter should allow reserved characters defined by
-    /// [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) _`:/?#[]@!$&'()*+,;=`_.
-    /// This is only applicable with [`ParameterIn::Query`]. Default value is _`false`_.
+    /// When _`true`_, values are serialized using reserved expansion, letting the reserved
+    /// characters defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2)
+    /// _`:/?#[]@!$&'()*+,;=`_ and percent-encoded triples pass through unchanged.
+    /// Default value is _`false`_.
+    ///
+    /// OpenAPI 3.1 restricted this to [`ParameterIn::Query`]; OpenAPI 3.2 defines it in terms of
+    /// RFC6570 reserved expansion, so it also applies to [`ParameterIn::Path`] parameters using
+    /// an RFC6570-based style.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_reserved: Option<bool>,
 
@@ -401,7 +406,19 @@ impl Parameter {
 #[serde(rename_all = "lowercase")]
 pub enum ParameterIn {
     /// Declares that parameter is used as query parameter.
+    ///
+    /// Must not appear in the same operation as a [`ParameterIn::QueryString`] parameter.
     Query,
+    /// Declares that the parameter is the entire URL query string, treated as a single value.
+    /// Added in OpenAPI 3.2.
+    ///
+    /// Such a parameter must describe its value with [`Parameter::content`] rather than
+    /// [`Parameter::schema`], must not appear more than once, and must not be combined with any
+    /// [`ParameterIn::Query`] parameter in the same operation.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#parameter-locations>.
+    #[serde(rename = "querystring")]
+    QueryString,
     /// Declares that parameter is used as path parameter.
     #[default]
     Path,
@@ -439,6 +456,12 @@ pub enum ParameterStyle {
     /// Simple way of rendering nested objects using form parameters .e.g. _`color[B]=150`_.
     /// Allowed with [`ParameterIn::Query`].
     DeepObject,
+    /// Cookie style parameters as defined by [RFC6265](https://www.rfc-editor.org/rfc/rfc6265),
+    /// e.g. _`name=value; other=thing`_. Added in OpenAPI 3.2 and allowed only with
+    /// [`ParameterIn::Cookie`].
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#style-values>.
+    Cookie,
 }
 
 #[cfg(test)]
@@ -573,6 +596,46 @@ mod tests {
     fn test_build_parameters() {
         let parameters = Parameters::new();
         assert!(parameters.is_empty());
+    }
+
+    #[test]
+    fn parameter_in_querystring_round_trips() {
+        let parameter = Parameter::new("query")
+            .location(ParameterIn::QueryString)
+            .content(
+                "application/x-www-form-urlencoded",
+                crate::Content::new(Schema::object(Object::new())),
+            );
+
+        let value = serde_json::to_value(&parameter).expect("serialize");
+        assert_eq!(value["in"], json!("querystring"));
+
+        let parsed: Parameter = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed.parameter_in, ParameterIn::QueryString);
+    }
+
+    #[test]
+    fn parameter_style_cookie_round_trips() {
+        let parameter = Parameter::new("session")
+            .location(ParameterIn::Cookie)
+            .style(ParameterStyle::Cookie);
+
+        let value = serde_json::to_value(&parameter).expect("serialize");
+        assert_eq!(value["style"], json!("cookie"));
+
+        let parsed: Parameter = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed.style, Some(ParameterStyle::Cookie));
+    }
+
+    #[test]
+    fn querystring_and_query_parameters_are_distinct_entries() {
+        let mut parameters = Parameters::new();
+        parameters.insert(Parameter::new("q").location(ParameterIn::Query));
+        parameters.insert(Parameter::new("q").location(ParameterIn::QueryString));
+
+        assert!(parameters.contains("q", ParameterIn::Query));
+        assert!(parameters.contains("q", ParameterIn::QueryString));
+        assert_eq!(parameters.0.len(), 2);
     }
 
     #[test]

--- a/crates/oapi/src/openapi/path.rs
+++ b/crates/oapi/src/openapi/path.rs
@@ -56,6 +56,8 @@ impl Paths {
                 item.servers.append(&mut value.servers);
                 item.parameters.append(&mut value.parameters);
                 item.operations.append(&mut value.operations);
+                item.additional_operations
+                    .append(&mut value.additional_operations);
             })
             .or_insert(value);
     }
@@ -89,7 +91,7 @@ impl Paths {
 ///
 /// [path_item]: https://spec.openapis.org/oas/latest.html#path-item-object
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Debug)]
+#[derive(Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PathItem {
     /// External reference to a Path Item Object defined elsewhere.
@@ -127,9 +129,71 @@ pub struct PathItem {
     #[serde(flatten, default)]
     pub operations: Operations,
 
+    /// Operations on this path that use an HTTP method with no dedicated field, e.g. a custom
+    /// or registered extension method. Added in OpenAPI 3.2.
+    ///
+    /// The key is the HTTP method with the exact capitalization sent in the request (e.g.
+    /// `PURGE`). Methods that already have a dedicated field must not appear here — use
+    /// [`PathItem::operations`] for those.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#path-item-object>.
+    #[serde(skip_serializing_if = "PropMap::is_empty", default)]
+    pub additional_operations: PropMap<String, Operation>,
+
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
     pub extensions: PropMap<String, serde_json::Value>,
+}
+
+/// Deserializing a [`PathItem`] cannot be derived: the operation map and the extension map are
+/// both `flatten`ed, so serde would hand every unmatched key to *both* of them and an operation
+/// such as `get` would end up duplicated in `extensions`, making the value re-serialize with
+/// repeated keys. Partition the keys explicitly instead.
+impl<'de> Deserialize<'de> for PathItem {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        fn field<T, E>(name: &str, value: serde_json::Value) -> Result<T, E>
+        where
+            T: serde::de::DeserializeOwned,
+            E: serde::de::Error,
+        {
+            serde_json::from_value(value)
+                .map_err(|e| E::custom(format!("invalid `{name}` in path item: {e}")))
+        }
+
+        let raw = PropMap::<String, serde_json::Value>::deserialize(deserializer)?;
+        let mut item = Self::default();
+        for (key, value) in raw {
+            match &*key {
+                "$ref" => item.ref_location = Some(field("$ref", value)?),
+                "summary" => item.summary = Some(field("summary", value)?),
+                "description" => item.description = Some(field("description", value)?),
+                "servers" => item.servers = field("servers", value)?,
+                "parameters" => item.parameters = field("parameters", value)?,
+                "additionalOperations" => {
+                    item.additional_operations = field("additionalOperations", value)?;
+                }
+                _ => {
+                    // A key naming an operation with a dedicated field goes to `operations`;
+                    // everything else (`x-*` and unknown keys) is kept as an extension.
+                    match serde_json::from_value::<PathItemType>(serde_json::Value::String(
+                        key.clone(),
+                    )) {
+                        Ok(item_type) => {
+                            item.operations
+                                .insert(item_type, field::<Operation, _>(&key, value)?);
+                        }
+                        Err(_) => {
+                            item.extensions.insert(key, value);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(item)
+    }
 }
 
 impl PathItem {
@@ -170,6 +234,8 @@ impl PathItem {
     /// value from `self` will be overwritten with the respective value from `other`.
     pub fn append(&mut self, other: &mut Self) {
         self.operations.append(&mut other.operations);
+        self.additional_operations
+            .append(&mut other.additional_operations);
         self.servers.append(&mut other.servers);
         self.parameters.append(&mut other.parameters);
         if other.description.is_some() {
@@ -196,6 +262,27 @@ impl PathItem {
         operation: O,
     ) -> Self {
         self.operations.insert(path_item_type, operation.into());
+        self
+    }
+
+    /// Append an [`Operation`] for an HTTP method that has no dedicated Path Item field, e.g.
+    /// a custom method. Requires OpenAPI 3.2.
+    ///
+    /// `method` must be the HTTP method with the exact capitalization sent in the request, and
+    /// must not be one of the methods covered by [`PathItemType`].
+    ///
+    /// ```
+    /// # use salvo_oapi::{Operation, PathItem};
+    /// let item = PathItem::default().add_additional_operation("PURGE", Operation::new());
+    /// ```
+    #[must_use]
+    pub fn add_additional_operation<M: Into<String>, O: Into<Operation>>(
+        mut self,
+        method: M,
+        operation: O,
+    ) -> Self {
+        self.additional_operations
+            .insert(method.into(), operation.into());
         self
     }
 
@@ -239,9 +326,10 @@ impl PathItem {
 
 /// Path item operation type.
 ///
-/// Mirrors the HTTP methods supported by the OpenAPI 3.1 [Path Item Object][path_item];
+/// Mirrors the HTTP methods that have a dedicated field in the [Path Item Object][path_item];
 /// note that the spec deliberately does not list `CONNECT`, so it is intentionally absent
-/// here as well.
+/// here as well. Methods without a dedicated field go in
+/// [`PathItem::additional_operations`] instead.
 ///
 /// [path_item]: https://spec.openapis.org/oas/latest.html#path-item-object
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -263,6 +351,11 @@ pub enum PathItemType {
     Patch,
     /// Type mapping for HTTP _TRACE_ request.
     Trace,
+    /// Type mapping for HTTP _QUERY_ request, as defined by
+    /// [draft-ietf-httpbis-safe-method-w-body](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-11.html).
+    ///
+    /// Added in OpenAPI 3.2; emitting it in a 3.1 document produces an invalid document.
+    Query,
 }
 
 #[cfg(test)]
@@ -471,6 +564,65 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn path_item_query_operation_serializes_under_query_key() {
+        let path_item = PathItem::new(PathItemType::Query, Operation::new());
+        assert_json_eq!(path_item, json!({ "query": { "responses": {} } }));
+
+        let parsed: PathItem =
+            serde_json::from_value(json!({ "query": { "responses": {} } })).expect("deserialize");
+        assert!(parsed.operations.contains_key(&PathItemType::Query));
+    }
+
+    #[test]
+    fn path_item_additional_operations_round_trip() {
+        let path_item = PathItem::new(PathItemType::Get, Operation::new())
+            .add_additional_operation("PURGE", Operation::new());
+
+        let value = serde_json::to_value(&path_item).expect("serialize");
+        assert_json_eq!(
+            &value,
+            json!({
+                "get": { "responses": {} },
+                "additionalOperations": { "PURGE": { "responses": {} } }
+            })
+        );
+
+        let parsed: PathItem = serde_json::from_value(value).expect("deserialize");
+        assert!(parsed.operations.contains_key(&PathItemType::Get));
+        assert!(parsed.additional_operations.contains_key("PURGE"));
+        assert_eq!(parsed, path_item);
+    }
+
+    #[test]
+    fn path_item_deserialize_keeps_operations_out_of_extensions() {
+        let raw = json!({
+            "summary": "summary",
+            "get": { "responses": {} },
+            "additionalOperations": { "PURGE": { "responses": {} } },
+            "x-internal": true
+        });
+
+        let item: PathItem = serde_json::from_value(raw.clone()).expect("deserialize");
+        assert!(item.operations.contains_key(&PathItemType::Get));
+        assert!(item.additional_operations.contains_key("PURGE"));
+        assert_eq!(item.extensions.len(), 1);
+        assert_eq!(item.extensions.get("x-internal"), Some(&json!(true)));
+
+        // Re-serializing must not emit `get` twice.
+        assert_json_eq!(serde_json::to_value(&item).expect("serialize"), raw);
+    }
+
+    #[test]
+    fn path_item_append_merges_additional_operations() {
+        let mut path_item = PathItem::default().add_additional_operation("PURGE", Operation::new());
+        let mut other = PathItem::default().add_additional_operation("LINK", Operation::new());
+        path_item.append(&mut other);
+
+        assert!(path_item.additional_operations.contains_key("PURGE"));
+        assert!(path_item.additional_operations.contains_key("LINK"));
     }
 
     #[test]

--- a/crates/oapi/src/openapi/response.rs
+++ b/crates/oapi/src/openapi/response.rs
@@ -145,7 +145,18 @@ where
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
+    /// Short summary of the meaning of the response. Added in OpenAPI 3.2.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#response-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
     /// Description of the response. Response support markdown syntax.
+    ///
+    /// Required in OpenAPI 3.1 and optional as of OpenAPI 3.2, so documents that omit it
+    /// deserialize into an empty `String`. It is always serialized — an empty description is
+    /// valid under both versions, whereas omitting it would be invalid 3.1.
+    #[serde(default)]
     pub description: String,
 
     /// Map of headers identified by their name. `Content-Type` header will be ignored.
@@ -187,6 +198,13 @@ impl Response {
     #[must_use]
     pub fn description<I: Into<String>>(mut self, description: I) -> Self {
         self.description = description.into();
+        self
+    }
+
+    /// Add a short summary of the meaning of the response. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn summary<I: Into<String>>(mut self, summary: I) -> Self {
+        self.summary = Some(summary.into());
         self
     }
 
@@ -274,6 +292,21 @@ mod tests {
             })
         );
         Ok(())
+    }
+
+    #[test]
+    fn response_summary_serializes_and_description_is_optional_on_input() {
+        let response = Response::new("A sample response").summary("Sample");
+        assert_json_eq!(
+            response,
+            json!({ "summary": "Sample", "description": "A sample response" })
+        );
+
+        // OpenAPI 3.2 makes `description` optional; such a document must still parse.
+        let parsed: Response =
+            serde_json::from_value(json!({ "summary": "Sample" })).expect("deserialize");
+        assert_eq!(parsed.summary.as_deref(), Some("Sample"));
+        assert_eq!(parsed.description, "");
     }
 
     #[test]

--- a/crates/oapi/src/openapi/schema.rs
+++ b/crates/oapi/src/openapi/schema.rs
@@ -194,6 +194,16 @@ pub struct Discriminator {
     #[serde(skip_serializing_if = "PropMap::is_empty", default)]
     pub mapping: PropMap<String, String>,
 
+    /// The schema name or URI reference to the schema that validates the payload when the
+    /// discriminating property is absent, or holds a value with no explicit or implicit
+    /// mapping. Added in OpenAPI 3.2.
+    ///
+    /// Required by the spec when the discriminating property is optional.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#discriminator-object>.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub default_mapping: Option<String>,
+
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
     pub extensions: PropMap<String, serde_json::Value>,
@@ -213,8 +223,24 @@ impl Discriminator {
         Self {
             property_name: property_name.into(),
             mapping: PropMap::new(),
+            default_mapping: None,
             extensions: PropMap::new(),
         }
+    }
+
+    /// Add a mapping between a payload value and a schema name or URI reference.
+    #[must_use]
+    pub fn add_mapping<K: Into<String>, V: Into<String>>(mut self, value: K, schema: V) -> Self {
+        self.mapping.insert(value.into(), schema.into());
+        self
+    }
+
+    /// Set the fallback schema used when the discriminating property is missing or unmapped.
+    /// Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn default_mapping<I: Into<String>>(mut self, default_mapping: I) -> Self {
+        self.default_mapping = Some(default_mapping.into());
+        self
     }
 
     /// Add openapi extensions (`x-something`) for [`Discriminator`].
@@ -887,7 +913,13 @@ mod tests {
             )])
             .response("204", Response::new("No Content"))
             .extend_responses(vec![("200", Response::new("Okay"))])
-            .add_security_scheme("TLS", SecurityScheme::MutualTls { description: None })
+            .add_security_scheme(
+                "TLS",
+                SecurityScheme::MutualTls {
+                    description: None,
+                    deprecated: None,
+                },
+            )
             .extend_security_schemes(vec![(
                 "APIKey",
                 SecurityScheme::Http(security::Http::default()),

--- a/crates/oapi/src/openapi/security.rs
+++ b/crates/oapi/src/openapi/security.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::iter;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::PropMap;
 
@@ -38,12 +38,24 @@ impl SecurityRequirement {
     /// needed by the [`SecurityRequirement`]. Scopes must match to the ones defined in
     /// [`SecurityScheme`].
     ///
+    /// As of OpenAPI 3.2 the name may instead be the URI of a Security Scheme Object. A name
+    /// identical to a component name is always resolved as a component name, so to reference a
+    /// scheme by a single-segment relative URI that collides with a component name, prefix it
+    /// with `./` (e.g. `./foo`). No such resolution is performed here — the name is stored
+    /// verbatim.
+    ///
     /// # Examples
     ///
     /// Creates a new security requirement with scopes.
     /// ```
     /// # use salvo_oapi::security::SecurityRequirement;
     /// SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
+    /// ```
+    ///
+    /// Reference a security scheme by URI (OpenAPI 3.2).
+    /// ```
+    /// # use salvo_oapi::security::SecurityRequirement;
+    /// SecurityRequirement::new("https://example.com/schemes.json#/oauth", ["read:items"]);
     /// ```
     ///
     /// You can also create an empty security requirement with `Default::default()`.
@@ -142,6 +154,9 @@ pub enum SecurityScheme {
         /// Description information.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+        /// Declares this security scheme deprecated. Added in OpenAPI 3.2.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        deprecated: Option<bool>,
     },
 }
 impl From<OAuth2> for SecurityScheme {
@@ -183,6 +198,10 @@ pub struct ApiKeyValue {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Declares this security scheme deprecated. Added in OpenAPI 3.2; defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
     pub extensions: PropMap<String, serde_json::Value>,
@@ -202,6 +221,7 @@ impl ApiKeyValue {
         Self {
             name: name.into(),
             description: None,
+            deprecated: None,
             extensions: Default::default(),
         }
     }
@@ -219,8 +239,16 @@ impl ApiKeyValue {
         Self {
             name: name.into(),
             description: Some(description.into()),
+            deprecated: None,
             extensions: Default::default(),
         }
+    }
+
+    /// Mark this [`ApiKeyValue`] deprecated. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = Some(deprecated);
+        self
     }
 
     /// Add openapi extensions (`x-something`) for [`ApiKeyValue`].
@@ -250,6 +278,10 @@ pub struct Http {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Declares this security scheme deprecated. Added in OpenAPI 3.2; defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
     pub extensions: PropMap<String, serde_json::Value>,
@@ -273,6 +305,7 @@ impl Http {
             scheme,
             bearer_format: None,
             description: None,
+            deprecated: None,
             extensions: Default::default(),
         }
     }
@@ -308,6 +341,13 @@ impl Http {
     pub fn description<S: Into<String>>(mut self, description: S) -> Self {
         self.description = Some(description.into());
 
+        self
+    }
+
+    /// Mark this [`Http`] security scheme deprecated. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = Some(deprecated);
         self
     }
 
@@ -362,6 +402,10 @@ pub struct OpenIdConnect {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Declares this security scheme deprecated. Added in OpenAPI 3.2; defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
     pub extensions: PropMap<String, serde_json::Value>,
@@ -380,6 +424,7 @@ impl OpenIdConnect {
         Self {
             open_id_connect_url: open_id_connect_url.into(),
             description: None,
+            deprecated: None,
             extensions: Default::default(),
         }
     }
@@ -397,8 +442,16 @@ impl OpenIdConnect {
         Self {
             open_id_connect_url: open_id_connect_url.into(),
             description: Some(description.into()),
+            deprecated: None,
             extensions: Default::default(),
         }
+    }
+
+    /// Mark this [`OpenIdConnect`] security scheme deprecated. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = Some(deprecated);
+        self
     }
 
     /// Add openapi extensions (`x-something`) for [`OpenIdConnect`].
@@ -412,13 +465,28 @@ impl OpenIdConnect {
 /// OAuth2 [`Flow`] configuration for [`SecurityScheme`].
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct OAuth2 {
-    /// Map of supported OAuth2 flows.
+    /// Map of supported OAuth2 flows, keyed by the flow name defined by the
+    /// [OAuth Flows Object][flows].
+    ///
+    /// [flows]: https://spec.openapis.org/oas/v3.2.0.html#oauth-flows-object
+    #[serde(deserialize_with = "deserialize_flows")]
     pub flows: PropMap<String, Flow>,
 
     /// Optional description for the [`OAuth2`] [`Flow`] [`SecurityScheme`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// URL to the OAuth2 authorization server metadata
+    /// ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)). TLS is required.
+    /// Added in OpenAPI 3.2.
+    #[serde(rename = "oauth2MetadataUrl", skip_serializing_if = "Option::is_none")]
+    pub oauth2_metadata_url: Option<String>,
+
+    /// Declares this security scheme deprecated. Added in OpenAPI 3.2; defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -463,6 +531,8 @@ impl OAuth2 {
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
             description: None,
+            oauth2_metadata_url: None,
+            deprecated: None,
             extensions: Default::default(),
         }
     }
@@ -507,9 +577,62 @@ impl OAuth2 {
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
             description: Some(description.into()),
+            oauth2_metadata_url: None,
+            deprecated: None,
             extensions: Default::default(),
         }
     }
+
+    /// Set the OAuth2 authorization server metadata URL. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn oauth2_metadata_url<S: Into<String>>(mut self, oauth2_metadata_url: S) -> Self {
+        self.oauth2_metadata_url = Some(oauth2_metadata_url.into());
+        self
+    }
+
+    /// Mark this [`OAuth2`] security scheme deprecated. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = Some(deprecated);
+        self
+    }
+}
+
+/// Deserialize the [`OAuth2::flows`] map by dispatching on the flow name rather than relying on
+/// [`Flow`]'s untagged representation.
+///
+/// Several flows are structurally indistinguishable — `password` and `clientCredentials` have
+/// identical fields, and `deviceAuthorization` is a superset of both — so an untagged match would
+/// resolve them by declaration order and pick the wrong variant. The map key names the flow, so
+/// use it.
+fn deserialize_flows<'de, D>(deserializer: D) -> Result<PropMap<String, Flow>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    fn flow<T, E>(name: &str, value: serde_json::Value) -> Result<T, E>
+    where
+        T: serde::de::DeserializeOwned,
+        E: serde::de::Error,
+    {
+        serde_json::from_value(value)
+            .map_err(|e| E::custom(format!("invalid `{name}` oauth2 flow: {e}")))
+    }
+
+    let raw = PropMap::<String, serde_json::Value>::deserialize(deserializer)?;
+    let mut flows = PropMap::new();
+    for (key, value) in raw {
+        let parsed = match &*key {
+            "implicit" => Flow::Implicit(flow(&key, value)?),
+            "password" => Flow::Password(flow(&key, value)?),
+            "clientCredentials" => Flow::ClientCredentials(flow(&key, value)?),
+            "authorizationCode" => Flow::AuthorizationCode(flow(&key, value)?),
+            "deviceAuthorization" => Flow::DeviceAuthorization(flow(&key, value)?),
+            // Unknown flow name: fall back to matching on shape.
+            _ => flow(&key, value)?,
+        };
+        flows.insert(key, parsed);
+    }
+    Ok(flows)
 }
 
 /// [`OAuth2`] flow configuration object.
@@ -519,6 +642,14 @@ impl OAuth2 {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 pub enum Flow {
+    /// Define device authorization [`Flow`] type. See [`DeviceAuthorization::new`] for usage
+    /// details. Added in OpenAPI 3.2.
+    ///
+    /// Declared first because this enum is untagged: the other variants ignore the unknown
+    /// `deviceAuthorizationUrl` key, so a device flow reached through a bare `Flow`
+    /// deserialization would otherwise be misparsed as [`Flow::Password`]. Inside an
+    /// [`OAuth2`] document the flow name decides the variant — see [`deserialize_flows`].
+    DeviceAuthorization(DeviceAuthorization),
     /// Define implicit [`Flow`] type. See [`Implicit::new`] for usage details.
     ///
     /// Soon to be deprecated by <https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics>.
@@ -534,6 +665,7 @@ pub enum Flow {
 impl Flow {
     fn get_type_as_str(&self) -> &str {
         match self {
+            Self::DeviceAuthorization(_) => "deviceAuthorization",
             Self::Implicit(_) => "implicit",
             Self::Password(_) => "password",
             Self::ClientCredentials(_) => "clientCredentials",
@@ -916,6 +1048,90 @@ impl ClientCredentials {
     }
 
     /// Add openapi extensions (`x-something`) for [`ClientCredentials`].
+    #[must_use]
+    pub fn extensions(mut self, extensions: PropMap<String, serde_json::Value>) -> Self {
+        self.extensions = extensions;
+        self
+    }
+}
+
+/// Device authorization [`Flow`] configuration for [`OAuth2`], as defined by
+/// [RFC8628](https://tools.ietf.org/html/rfc8628). Added in OpenAPI 3.2.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceAuthorization {
+    /// Device authorization url for this flow. OAuth2 standard requires TLS.
+    pub device_authorization_url: String,
+
+    /// Token url for this flow. OAuth2 standard requires TLS.
+    pub token_url: String,
+
+    /// Optional refresh token url.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// Scopes required by the flow.
+    #[serde(flatten)]
+    pub scopes: Scopes,
+
+    /// Optional extensions "x-something"
+    #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
+    pub extensions: PropMap<String, serde_json::Value>,
+}
+
+impl DeviceAuthorization {
+    /// Construct a new device authorization OAuth flow.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use salvo_oapi::security::{DeviceAuthorization, Scopes};
+    /// DeviceAuthorization::new(
+    ///     "https://localhost/device_authorization",
+    ///     "https://localhost/token",
+    ///     Scopes::from_iter([("edit:items", "edit my items")]),
+    /// );
+    /// ```
+    pub fn new<S: Into<String>>(device_authorization_url: S, token_url: S, scopes: Scopes) -> Self {
+        Self {
+            device_authorization_url: device_authorization_url.into(),
+            token_url: token_url.into(),
+            refresh_url: None,
+            scopes,
+            extensions: Default::default(),
+        }
+    }
+
+    /// Construct a new device authorization OAuth flow with an additional refresh URL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use salvo_oapi::security::{DeviceAuthorization, Scopes};
+    /// DeviceAuthorization::with_refresh_url(
+    ///     "https://localhost/device_authorization",
+    ///     "https://localhost/token",
+    ///     Scopes::new(),
+    ///     "https://localhost/refresh-token",
+    /// );
+    /// ```
+    pub fn with_refresh_url<S: Into<String>>(
+        device_authorization_url: S,
+        token_url: S,
+        scopes: Scopes,
+        refresh_url: S,
+    ) -> Self {
+        Self {
+            device_authorization_url: device_authorization_url.into(),
+            token_url: token_url.into(),
+            refresh_url: Some(refresh_url.into()),
+            scopes,
+            extensions: Default::default(),
+        }
+    }
+
+    /// Add openapi extensions (`x-something`) for [`DeviceAuthorization`].
     #[must_use]
     pub fn extensions(mut self, extensions: PropMap<String, serde_json::Value>) -> Self {
         self.extensions = extensions;
@@ -1449,11 +1665,113 @@ mod tests {
     test_fn! {
         security_scheme_correct_mutual_tls:
         SecurityScheme::MutualTls {
-            description: Some(String::from("authorization is performed with client side certificate"))
+            description: Some(String::from("authorization is performed with client side certificate")),
+            deprecated: None
         };
         r###"{
   "type": "mutualTLS",
   "description": "authorization is performed with client side certificate"
 }"###
+    }
+
+    #[test]
+    fn security_requirement_accepts_uri_references() {
+        // OpenAPI 3.2 allows a requirement name to be a URI, a `./`-prefixed relative
+        // reference disambiguating a component-name collision, or a plain component name.
+        let requirement = SecurityRequirement::new("api_key", Vec::<String>::new())
+            .add("./foo", ["read:items"])
+            .add("https://example.com/schemes.json#/oauth", ["write:items"]);
+
+        let value = serde_json::to_value(&requirement).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "api_key": [],
+                "./foo": ["read:items"],
+                "https://example.com/schemes.json#/oauth": ["write:items"]
+            })
+        );
+
+        let parsed: SecurityRequirement = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, requirement);
+    }
+
+    #[test]
+    fn device_authorization_flow_round_trips_under_its_own_key() {
+        let scheme = SecurityScheme::OAuth2(OAuth2::new([Flow::DeviceAuthorization(
+            DeviceAuthorization::with_refresh_url(
+                "https://localhost/device_authorization",
+                "https://localhost/token",
+                Scopes::one("edit:items", "edit my items"),
+                "https://localhost/refresh",
+            ),
+        )]));
+
+        let value = serde_json::to_value(&scheme).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "oauth2",
+                "flows": {
+                    "deviceAuthorization": {
+                        "deviceAuthorizationUrl": "https://localhost/device_authorization",
+                        "tokenUrl": "https://localhost/token",
+                        "refreshUrl": "https://localhost/refresh",
+                        "scopes": { "edit:items": "edit my items" }
+                    }
+                }
+            })
+        );
+
+        // `Flow` is untagged, so the device flow must not be swallowed by `Password`, whose
+        // fields are a subset of it.
+        let parsed: SecurityScheme = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, scheme);
+    }
+
+    #[test]
+    fn oauth2_metadata_url_and_deprecated_serialize() {
+        let scheme = SecurityScheme::OAuth2(
+            OAuth2::new([Flow::ClientCredentials(ClientCredentials::new(
+                "https://localhost/token",
+                Scopes::new(),
+            ))])
+            .oauth2_metadata_url("https://localhost/.well-known/oauth-authorization-server")
+            .deprecated(true),
+        );
+
+        let value = serde_json::to_value(&scheme).expect("serialize");
+        assert_eq!(
+            value["oauth2MetadataUrl"],
+            serde_json::json!("https://localhost/.well-known/oauth-authorization-server")
+        );
+        assert_eq!(value["deprecated"], serde_json::json!(true));
+
+        let parsed: SecurityScheme = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, scheme);
+    }
+
+    #[test]
+    fn deprecated_is_available_on_every_scheme_kind() {
+        for scheme in [
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Basic).deprecated(true)),
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("api_key").deprecated(true))),
+            SecurityScheme::OpenIdConnect(
+                OpenIdConnect::new("https://localhost/openid").deprecated(true),
+            ),
+            SecurityScheme::MutualTls {
+                description: None,
+                deprecated: Some(true),
+            },
+        ] {
+            let value = serde_json::to_value(&scheme).expect("serialize");
+            assert_eq!(
+                value["deprecated"],
+                serde_json::json!(true),
+                "deprecated missing from {value}"
+            );
+            let parsed: SecurityScheme = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(parsed, scheme);
+        }
     }
 }

--- a/crates/oapi/src/openapi/server.rs
+++ b/crates/oapi/src/openapi/server.rs
@@ -96,6 +96,7 @@ impl Servers {
         if let Some(mut exist_server) = exist_server {
             let Server {
                 description,
+                name,
                 mut variables,
                 extensions,
                 ..
@@ -103,6 +104,9 @@ impl Servers {
             exist_server.variables.append(&mut variables);
             if description.is_some() {
                 exist_server.description = description;
+            }
+            if name.is_some() {
+                exist_server.name = name;
             }
             exist_server.extensions.extend(extensions);
             self.0.remove(&exist_server);
@@ -155,8 +159,15 @@ pub struct Server {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Optional unique name used to refer to the host designated by [`Server::url`]. Added in
+    /// OpenAPI 3.2.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#server-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
     /// Optional map of variable name and its substitution value used in [`Server::url`].
-    #[serde(skip_serializing_if = "ServerVariables::is_empty")]
+    #[serde(default, skip_serializing_if = "ServerVariables::is_empty")]
     pub variables: ServerVariables,
 
     /// Optional extensions "x-something"
@@ -217,6 +228,13 @@ impl Server {
     #[must_use]
     pub fn description<S: Into<String>>(mut self, description: S) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Add or change the unique name used to refer to this [`Server`]. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
         self
     }
 
@@ -335,7 +353,7 @@ pub struct ServerVariable {
 
     /// Enum values can be used to limit possible options for substitution. If enum values is used
     /// the [`ServerVariable::default_value`] must contain one of the enum values.
-    #[serde(rename = "enum", skip_serializing_if = "BTreeSet::is_empty")]
+    #[serde(default, rename = "enum", skip_serializing_if = "BTreeSet::is_empty")]
     enum_values: BTreeSet<String>,
 
     /// Optional extensions "x-something"

--- a/crates/oapi/src/openapi/tag.rs
+++ b/crates/oapi/src/openapi/tag.rs
@@ -20,6 +20,13 @@ pub struct Tag {
     /// Name of the tag. Should match to tag of **operation**.
     pub name: String,
 
+    /// Short summary of the tag, used for display purposes. Added in OpenAPI 3.2 as the
+    /// standardized replacement for the `x-displayName` extension.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#tag-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
     /// Additional description for the tag shown in the document.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -27,6 +34,20 @@ pub struct Tag {
     /// Additional external documentation for the tag.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocs>,
+
+    /// [`Tag::name`] of the tag this tag is nested under. Added in OpenAPI 3.2.
+    ///
+    /// The named tag must exist in the document and circular parent/child references are not
+    /// allowed; neither condition is validated here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+
+    /// Machine-readable string categorizing what sort of tag this is. Added in OpenAPI 3.2.
+    ///
+    /// Any string is allowed; commonly used values are `nav`, `badge` and `audience`. See the
+    /// [registry](https://spec.openapis.org/registry/tag-kind/) for the well-known values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "PropMap::is_empty", flatten)]
@@ -74,10 +95,31 @@ impl Tag {
         self
     }
 
+    /// Add a short summary used for display purposes. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
     /// Add additional description for the tag.
     #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Nest this tag under the tag with the given name. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn parent(mut self, parent: impl Into<String>) -> Self {
+        self.parent = Some(parent.into());
+        self
+    }
+
+    /// Categorize the tag, e.g. `nav`, `badge` or `audience`. Requires OpenAPI 3.2.
+    #[must_use]
+    pub fn kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
         self
     }
 
@@ -116,6 +158,39 @@ mod tests {
 
         let tag = tag.external_docs(ExternalDocs::new(""));
         assert!(tag.external_docs.is_some());
+    }
+
+    #[test]
+    fn tag_openapi_3_2_fields_round_trip() {
+        let tag = Tag::new("partner")
+            .summary("Partner")
+            .description("Operations available to the partners network")
+            .parent("external")
+            .kind("audience");
+
+        let value = serde_json::to_value(&tag).expect("serialize");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "name": "partner",
+                "summary": "Partner",
+                "description": "Operations available to the partners network",
+                "parent": "external",
+                "kind": "audience"
+            })
+        );
+
+        let parsed: Tag = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn tag_3_1_output_is_unchanged() {
+        let tag = Tag::new("pets").description("pet operations");
+        assert_eq!(
+            serde_json::to_value(&tag).expect("serialize"),
+            serde_json::json!({ "name": "pets", "description": "pet operations" })
+        );
     }
 
     #[test]

--- a/crates/oapi/src/openapi/xml.rs
+++ b/crates/oapi/src/openapi/xml.rs
@@ -15,7 +15,17 @@ use serde::{Deserialize, Serialize};
 /// [schema]: ../schema/index.html
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct Xml {
+    /// The kind of XML node the schema corresponds to. Added in OpenAPI 3.2.
+    ///
+    /// When set, [`Xml::attribute`] and [`Xml::wrapped`] must not be used — `nodeType` is the
+    /// replacement for both.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0.html#xml-object>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_type: Option<XmlNodeType>,
+
     /// Used to replace the name of attribute or type used in schema property.
     /// When used with [`Xml::wrapped`] attribute the name will be used as a wrapper name
     /// for wrapped array instead of the item or type name.
@@ -31,13 +41,38 @@ pub struct Xml {
     pub prefix: Option<Cow<'static, str>>,
 
     /// Flag deciding will this attribute translate to element attribute instead of xml element.
+    ///
+    /// Deprecated in OpenAPI 3.2 in favour of [`XmlNodeType::Attribute`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribute: Option<bool>,
 
     /// Flag only usable with array definition. If set to true the output xml will wrap the array
     /// of items `<pets><pet></pet></pets>` instead of unwrapped `<pet></pet>`.
+    ///
+    /// Deprecated in OpenAPI 3.2 in favour of [`XmlNodeType::Element`] on the array schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrapped: Option<bool>,
+}
+
+/// The kind of XML [DOM node](https://dom.spec.whatwg.org/#interface-node) a schema describes.
+///
+/// Used by the OpenAPI 3.2 [`Xml::node_type`] field.
+///
+/// See <https://spec.openapis.org/oas/v3.2.0.html#xml-node-types>.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum XmlNodeType {
+    /// The schema represents an element and describes its contents.
+    Element,
+    /// The schema represents an attribute and describes its value.
+    Attribute,
+    /// The schema represents a text node (parsed character data).
+    Text,
+    /// The schema represents a CDATA section.
+    Cdata,
+    /// The schema does not correspond to any node; nodes for its subschemas are placed
+    /// directly under the parent schema's node.
+    None,
 }
 
 impl Xml {
@@ -51,6 +86,15 @@ impl Xml {
 }
 
 impl Xml {
+    /// Set [`Xml::node_type`]. Requires OpenAPI 3.2.
+    ///
+    /// Builder style chainable consuming add node type method.
+    #[must_use]
+    pub fn node_type(mut self, node_type: XmlNodeType) -> Self {
+        self.node_type = Some(node_type);
+        self
+    }
+
     /// Add [`Xml::name`] to xml object.
     ///
     /// Builder style chainable consuming add name method.
@@ -99,7 +143,7 @@ impl Xml {
 
 #[cfg(test)]
 mod tests {
-    use super::Xml;
+    use super::{Xml, XmlNodeType};
 
     #[test]
     fn xml_new() {
@@ -125,5 +169,31 @@ mod tests {
 
         xml = xml.wrapped(true);
         assert!(xml.wrapped.is_some());
+    }
+
+    #[test]
+    fn xml_node_type_round_trips() {
+        for (node_type, rendered) in [
+            (XmlNodeType::Element, "element"),
+            (XmlNodeType::Attribute, "attribute"),
+            (XmlNodeType::Text, "text"),
+            (XmlNodeType::Cdata, "cdata"),
+            (XmlNodeType::None, "none"),
+        ] {
+            let xml = Xml::new().node_type(node_type);
+            let value = serde_json::to_value(&xml).expect("serialize");
+            assert_eq!(value, serde_json::json!({ "nodeType": rendered }));
+            let parsed: Xml = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(parsed.node_type, Some(node_type));
+        }
+    }
+
+    #[test]
+    fn xml_without_node_type_is_unchanged() {
+        let xml = Xml::new().name("pet").wrapped(true);
+        assert_eq!(
+            serde_json::to_value(&xml).expect("serialize"),
+            serde_json::json!({ "name": "pet", "wrapped": true })
+        );
     }
 }

--- a/crates/oapi/src/routing.rs
+++ b/crates/oapi/src/routing.rs
@@ -76,12 +76,22 @@ fn normalize_oapi_path(path: &str) -> String {
     normalized
 }
 
+/// Where an operation discovered on a route belongs inside a Path Item Object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OperationSlot {
+    /// A method with a dedicated Path Item field.
+    Standard(PathItemType),
+    /// A method with no dedicated field, emitted under `additionalOperations`. The value is
+    /// the method name with the capitalization sent in the request. Requires OpenAPI 3.2.
+    Additional(String),
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct NormNode {
     // pub(crate) router_id: usize,
     pub(crate) handler_type_id: Option<TypeId>,
     pub(crate) handler_type_name: Option<&'static str>,
-    pub(crate) method: Option<PathItemType>,
+    pub(crate) method: Option<OperationSlot>,
     pub(crate) path: Option<String>,
     pub(crate) children: Vec<Self>,
     pub(crate) metadata: Metadata,
@@ -110,34 +120,31 @@ impl NormNode {
                     node.path = Some(normalize_oapi_path(&path));
                 }
                 FilterInfo::Method(method) => {
-                    // Only overwrite when the method maps to a known
-                    // `PathItemType`; unknown/extension methods leave any
-                    // previously recognized value in place so combining a
-                    // standard method filter with a custom one does not erase
-                    // the standard mapping (the previous string-parsing path
-                    // had the same behavior via its `_ => {}` arm).
-                    //
-                    // CONNECT is intentionally not mapped: OpenAPI 3.1 does
-                    // not define a `connect` operation under Path Item, so
-                    // emitting one would produce an invalid document.
+                    // Methods with a dedicated Path Item field map to `PathItemType`;
+                    // everything else (CONNECT and custom/extension methods) goes to
+                    // `additionalOperations`, which requires OpenAPI 3.2. Whether such a
+                    // slot is actually emitted is decided later, when the document version
+                    // is known.
                     let item = match method {
-                        Method::GET => Some(PathItemType::Get),
-                        Method::POST => Some(PathItemType::Post),
-                        Method::PUT => Some(PathItemType::Put),
-                        Method::DELETE => Some(PathItemType::Delete),
-                        Method::HEAD => Some(PathItemType::Head),
-                        Method::OPTIONS => Some(PathItemType::Options),
-                        Method::TRACE => Some(PathItemType::Trace),
-                        Method::PATCH => Some(PathItemType::Patch),
-                        _ => None,
+                        Method::GET => OperationSlot::Standard(PathItemType::Get),
+                        Method::POST => OperationSlot::Standard(PathItemType::Post),
+                        Method::PUT => OperationSlot::Standard(PathItemType::Put),
+                        Method::DELETE => OperationSlot::Standard(PathItemType::Delete),
+                        Method::HEAD => OperationSlot::Standard(PathItemType::Head),
+                        Method::OPTIONS => OperationSlot::Standard(PathItemType::Options),
+                        Method::TRACE => OperationSlot::Standard(PathItemType::Trace),
+                        Method::PATCH => OperationSlot::Standard(PathItemType::Patch),
+                        Method::QUERY => OperationSlot::Standard(PathItemType::Query),
+                        other => OperationSlot::Additional(other.as_str().to_owned()),
                     };
-                    if item.is_some() {
-                        node.method = item;
-                    } else if method == Method::CONNECT {
-                        tracing::warn!(
-                            "HTTP CONNECT has no OpenAPI 3.1 mapping; the route will be \
-                             omitted from the generated document"
-                        );
+                    // A standard method never loses to a custom one, so combining a
+                    // standard method filter with a custom one does not erase the standard
+                    // mapping (the previous string-parsing path had the same behavior via
+                    // its `_ => {}` arm).
+                    if matches!(item, OperationSlot::Standard(_))
+                        || !matches!(node.method, Some(OperationSlot::Standard(_)))
+                    {
+                        node.method = Some(item);
                     }
                 }
                 // Other filter kinds (Scheme/Host/Port/Other) do not carry

--- a/crates/oapi/tests/openapi_3_2.rs
+++ b/crates/oapi/tests/openapi_3_2.rs
@@ -1,0 +1,249 @@
+//! Round-trip fixtures for OpenAPI 3.2 documents.
+//!
+//! Every 3.2 object added in <https://github.com/salvo-rs/salvo/issues/1685> appears at least
+//! once here, so a regression in serialization *or* deserialization shows up as a diff against
+//! the fixture rather than as a silently dropped field.
+
+use salvo_oapi::schema::OneOf;
+use salvo_oapi::security::{
+    ApiKey, ApiKeyValue, DeviceAuthorization, Flow, OAuth2, Scopes, SecurityScheme,
+};
+use salvo_oapi::{
+    BasicType, Components, Content, Discriminator, Encoding, Example, Header, Info, Object,
+    OpenApi, OpenApiVersion, Operation, Parameter, ParameterIn, ParameterStyle, PathItem,
+    PathItemType, Ref, Response, Schema, Server, Tag, Xml, XmlNodeType,
+};
+use serde_json::{Value, json};
+
+fn document() -> OpenApi {
+    let mut doc = OpenApi::with_info(
+        Info::new("streaming api", "1.0.0").summary("A short summary of the API"),
+    )
+    .openapi_version(OpenApiVersion::Version3_2)
+    .self_uri("https://example.com/openapi.json");
+
+    doc.servers.insert(
+        Server::new("https://example.com/api")
+            .name("production")
+            .description("primary host"),
+    );
+
+    doc.tags
+        .insert(Tag::new("external").summary("External").kind("audience"));
+    doc.tags.insert(
+        Tag::new("partner")
+            .summary("Partner")
+            .parent("external")
+            .kind("audience"),
+    );
+
+    let stream = Content::default()
+        .item_schema(Ref::from_schema_name("Frame"))
+        .prefix_encoding([Encoding::default().content_type("text/html")])
+        .item_encoding(
+            Encoding::default()
+                .content_type("image/*")
+                .encoding("thumb", Encoding::default().content_type("image/png")),
+        );
+
+    let response = Response::new("a stream of frames")
+        .summary("Frames")
+        .add_content("multipart/mixed", stream)
+        .add_header(
+            "X-Rate-Limit",
+            Header::new(Object::with_type(BasicType::Integer)).required(true),
+        );
+
+    let search = Operation::new()
+        .add_response("200", response)
+        .add_parameter(
+            Parameter::new("filter")
+                .location(ParameterIn::QueryString)
+                .content(
+                    "application/x-www-form-urlencoded",
+                    Content::new(Object::with_type(BasicType::String)),
+                ),
+        )
+        .add_parameter(
+            Parameter::new("session")
+                .location(ParameterIn::Cookie)
+                .style(ParameterStyle::Cookie)
+                .schema(Object::with_type(BasicType::String))
+                .add_example(
+                    "basic",
+                    Example::new()
+                        .data_value(json!({ "id": 1 }))
+                        .serialized_value("session=1"),
+                ),
+        );
+
+    doc.paths.insert(
+        "/search",
+        PathItem::new(PathItemType::Query, search)
+            .add_additional_operation("PURGE", Operation::new()),
+    );
+
+    doc.components = Components::new()
+        .add_schema(
+            "Frame",
+            Schema::from(
+                Object::new()
+                    .property("kind", Object::with_type(BasicType::String))
+                    .xml(Xml::new().node_type(XmlNodeType::Element).name("frame")),
+            ),
+        )
+        .add_schema(
+            "AnyFrame",
+            Schema::OneOf(
+                OneOf::new()
+                    .item(Ref::from_schema_name("Frame"))
+                    .discriminator(
+                        Discriminator::new("kind")
+                            .add_mapping("image", "#/components/schemas/Frame")
+                            .default_mapping("#/components/schemas/Frame"),
+                    ),
+            ),
+        )
+        .add_media_type("FramePayload", Content::new(Ref::from_schema_name("Frame")))
+        .add_security_scheme(
+            "device",
+            SecurityScheme::OAuth2(
+                OAuth2::new([Flow::DeviceAuthorization(DeviceAuthorization::new(
+                    "https://example.com/device",
+                    "https://example.com/token",
+                    Scopes::one("read:frames", "read frames"),
+                ))])
+                .oauth2_metadata_url("https://example.com/.well-known/oauth-authorization-server"),
+            ),
+        )
+        .add_security_scheme(
+            "legacy",
+            SecurityScheme::ApiKey(ApiKey::Header(
+                ApiKeyValue::new("X-Api-Key").deprecated(true),
+            )),
+        );
+
+    doc
+}
+
+/// Every 3.2-only field must reach the wire under its spec name.
+#[test]
+fn openapi_3_2_document_serializes_all_new_fields() {
+    let value: Value = serde_json::to_value(document()).expect("serialize");
+
+    assert_eq!(value["openapi"], json!("3.2.0"));
+    assert_eq!(value["$self"], json!("https://example.com/openapi.json"));
+    assert_eq!(
+        value["info"]["summary"],
+        json!("A short summary of the API")
+    );
+
+    let server = &value["servers"][0];
+    assert_eq!(server["name"], json!("production"));
+
+    let partner = value["tags"]
+        .as_array()
+        .expect("tags array")
+        .iter()
+        .find(|tag| tag["name"] == json!("partner"))
+        .expect("partner tag");
+    assert_eq!(partner["summary"], json!("Partner"));
+    assert_eq!(partner["parent"], json!("external"));
+    assert_eq!(partner["kind"], json!("audience"));
+
+    let path = &value["paths"]["/search"];
+    assert!(path["query"].is_object(), "QUERY operation missing: {path}");
+    assert!(path["additionalOperations"]["PURGE"].is_object());
+
+    let params = path["query"]["parameters"].as_array().expect("parameters");
+    assert!(params.iter().any(|p| p["in"] == json!("querystring")));
+    assert!(params.iter().any(|p| p["style"] == json!("cookie")));
+
+    let example = &params
+        .iter()
+        .find(|p| p["name"] == json!("session"))
+        .expect("session parameter")["examples"]["basic"];
+    assert_eq!(example["dataValue"], json!({ "id": 1 }));
+    assert_eq!(example["serializedValue"], json!("session=1"));
+
+    let response = &path["query"]["responses"]["200"];
+    assert_eq!(response["summary"], json!("Frames"));
+
+    let media = &response["content"]["multipart/mixed"];
+    assert!(media["itemSchema"].is_object());
+    assert!(media["prefixEncoding"].is_array());
+    assert_eq!(media["itemEncoding"]["contentType"], json!("image/*"));
+    assert_eq!(
+        media["itemEncoding"]["encoding"]["thumb"]["contentType"],
+        json!("image/png")
+    );
+
+    let components = &value["components"];
+    assert!(components["mediaTypes"]["FramePayload"].is_object());
+
+    assert_eq!(
+        components["schemas"]["AnyFrame"]["discriminator"]["defaultMapping"],
+        json!("#/components/schemas/Frame")
+    );
+    assert_eq!(
+        components["schemas"]["Frame"]["xml"]["nodeType"],
+        json!("element")
+    );
+
+    let device = &components["securitySchemes"]["device"];
+    assert!(device["flows"]["deviceAuthorization"].is_object());
+    assert_eq!(
+        device["flows"]["deviceAuthorization"]["deviceAuthorizationUrl"],
+        json!("https://example.com/device")
+    );
+    assert_eq!(
+        device["oauth2MetadataUrl"],
+        json!("https://example.com/.well-known/oauth-authorization-server")
+    );
+    assert_eq!(
+        components["securitySchemes"]["legacy"]["deprecated"],
+        json!(true)
+    );
+}
+
+/// Deserializing our own output must reproduce the same document, and re-serializing it must
+/// reproduce the same JSON.
+#[test]
+fn openapi_3_2_document_round_trips() {
+    let doc = document();
+    let value = serde_json::to_value(&doc).expect("serialize");
+
+    let parsed: OpenApi = serde_json::from_value(value.clone()).expect("deserialize");
+    assert_eq!(parsed, doc);
+
+    let reserialized = serde_json::to_value(&parsed).expect("re-serialize");
+    assert_eq!(reserialized, value);
+}
+
+/// A 3.1 document must keep its 3.1 shape: none of the new fields appear unless set.
+#[test]
+fn openapi_3_1_document_is_unaffected() {
+    let doc = OpenApi::new("plain api", "1.0.0").add_path(
+        "/pets",
+        PathItem::new(
+            PathItemType::Get,
+            Operation::new().add_response("200", Response::new("ok")),
+        ),
+    );
+
+    let value = serde_json::to_value(&doc).expect("serialize");
+    assert_eq!(value["openapi"], json!("3.1.0"));
+    assert!(value.get("$self").is_none());
+    assert!(
+        value["paths"]["/pets"]
+            .get("additionalOperations")
+            .is_none()
+    );
+    assert_eq!(
+        value["paths"]["/pets"]["get"]["responses"]["200"]["description"],
+        json!("ok")
+    );
+
+    let parsed: OpenApi = serde_json::from_value(value.clone()).expect("deserialize");
+    assert_eq!(serde_json::to_value(&parsed).expect("re-serialize"), value);
+}

--- a/examples/oapi-3-2/Cargo.toml
+++ b/examples/oapi-3-2/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-oapi-3-2"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+salvo = { workspace = true, features = ["oapi"] }
+tokio = { workspace = true, features = ["macros"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/examples/oapi-3-2/src/main.rs
+++ b/examples/oapi-3-2/src/main.rs
@@ -1,0 +1,57 @@
+//! Emitting an OpenAPI 3.2 document.
+//!
+//! OpenAPI 3.1 stays the default, so 3.2 is opt-in via [`OpenApi::openapi_version`]. Only a 3.2
+//! document may carry the `QUERY` operation registered below — under 3.1 the route is skipped
+//! with a warning, since OpenAPI 3.1 has no `query` field on a Path Item Object.
+
+use salvo::oapi::extract::*;
+use salvo::oapi::{OpenApiVersion, Server as OapiServer, Tag};
+use salvo::prelude::*;
+
+#[endpoint(tags("search"))]
+async fn hello(name: QueryParam<String, false>) -> String {
+    format!("Hello, {}!", name.as_deref().unwrap_or("World"))
+}
+
+/// Run a complex search whose description travels in the request content.
+#[endpoint(tags("search"))]
+async fn search() -> &'static str {
+    "results"
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().init();
+
+    let router = Router::new()
+        .push(Router::with_path("hello").get(hello))
+        // `Router::query` registers the HTTP QUERY method, which maps to the OpenAPI 3.2
+        // `query` field of the Path Item Object.
+        .push(Router::with_path("search").query(search));
+
+    let mut doc = OpenApi::new("3.2 demo api", "0.0.1")
+        .openapi_version(OpenApiVersion::Version3_2)
+        // `$self` gives the document a stable base URI for relative references (3.2).
+        .self_uri("https://example.com/api-doc/openapi.json")
+        .merge_router(&router);
+
+    // `name` on a Server Object and `summary`/`kind` on a Tag Object are 3.2 additions.
+    doc.servers
+        .insert(OapiServer::new("/").name("local").description("local host"));
+    doc.tags.insert(
+        Tag::new("search")
+            .summary("Search")
+            .description("Search operations")
+            .kind("nav"),
+    );
+
+    let router = router
+        .unshift(doc.into_router("/api-doc/openapi.json"))
+        // Swagger UI (bundled with salvo-oapi) renders 3.2 documents, including the `query`
+        // operation below. Scalar, RapiDoc and ReDoc load the document without complaint but
+        // currently ignore `query` operations — see the crate docs for the compatibility notes.
+        .unshift(SwaggerUi::new("/api-doc/openapi.json").into_router("/swagger-ui"));
+
+    let acceptor = TcpListener::new("0.0.0.0:8699").bind().await;
+    Server::new(acceptor).serve(router).await;
+}


### PR DESCRIPTION
Closes #1685.

Completes phases 2 and 3 of OpenAPI 3.2 support. Phase 1 (`OpenApiVersion::Version3_2` and the root `$self` field) landed in #1686, and QUERY method routing in salvo-core landed in #1687.

## What changed

**Phase 2 — 3.2 object model.** All thirteen checklist items:

| Object | Added |
| --- | --- |
| Tag | `summary`, `parent`, `kind` |
| Server | `name` |
| Path Item | `query` (via `PathItemType::Query`), `additionalOperations` |
| Parameter | `in: querystring`, `style: cookie`, updated `allowReserved` semantics |
| Media Type | `itemSchema`, `prefixEncoding`, `itemEncoding` |
| Encoding | nested `encoding`, `prefixEncoding`, `itemEncoding` |
| Example | `dataValue`, `serializedValue` |
| Response | `summary`; `description` now optional on input |
| Components | `mediaTypes` |
| Discriminator | `defaultMapping` |
| XML | `nodeType` (new `XmlNodeType` enum) |
| Security Scheme | `deprecated`, `oauth2MetadataUrl` |
| OAuth Flows | Device Authorization flow + `deviceAuthorizationUrl` |

Security Requirement URI references were reviewed: the model is a plain `BTreeMap<String, Vec<String>>`, so URI names and `./`-prefixed relative references already work. Added docs and a conformance test rather than code.

**Phase 3 — generation, macros, docs.** Route discovery now emits `QUERY` and custom HTTP methods (the latter via `additionalOperations`), and does so *version-aware*: since both are 3.2-only constructs, `merge_router` skips them with an actionable warning while the document still declares 3.1. This also resolves the checklist's open question about version-aware validation. Macros learned the `QueryString` location and `Cookie` style. Also closes the model gaps the issue called out — Info `summary` and the fuller Header Object surface (`required`, `deprecated`, `style`, `explode`, `example`, `examples`, `content`, extensions, plus `Header::with_content`).

Reusable Media Type references are exposed without the churn of turning every `content` map into `RefOr<Content>`: `Content` gained an optional `$ref` (`Content::from_ref`), mirroring the existing `PathItem::ref_location` convention. A `Content` carrying only that field serializes exactly as a Reference Object.

**3.1 remains the default emitted version.**

## Pre-existing defects fixed along the way

These are not 3.2 features, but the round-trip fixtures the issue asks for cannot pass without them:

1. **`PathItem` duplicated operations into `extensions`.** It flattens both the operation map and the extension map, so serde handed every unmatched key to *both* — a parsed path item re-serialized with repeated keys. `PathItem` now implements `Deserialize` explicitly and partitions keys.
2. **`clientCredentials` OAuth2 flows deserialized as `Flow::Password`.** `Flow` is untagged and those two variants have identical fields, so the first match won. Flows are now dispatched by their flow name, which additionally keeps the new device flow independent of enum declaration order.
3. **salvo-oapi could not deserialize its own output.** Many fields carried `skip_serializing_if` without a matching `default`, so any omitted optional field failed with `missing field`. Added where needed. (`Option` fields already default implicitly and were left alone — an early blanket pass also hit `Object::schema_type`, which broke `Schema`'s untagged variant discrimination; that was reverted.)

## Breaking changes

The wire-format change is purely additive, but the Rust API is not:

- New variants: `PathItemType::Query`, `ParameterIn::QueryString`, `ParameterStyle::Cookie`, `Flow::DeviceAuthorization` — these break downstream exhaustive matches.
- `SecurityScheme::MutualTls` gained a `deprecated` field, breaking struct-literal construction.
- `Header::schema` is now `Option<RefOr<Schema>>` so a header can describe its value with `content`. `Header::default()` still yields a `String` schema, so serialized output is unchanged.

All are noted in the `Unreleased` changelog entry.

## Testing

- Full workspace suite green: 55 test targets, `cargo fmt` applied, no new clippy warnings in the touched crates.
- New `crates/oapi/tests/openapi_3_2.rs` round-trip fixtures: every new field is asserted on the wire under its spec name, the document round-trips (`serialize → deserialize → serialize` is stable), and a 3.1 document is asserted unchanged.
- New `examples/oapi-3-2` was run end-to-end; the served document carries `"openapi": "3.2.0"`, `$self`, server `name`, tag `summary`/`kind`, and the `query` operation under `/search`.

## Reviewer note: documentation UI compatibility

I smoke-tested a 3.2 document against all four bundled UIs in a browser. All four load it, but only the vendored **Swagger UI v5.32.11 renders `query` operations** — Scalar, RapiDoc and ReDoc display the rest of the document and silently omit them.

I deliberately did **not** pin the Scalar/RapiDoc/ReDoc CDN URLs, which the checklist listed as an option. They currently track `latest`, and no released build of those three renders `query` yet, so pinning would lock in the same gap while forfeiting support the moment upstream ships it. Findings are recorded in the changelog and in the `OpenApi::openapi_version` docs. Happy to pin anyway if you'd rather have reproducible asset versions — that's a separate trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
