### PR TITLE
Add RFC 9457 problem details support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Changelog established for upcoming releases.
-- Opt-in RFC 9457 Problem Details responses and OpenAPI integration via the `rfc9457`
-  feature.
+- Opt-in RFC 9457 Problem Details responses with typed extension members and OpenAPI integration
+  via the `rfc9457` feature.
 - Initial opt-in OpenAPI 3.2 document support in `salvo-oapi`, including the `$self` field.
 - OpenAPI 3.2 object model in `salvo-oapi`:
   - Tag Object `summary`, `parent` and `kind`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Changelog established for upcoming releases.
+- Opt-in RFC 9457 Problem Details responses and OpenAPI integration via the `rfc9457`
+  feature.
 - Initial opt-in OpenAPI 3.2 document support in `salvo-oapi`, including the `$self` field.
 - OpenAPI 3.2 object model in `salvo-oapi`:
   - Tag Object `summary`, `parent` and `kind`.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,6 +46,7 @@ full = [
     "aws-lc-rs",
     "matched-path",
     "socket2",
+    "rfc9457",
 ]
 cookie = ["dep:cookie"]
 fix-http1-request-uri = ["http1"]
@@ -72,6 +73,7 @@ test = [
 ]
 socket2 = ["dep:socket2"]
 matched-path = []
+rfc9457 = []
 tls12 = ["tokio-rustls?/tls12"]
 
 [dependencies]

--- a/crates/core/src/catcher.rs
+++ b/crates/core/src/catcher.rs
@@ -287,6 +287,57 @@ impl Handler for DefaultGoal {
     }
 }
 
+cfg_feature! {
+    #![feature = "rfc9457"]
+    /// A [`Catcher`] goal that renders errors as RFC 9457 [`Problem`](crate::http::Problem)
+    /// details.
+    ///
+    /// Unlike [`DefaultGoal`], this goal always produces an
+    /// `application/problem+json` response and does not perform content negotiation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use salvo_core::catcher::{Catcher, ProblemGoal};
+    ///
+    /// let catcher = Catcher::new(ProblemGoal::new());
+    /// # let _ = catcher;
+    /// ```
+    #[derive(Default, Debug)]
+    pub struct ProblemGoal;
+
+    impl ProblemGoal {
+        /// Creates a new RFC 9457 problem details catcher goal.
+        #[must_use]
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    #[async_trait]
+    impl Handler for ProblemGoal {
+        async fn handle(
+            &self,
+            _req: &mut Request,
+            _depot: &mut Depot,
+            res: &mut Response,
+            _ctrl: &mut FlowCtrl,
+        ) {
+            let status = res.status_code.unwrap_or(StatusCode::NOT_FOUND);
+            if (status.is_server_error() || status.is_client_error())
+                && (res.body.is_none() || res.body.is_error())
+            {
+                let problem = if let ResBody::Error(error) = &res.body {
+                    crate::http::Problem::from(error)
+                } else {
+                    crate::http::Problem::new(status)
+                };
+                res.render(problem);
+            }
+        }
+    }
+}
+
 /// Escapes text interpolated into the HTML error page so that request-derived
 /// content (e.g. via `StatusError::brief`/`detail`/`cause`) cannot inject markup
 /// (reflected XSS).
@@ -624,5 +675,37 @@ mod tests {
         }
 
         assert_eq!(access(&service, "notfound").await, "Custom 404 Error Page");
+    }
+
+    #[cfg(feature = "rfc9457")]
+    #[tokio::test]
+    async fn test_problem_goal() {
+        #[handler]
+        async fn fail() -> StatusError {
+            StatusError::bad_request().brief("invalid request")
+        }
+
+        let service =
+            Service::new(Router::new().get(fail)).catcher(Catcher::new(ProblemGoal::new()));
+        let mut response = TestClient::get("http://127.0.0.1:8698/")
+            .send(&service)
+            .await;
+
+        assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static(
+                "application/problem+json"
+            ))
+        );
+        assert_eq!(
+            response.take_json::<serde_json::Value>().await.unwrap(),
+            serde_json::json!({
+                "type": "about:blank",
+                "title": "Bad Request",
+                "status": 400,
+                "detail": "invalid request"
+            })
+        );
     }
 }

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -67,7 +67,7 @@ cfg_feature! {
 pub use errors::{ParseError, ParseResult, StatusError, StatusResult};
 cfg_feature! {
     #![feature = "rfc9457"]
-    pub use errors::{PROBLEM_JSON, Problem};
+    pub use errors::{NoExtensions, PROBLEM_JSON, PlainProblem, Problem};
 }
 pub use headers;
 pub use http::method::Method;

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -65,6 +65,10 @@ cfg_feature! {
 }
 
 pub use errors::{ParseError, ParseResult, StatusError, StatusResult};
+cfg_feature! {
+    #![feature = "rfc9457"]
+    pub use errors::{PROBLEM_JSON, Problem};
+}
 pub use headers;
 pub use http::method::Method;
 pub use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header, method, uri};

--- a/crates/core/src/http/errors.rs
+++ b/crates/core/src/http/errors.rs
@@ -1,6 +1,11 @@
 //! HTTP Errors.
 
 mod parse_error;
+cfg_feature! {
+    #![feature = "rfc9457"]
+    mod problem;
+    pub use problem::{PROBLEM_JSON, Problem};
+}
 mod status_error;
 pub use parse_error::{ParseError, ParseResult};
 pub use status_error::{StatusError, StatusResult};

--- a/crates/core/src/http/errors.rs
+++ b/crates/core/src/http/errors.rs
@@ -4,7 +4,7 @@ mod parse_error;
 cfg_feature! {
     #![feature = "rfc9457"]
     mod problem;
-    pub use problem::{PROBLEM_JSON, Problem};
+    pub use problem::{NoExtensions, PROBLEM_JSON, PlainProblem, Problem};
 }
 mod status_error;
 pub use parse_error::{ParseError, ParseResult};

--- a/crates/core/src/http/errors/problem.rs
+++ b/crates/core/src/http/errors/problem.rs
@@ -1,0 +1,299 @@
+use std::error::Error as StdError;
+use std::fmt::{self, Display, Formatter};
+
+use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde_json::{Map, Value};
+
+use crate::http::header::{CONTENT_TYPE, HeaderValue};
+use crate::http::{Response, StatusCode, StatusError};
+use crate::Scribe;
+
+/// The media type for an RFC 9457 JSON problem details document.
+pub const PROBLEM_JSON: &str = "application/problem+json";
+
+const ABOUT_BLANK: &str = "about:blank";
+const STANDARD_MEMBERS: [&str; 5] = ["type", "title", "status", "detail", "instance"];
+
+/// An [RFC 9457] problem details response.
+///
+/// The Rust field and builder for the RFC's `type` member are named [`kind`](Self::kind) because
+/// `type` is a Rust keyword. It is still serialized as `type` on the wire.
+///
+/// `Problem::new` creates an `about:blank` problem. Use [`Problem::kind`] to identify a more
+/// specific problem type and [`Problem::extension`] for problem-specific extension members.
+///
+/// # Example
+///
+/// ```
+/// use salvo_core::http::{Problem, StatusCode};
+/// use serde_json::json;
+///
+/// let problem = Problem::new(StatusCode::UNPROCESSABLE_ENTITY)
+///     .kind("https://example.com/problems/validation-error")
+///     .title("The request is not valid")
+///     .detail("The age field must be a positive integer")
+///     .instance("/problems/123")
+///     .extension("errors", json!([{"pointer": "#/age"}]));
+///
+/// assert_eq!(problem.status, StatusCode::UNPROCESSABLE_ENTITY);
+/// assert_eq!(problem.kind, "https://example.com/problems/validation-error");
+/// ```
+///
+/// [RFC 9457]: https://www.rfc-editor.org/rfc/rfc9457.html
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Problem {
+    /// A URI reference that identifies the problem type.
+    ///
+    /// This is serialized as the RFC 9457 `type` member.
+    pub kind: String,
+    /// A short, human-readable summary of the problem type.
+    pub title: String,
+    /// The HTTP status code for this occurrence of the problem.
+    ///
+    /// Rendering the problem also uses this value as the HTTP response status.
+    pub status: StatusCode,
+    /// A human-readable explanation specific to this occurrence of the problem.
+    pub detail: Option<String>,
+    /// A URI reference that identifies this specific occurrence of the problem.
+    pub instance: Option<String>,
+    extensions: Map<String, Value>,
+}
+
+impl Problem {
+    /// Creates an `about:blank` problem for `status`.
+    ///
+    /// Its title is initialized from the status code's canonical reason phrase.
+    #[must_use]
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            kind: ABOUT_BLANK.into(),
+            title: status.canonical_reason().unwrap_or("Unknown Status").into(),
+            status,
+            detail: None,
+            instance: None,
+            extensions: Map::new(),
+        }
+    }
+
+    /// Sets the URI reference that identifies the problem type.
+    #[must_use]
+    pub fn kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = kind.into();
+        self
+    }
+
+    /// Sets the short, human-readable summary of the problem type.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Sets the explanation specific to this occurrence of the problem.
+    #[must_use]
+    pub fn detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    /// Sets the URI reference that identifies this occurrence of the problem.
+    #[must_use]
+    pub fn instance(mut self, instance: impl Into<String>) -> Self {
+        self.instance = Some(instance.into());
+        self
+    }
+
+    /// Adds a problem-specific extension member.
+    ///
+    /// RFC 9457 extension members are serialized at the top level. Standard member names are
+    /// reserved and are ignored here so an extension cannot replace their values.
+    #[must_use]
+    pub fn extension(mut self, name: impl Into<String>, value: Value) -> Self {
+        let name = name.into();
+        if !STANDARD_MEMBERS.contains(&name.as_str()) {
+            self.extensions.insert(name, value);
+        }
+        self
+    }
+
+    /// Returns the problem-specific extension members.
+    #[must_use]
+    pub fn extensions(&self) -> &Map<String, Value> {
+        &self.extensions
+    }
+}
+
+impl Serialize for Problem {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut length = 3 + self.extensions.len();
+        length += usize::from(self.detail.is_some()) + usize::from(self.instance.is_some());
+        let mut map = serializer.serialize_map(Some(length))?;
+        map.serialize_entry("type", &self.kind)?;
+        map.serialize_entry("title", &self.title)?;
+        map.serialize_entry("status", &self.status.as_u16())?;
+        if let Some(detail) = &self.detail {
+            map.serialize_entry("detail", detail)?;
+        }
+        if let Some(instance) = &self.instance {
+            map.serialize_entry("instance", instance)?;
+        }
+        for (name, value) in &self.extensions {
+            map.serialize_entry(name, value)?;
+        }
+        map.end()
+    }
+}
+
+impl Scribe for Problem {
+    fn render(self, res: &mut Response) {
+        let status = self.status;
+        match serde_json::to_vec(&self) {
+            Ok(data) => {
+                res.status_code(status);
+                res.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static(PROBLEM_JSON),
+                );
+                res.body(data);
+            }
+            Err(error) => {
+                tracing::error!(error = ?error, "problem details serialization failed");
+                res.render(StatusError::internal_server_error().cause(error));
+            }
+        }
+    }
+}
+
+impl From<StatusCode> for Problem {
+    fn from(status: StatusCode) -> Self {
+        Self::new(status)
+    }
+}
+
+impl From<&StatusError> for Problem {
+    fn from(error: &StatusError) -> Self {
+        Self::new(error.code)
+            .title(error.name.clone())
+            .detail(error.brief.clone())
+    }
+}
+
+impl From<StatusError> for Problem {
+    fn from(error: StatusError) -> Self {
+        Self::from(&error)
+    }
+}
+
+impl Display for Problem {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} {}: {}", self.status.as_u16(), self.title, self.kind)?;
+        if let Some(detail) = &self.detail {
+            write!(formatter, ": {detail}")?;
+        }
+        Ok(())
+    }
+}
+
+impl StdError for Problem {}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::http::ResBody;
+
+    #[test]
+    fn serializes_standard_and_extension_members() {
+        let problem = Problem::new(StatusCode::UNPROCESSABLE_ENTITY)
+            .kind("https://example.com/problems/validation-error")
+            .title("The request is not valid")
+            .detail("The age field must be a positive integer")
+            .instance("/problems/123")
+            .extension("errors", json!([{"pointer": "#/age"}]));
+
+        assert_eq!(
+            serde_json::to_value(problem).expect("problem should serialize"),
+            json!({
+                "type": "https://example.com/problems/validation-error",
+                "title": "The request is not valid",
+                "status": 422,
+                "detail": "The age field must be a positive integer",
+                "instance": "/problems/123",
+                "errors": [{"pointer": "#/age"}]
+            })
+        );
+    }
+
+    #[test]
+    fn defaults_to_about_blank() {
+        assert_eq!(
+            serde_json::to_value(Problem::new(StatusCode::NOT_FOUND))
+                .expect("problem should serialize"),
+            json!({
+                "type": "about:blank",
+                "title": "Not Found",
+                "status": 404
+            })
+        );
+    }
+
+    #[test]
+    fn standard_member_names_cannot_be_extensions() {
+        let problem = Problem::new(StatusCode::BAD_REQUEST)
+            .extension("type", json!("https://example.com/problems/replaced"))
+            .extension("status", json!(500));
+
+        assert!(problem.extensions().is_empty());
+        assert_eq!(
+            serde_json::to_value(problem).expect("problem should serialize"),
+            json!({
+                "type": "about:blank",
+                "title": "Bad Request",
+                "status": 400
+            })
+        );
+    }
+
+    #[test]
+    fn render_sets_status_content_type_and_body() {
+        let mut response = Response::new();
+        response.render(Problem::new(StatusCode::CONFLICT).detail("conflicting state"));
+
+        assert_eq!(response.status_code, Some(StatusCode::CONFLICT));
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE),
+            Some(&HeaderValue::from_static(PROBLEM_JSON))
+        );
+        let ResBody::Once(body) = response.take_body() else {
+            panic!("expected a single problem details body");
+        };
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).expect("body should be JSON"),
+            json!({
+                "type": "about:blank",
+                "title": "Conflict",
+                "status": 409,
+                "detail": "conflicting state"
+            })
+        );
+    }
+
+    #[test]
+    fn status_error_conversion_does_not_expose_internal_details() {
+        let status_error = StatusError::internal_server_error()
+            .brief("request failed")
+            .detail("database password was rejected")
+            .cause(std::io::Error::other("internal failure"));
+
+        let value = serde_json::to_value(Problem::from(status_error))
+            .expect("problem should serialize");
+        assert_eq!(value["detail"], "request failed");
+        assert!(!value.to_string().contains("database password"));
+        assert!(!value.to_string().contains("internal failure"));
+    }
+}

--- a/crates/core/src/http/errors/problem.rs
+++ b/crates/core/src/http/errors/problem.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt::{self, Display, Formatter};
 
-use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde::ser::{Error as _, Serialize, SerializeMap, Serializer};
 use serde_json::{Map, Value};
 
 use crate::http::header::{CONTENT_TYPE, HeaderValue};
@@ -14,26 +14,42 @@ pub const PROBLEM_JSON: &str = "application/problem+json";
 const ABOUT_BLANK: &str = "about:blank";
 const STANDARD_MEMBERS: [&str; 5] = ["type", "title", "status", "detail", "instance"];
 
+/// An empty object used when a [`Problem`] has no extension members.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize)]
+pub struct NoExtensions {}
+
+/// A problem details response without extension members.
+pub type PlainProblem = Problem<NoExtensions>;
+
 /// An [RFC 9457] problem details response.
 ///
 /// The Rust field and builder for the RFC's `type` member are named [`kind`](Self::kind) because
 /// `type` is a Rust keyword. It is still serialized as `type` on the wire.
 ///
-/// `Problem::new` creates an `about:blank` problem. Use [`Problem::kind`] to identify a more
-/// specific problem type and [`Problem::extension`] for problem-specific extension members.
+/// `Problem::new` creates an `about:blank` problem without extension members. Use
+/// [`Problem::kind`] to identify a more specific problem type and [`Problem::with_extensions`] for
+/// typed, problem-specific extension members. Extensions must serialize as a JSON object and must
+/// not use a standard problem member name.
 ///
 /// # Example
 ///
 /// ```
 /// use salvo_core::http::{Problem, StatusCode};
-/// use serde_json::json;
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct ValidationExtensions {
+///     errors: Vec<&'static str>,
+/// }
 ///
 /// let problem = Problem::new(StatusCode::UNPROCESSABLE_ENTITY)
 ///     .kind("https://example.com/problems/validation-error")
 ///     .title("The request is not valid")
 ///     .detail("The age field must be a positive integer")
 ///     .instance("/problems/123")
-///     .extension("errors", json!([{"pointer": "#/age"}]));
+///     .with_extensions(ValidationExtensions {
+///         errors: vec!["#/age"],
+///     });
 ///
 /// assert_eq!(problem.status, StatusCode::UNPROCESSABLE_ENTITY);
 /// assert_eq!(problem.kind, "https://example.com/problems/validation-error");
@@ -42,7 +58,7 @@ const STANDARD_MEMBERS: [&str; 5] = ["type", "title", "status", "detail", "insta
 /// [RFC 9457]: https://www.rfc-editor.org/rfc/rfc9457.html
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct Problem {
+pub struct Problem<Extensions = NoExtensions> {
     /// A URI reference that identifies the problem type.
     ///
     /// This is serialized as the RFC 9457 `type` member.
@@ -57,10 +73,11 @@ pub struct Problem {
     pub detail: Option<String>,
     /// A URI reference that identifies this specific occurrence of the problem.
     pub instance: Option<String>,
-    extensions: Map<String, Value>,
+    /// Problem-specific members serialized at the top level of the problem object.
+    pub extensions: Extensions,
 }
 
-impl Problem {
+impl Problem<NoExtensions> {
     /// Creates an `about:blank` problem for `status`.
     ///
     /// Its title is initialized from the status code's canonical reason phrase.
@@ -72,10 +89,35 @@ impl Problem {
             status,
             detail: None,
             instance: None,
-            extensions: Map::new(),
+            extensions: NoExtensions {},
         }
     }
 
+    /// Adds a dynamically named problem-specific extension member.
+    ///
+    /// Use [`Problem::with_extensions`] when the extension members have a known shape.
+    #[must_use]
+    pub fn extension(self, name: impl Into<String>, value: Value) -> Problem<Map<String, Value>> {
+        self.with_extensions(Map::new()).extension(name, value)
+    }
+}
+
+impl Problem<Map<String, Value>> {
+    /// Adds a dynamically named problem-specific extension member.
+    ///
+    /// Standard problem member names are reserved and are ignored here so an extension cannot
+    /// replace their values.
+    #[must_use]
+    pub fn extension(mut self, name: impl Into<String>, value: Value) -> Self {
+        let name = name.into();
+        if !STANDARD_MEMBERS.contains(&name.as_str()) {
+            self.extensions.insert(name, value);
+        }
+        self
+    }
+}
+
+impl<Extensions> Problem<Extensions> {
     /// Sets the URI reference that identifies the problem type.
     #[must_use]
     pub fn kind(mut self, kind: impl Into<String>) -> Self {
@@ -104,32 +146,53 @@ impl Problem {
         self
     }
 
-    /// Adds a problem-specific extension member.
-    ///
-    /// RFC 9457 extension members are serialized at the top level. Standard member names are
-    /// reserved and are ignored here so an extension cannot replace their values.
+    /// Replaces the extension object, changing its type.
     #[must_use]
-    pub fn extension(mut self, name: impl Into<String>, value: Value) -> Self {
-        let name = name.into();
-        if !STANDARD_MEMBERS.contains(&name.as_str()) {
-            self.extensions.insert(name, value);
+    pub fn with_extensions<NewExtensions>(
+        self,
+        extensions: NewExtensions,
+    ) -> Problem<NewExtensions> {
+        Problem {
+            kind: self.kind,
+            title: self.title,
+            status: self.status,
+            detail: self.detail,
+            instance: self.instance,
+            extensions,
         }
-        self
     }
 
     /// Returns the problem-specific extension members.
     #[must_use]
-    pub fn extensions(&self) -> &Map<String, Value> {
+    pub fn extensions(&self) -> &Extensions {
         &self.extensions
     }
 }
 
-impl Serialize for Problem {
+impl<Extensions> Serialize for Problem<Extensions>
+where
+    Extensions: Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut length = 3 + self.extensions.len();
+        let extensions = serde_json::to_value(&self.extensions).map_err(S::Error::custom)?;
+        let Value::Object(extensions) = extensions else {
+            return Err(S::Error::custom(
+                "problem extensions must serialize as a JSON object",
+            ));
+        };
+        if let Some(name) = STANDARD_MEMBERS
+            .iter()
+            .find(|name| extensions.contains_key(**name))
+        {
+            return Err(S::Error::custom(format_args!(
+                "problem extension member `{name}` is reserved"
+            )));
+        }
+
+        let mut length = 3 + extensions.len();
         length += usize::from(self.detail.is_some()) + usize::from(self.instance.is_some());
         let mut map = serializer.serialize_map(Some(length))?;
         map.serialize_entry("type", &self.kind)?;
@@ -141,14 +204,17 @@ impl Serialize for Problem {
         if let Some(instance) = &self.instance {
             map.serialize_entry("instance", instance)?;
         }
-        for (name, value) in &self.extensions {
-            map.serialize_entry(name, value)?;
+        for (name, value) in extensions {
+            map.serialize_entry(&name, &value)?;
         }
         map.end()
     }
 }
 
-impl Scribe for Problem {
+impl<Extensions> Scribe for Problem<Extensions>
+where
+    Extensions: Serialize,
+{
     fn render(self, res: &mut Response) {
         let status = self.status;
         match serde_json::to_vec(&self) {
@@ -168,13 +234,13 @@ impl Scribe for Problem {
     }
 }
 
-impl From<StatusCode> for Problem {
+impl From<StatusCode> for PlainProblem {
     fn from(status: StatusCode) -> Self {
         Self::new(status)
     }
 }
 
-impl From<&StatusError> for Problem {
+impl From<&StatusError> for PlainProblem {
     fn from(error: &StatusError) -> Self {
         Self::new(error.code)
             .title(error.name.clone())
@@ -182,13 +248,13 @@ impl From<&StatusError> for Problem {
     }
 }
 
-impl From<StatusError> for Problem {
+impl From<StatusError> for PlainProblem {
     fn from(error: StatusError) -> Self {
         Self::from(&error)
     }
 }
 
-impl Display for Problem {
+impl<Extensions> Display for Problem<Extensions> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(formatter, "{} {}: {}", self.status.as_u16(), self.title, self.kind)?;
         if let Some(detail) = &self.detail {
@@ -198,10 +264,11 @@ impl Display for Problem {
     }
 }
 
-impl StdError for Problem {}
+impl<Extensions> StdError for Problem<Extensions> where Extensions: fmt::Debug {}
 
 #[cfg(test)]
 mod tests {
+    use serde::Serialize;
     use serde_json::json;
 
     use super::*;
@@ -230,10 +297,63 @@ mod tests {
     }
 
     #[test]
-    fn defaults_to_about_blank() {
+    fn serializes_typed_extension_members_at_the_top_level() {
+        #[derive(Serialize)]
+        struct OutOfCreditExtensions {
+            balance: u64,
+            accounts: Vec<&'static str>,
+        }
+
+        let problem = Problem::new(StatusCode::FORBIDDEN).with_extensions(
+            OutOfCreditExtensions {
+                balance: 30,
+                accounts: vec!["/account/12345", "/account/67890"],
+            },
+        );
+
         assert_eq!(
-            serde_json::to_value(Problem::new(StatusCode::NOT_FOUND))
-                .expect("problem should serialize"),
+            serde_json::to_value(problem).expect("problem should serialize"),
+            json!({
+                "type": "about:blank",
+                "title": "Forbidden",
+                "status": 403,
+                "balance": 30,
+                "accounts": ["/account/12345", "/account/67890"]
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_typed_extensions() {
+        let scalar = Problem::new(StatusCode::BAD_REQUEST).with_extensions("not an object");
+        assert!(
+            serde_json::to_value(scalar)
+                .expect_err("scalar extensions should fail")
+                .to_string()
+                .contains("must serialize as a JSON object")
+        );
+
+        #[derive(Serialize)]
+        struct ReservedExtension {
+            #[serde(rename = "type")]
+            kind: &'static str,
+        }
+        let reserved = Problem::new(StatusCode::BAD_REQUEST).with_extensions(ReservedExtension {
+            kind: "https://example.com/problems/replaced",
+        });
+        assert!(
+            serde_json::to_value(reserved)
+                .expect_err("reserved extension names should fail")
+                .to_string()
+                .contains("is reserved")
+        );
+    }
+
+    #[test]
+    fn defaults_to_about_blank() {
+        let problem: PlainProblem = Problem::new(StatusCode::NOT_FOUND);
+        assert_eq!(
+            serde_json::to_value(problem).expect("problem should serialize"),
             json!({
                 "type": "about:blank",
                 "title": "Not Found",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,7 @@
 //! | `unix` | Listener based on Unix socket | ❌ |
 //! | `anyhow` | Integrate with the [`anyhow`](https://crates.io/crates/anyhow) crate | ❌ |
 //! | `eyre` | Integrate with the [`eyre`](https://crates.io/crates/eyre) crate | ❌ |
+//! | `rfc9457` | RFC 9457 Problem Details responses | ❌ |
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
 #![doc(html_logo_url = "https://salvo.rs/images/logo.svg")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -89,6 +90,10 @@ pub mod prelude {
 
     pub use crate::depot::Depot;
     pub use crate::http::{Request, Response, StatusCode, StatusError};
+    cfg_feature! {
+        #![feature = "rfc9457"]
+        pub use crate::http::Problem;
+    }
     cfg_feature! {
         #![feature ="rustls"]
         pub use crate::conn::RustlsListener;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -92,7 +92,7 @@ pub mod prelude {
     pub use crate::http::{Request, Response, StatusCode, StatusError};
     cfg_feature! {
         #![feature = "rfc9457"]
-        pub use crate::http::Problem;
+        pub use crate::http::{NoExtensions, PlainProblem, Problem};
     }
     cfg_feature! {
         #![feature ="rustls"]

--- a/crates/oapi/Cargo.toml
+++ b/crates/oapi/Cargo.toml
@@ -35,6 +35,7 @@ full = [
     "yaml",
     "non-strict-integers",
     "compact_str",
+    "rfc9457",
 ]
 swagger-ui = ["dep:rust-embed"]
 scalar = []
@@ -57,6 +58,7 @@ preserve-order = ["preserve-path-order", "preserve-prop-order"]
 preserve-path-order = []
 preserve-prop-order = []
 compact_str = ["salvo-oapi-macros/compact_str", "dep:compact_str"]
+rfc9457 = ["salvo_core/rfc9457"]
 
 [dependencies]
 salvo_core = { workspace = true, default-features = false, features = [

--- a/crates/oapi/src/endpoint.rs
+++ b/crates/oapi/src/endpoint.rs
@@ -87,7 +87,10 @@ impl EndpointOutRegister for StatusError {
 }
 
 #[cfg(feature = "rfc9457")]
-impl EndpointOutRegister for Problem {
+impl<Extensions> EndpointOutRegister for Problem<Extensions>
+where
+    Extensions: ToSchema + 'static,
+{
     #[inline]
     fn register(components: &mut Components, operation: &mut Operation) {
         operation

--- a/crates/oapi/src/endpoint.rs
+++ b/crates/oapi/src/endpoint.rs
@@ -1,6 +1,8 @@
 use std::any::TypeId;
 use std::fmt::{self, Debug, Formatter};
 
+#[cfg(feature = "rfc9457")]
+use salvo_core::http::Problem;
 use salvo_core::http::StatusCode;
 use salvo_core::prelude::StatusError;
 use salvo_core::writing;
@@ -76,6 +78,16 @@ where
 }
 
 impl EndpointOutRegister for StatusError {
+    #[inline]
+    fn register(components: &mut Components, operation: &mut Operation) {
+        operation
+            .responses
+            .append(&mut Self::to_responses(components));
+    }
+}
+
+#[cfg(feature = "rfc9457")]
+impl EndpointOutRegister for Problem {
     #[inline]
     fn register(components: &mut Components, operation: &mut Operation) {
         operation

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -42,13 +42,15 @@ cfg_feature! {
     pub mod redoc;
 }
 
+#[cfg(feature = "rfc9457")]
+use std::any::TypeId;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList};
 use std::marker::PhantomData;
 
 use salvo_core::extract::Extractible;
-#[cfg(feature = "rfc9457")]
-use salvo_core::http::Problem;
 use salvo_core::http::StatusError;
+#[cfg(feature = "rfc9457")]
+use salvo_core::http::{NoExtensions, Problem};
 use salvo_core::writing;
 #[doc = include_str!("../docs/derive_to_parameters.md")]
 pub use salvo_oapi_macros::ToParameters;
@@ -776,34 +778,69 @@ impl ComposeSchema for StatusError {
 }
 
 #[cfg(feature = "rfc9457")]
-impl ToSchema for Problem {
+fn problem_base_schema(components: &mut Components) -> RefOr<schema::Schema> {
+    let uri_reference = || {
+        Object::new()
+            .schema_type(schema::BasicType::String)
+            .format(SchemaFormat::Custom("uri-reference".into()))
+    };
+    let status = Object::new()
+        .schema_type(schema::BasicType::Integer)
+        .format(SchemaFormat::KnownFormat(schema::KnownFormat::Int32))
+        .minimum(100)
+        .maximum(599);
+    Object::new()
+        .property("type", uri_reference())
+        .required("type")
+        .property("title", String::to_schema(components))
+        .required("title")
+        .property("status", status)
+        .required("status")
+        .property("detail", String::to_schema(components))
+        .property("instance", uri_reference())
+        .into()
+}
+
+#[cfg(feature = "rfc9457")]
+impl ToSchema for NoExtensions {
+    fn to_schema(_components: &mut Components) -> RefOr<schema::Schema> {
+        Object::new().schema_type(schema::BasicType::Object).into()
+    }
+}
+
+#[cfg(feature = "rfc9457")]
+impl ComposeSchema for NoExtensions {
+    fn compose(
+        components: &mut Components,
+        _generics: Vec<RefOr<schema::Schema>>,
+    ) -> RefOr<schema::Schema> {
+        Self::to_schema(components)
+    }
+}
+
+#[cfg(feature = "rfc9457")]
+impl<Extensions> ToSchema for Problem<Extensions>
+where
+    Extensions: ToSchema + 'static,
+{
     fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
-        let name = crate::naming::assign_name::<Self>(Default::default());
+        let name_rule = if TypeId::of::<Extensions>() == TypeId::of::<NoExtensions>() {
+            crate::naming::NameRule::Force("Problem")
+        } else {
+            Default::default()
+        };
+        let name = crate::naming::assign_name::<Self>(name_rule);
         let ref_or = crate::RefOr::Ref(crate::Ref::new(format!("#/components/schemas/{name}")));
         if !components.schemas.contains_key(&name) {
             components.schemas.insert(name.clone(), ref_or.clone());
-            let uri_reference = || {
-                Object::new()
-                    .schema_type(schema::BasicType::String)
-                    .format(SchemaFormat::Custom("uri-reference".into()))
+            let schema = if TypeId::of::<Extensions>() == TypeId::of::<NoExtensions>() {
+                problem_base_schema(components)
+            } else {
+                schema::AllOf::new()
+                    .item(problem_base_schema(components))
+                    .item(Extensions::to_schema(components))
+                    .into()
             };
-            let status = Object::new()
-                .schema_type(schema::BasicType::Integer)
-                .format(SchemaFormat::KnownFormat(schema::KnownFormat::Int32))
-                .minimum(100)
-                .maximum(599);
-            let schema = Schema::from(
-                Object::new()
-                    .property("type", uri_reference())
-                    .required("type")
-                    .property("title", String::to_schema(components))
-                    .required("title")
-                    .property("status", status)
-                    .required("status")
-                    .property("detail", String::to_schema(components))
-                    .property("instance", uri_reference())
-                    .additional_properties(schema::AdditionalProperties::FreeForm(true)),
-            );
             components.schemas.insert(name, schema);
         }
         ref_or
@@ -811,12 +848,24 @@ impl ToSchema for Problem {
 }
 
 #[cfg(feature = "rfc9457")]
-impl ComposeSchema for Problem {
+impl<Extensions> ComposeSchema for Problem<Extensions>
+where
+    Extensions: ComposeSchema + 'static,
+{
     fn compose(
         components: &mut Components,
-        _generics: Vec<RefOr<schema::Schema>>,
+        generics: Vec<RefOr<schema::Schema>>,
     ) -> RefOr<schema::Schema> {
-        Self::to_schema(components)
+        let base = problem_base_schema(components);
+        if TypeId::of::<Extensions>() == TypeId::of::<NoExtensions>() {
+            base
+        } else {
+            let extensions = generics
+                .first()
+                .cloned()
+                .unwrap_or_else(|| Extensions::compose(components, vec![]));
+            schema::AllOf::new().item(base).item(extensions).into()
+        }
     }
 }
 
@@ -1161,7 +1210,10 @@ impl ToResponses for StatusError {
 }
 
 #[cfg(feature = "rfc9457")]
-impl ToResponses for Problem {
+impl<Extensions> ToResponses for Problem<Extensions>
+where
+    Extensions: ToSchema + 'static,
+{
     fn to_responses(components: &mut Components) -> Responses {
         Responses::new().response(
             "default",
@@ -1225,7 +1277,7 @@ mod tests {
     #[test]
     fn test_problem_schema_and_response_media_type() {
         let mut components = Components::new();
-        let schema_ref = Problem::to_schema(&mut components);
+        let schema_ref = salvo_core::http::PlainProblem::to_schema(&mut components);
         let RefOr::Ref(schema_ref) = schema_ref else {
             panic!("problem schema should use a component reference");
         };
@@ -1245,10 +1297,9 @@ mod tests {
         assert_eq!(schema["properties"]["instance"]["format"], "uri-reference");
         assert_eq!(schema["properties"]["status"]["minimum"], 100);
         assert_eq!(schema["properties"]["status"]["maximum"], 599);
-        assert_eq!(schema["additionalProperties"], true);
         assert_eq!(schema["required"], json!(["type", "title", "status"]));
 
-        let responses = Problem::to_responses(&mut components);
+        let responses = salvo_core::http::PlainProblem::to_responses(&mut components);
         let response = responses
             .get("default")
             .expect("problem should register a default response");
@@ -1258,6 +1309,48 @@ mod tests {
                 .get("application/problem+json")
                 .is_some()
         );
+    }
+
+    #[cfg(feature = "rfc9457")]
+    #[test]
+    fn test_problem_schema_composes_typed_extensions() {
+        #[derive(ToSchema)]
+        #[allow(dead_code)]
+        struct ValidationExtensions {
+            errors: Vec<String>,
+        }
+
+        let mut components = Components::new();
+        let schema_ref = Problem::<ValidationExtensions>::to_schema(&mut components);
+        let RefOr::Ref(schema_ref) = schema_ref else {
+            panic!("problem schema should use a component reference");
+        };
+        let name = schema_ref
+            .ref_location
+            .rsplit('/')
+            .next()
+            .expect("component reference should have a name");
+        let schema = components
+            .schemas
+            .get(name)
+            .expect("typed problem component should exist");
+        let schema = serde_json::to_value(schema).expect("schema should serialize");
+
+        assert_eq!(schema["allOf"].as_array().map(Vec::len), Some(2));
+        let extension_ref = schema["allOf"][1]["$ref"]
+            .as_str()
+            .expect("extension schema should use a component reference");
+        let extension_name = extension_ref
+            .rsplit('/')
+            .next()
+            .expect("extension reference should have a name");
+        let extension_schema = components
+            .schemas
+            .get(extension_name)
+            .expect("extension component should exist");
+        let extension_schema =
+            serde_json::to_value(extension_schema).expect("extension schema should serialize");
+        assert_eq!(extension_schema["properties"]["errors"]["type"], "array");
     }
 
     #[test]

--- a/crates/oapi/src/lib.rs
+++ b/crates/oapi/src/lib.rs
@@ -46,6 +46,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList};
 use std::marker::PhantomData;
 
 use salvo_core::extract::Extractible;
+#[cfg(feature = "rfc9457")]
+use salvo_core::http::Problem;
 use salvo_core::http::StatusError;
 use salvo_core::writing;
 #[doc = include_str!("../docs/derive_to_parameters.md")]
@@ -773,6 +775,51 @@ impl ComposeSchema for StatusError {
     }
 }
 
+#[cfg(feature = "rfc9457")]
+impl ToSchema for Problem {
+    fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
+        let name = crate::naming::assign_name::<Self>(Default::default());
+        let ref_or = crate::RefOr::Ref(crate::Ref::new(format!("#/components/schemas/{name}")));
+        if !components.schemas.contains_key(&name) {
+            components.schemas.insert(name.clone(), ref_or.clone());
+            let uri_reference = || {
+                Object::new()
+                    .schema_type(schema::BasicType::String)
+                    .format(SchemaFormat::Custom("uri-reference".into()))
+            };
+            let status = Object::new()
+                .schema_type(schema::BasicType::Integer)
+                .format(SchemaFormat::KnownFormat(schema::KnownFormat::Int32))
+                .minimum(100)
+                .maximum(599);
+            let schema = Schema::from(
+                Object::new()
+                    .property("type", uri_reference())
+                    .required("type")
+                    .property("title", String::to_schema(components))
+                    .required("title")
+                    .property("status", status)
+                    .required("status")
+                    .property("detail", String::to_schema(components))
+                    .property("instance", uri_reference())
+                    .additional_properties(schema::AdditionalProperties::FreeForm(true)),
+            );
+            components.schemas.insert(name, schema);
+        }
+        ref_or
+    }
+}
+
+#[cfg(feature = "rfc9457")]
+impl ComposeSchema for Problem {
+    fn compose(
+        components: &mut Components,
+        _generics: Vec<RefOr<schema::Schema>>,
+    ) -> RefOr<schema::Schema> {
+        Self::to_schema(components)
+    }
+}
+
 impl ToSchema for salvo_core::Error {
     fn to_schema(components: &mut Components) -> RefOr<schema::Schema> {
         StatusError::to_schema(components)
@@ -1112,6 +1159,19 @@ impl ToResponses for StatusError {
         responses
     }
 }
+
+#[cfg(feature = "rfc9457")]
+impl ToResponses for Problem {
+    fn to_responses(components: &mut Components) -> Responses {
+        Responses::new().response(
+            "default",
+            Response::new("RFC 9457 problem details response").add_content(
+                salvo_core::http::PROBLEM_JSON,
+                Content::new(Self::to_schema(components)),
+            ),
+        )
+    }
+}
 impl ToResponses for salvo_core::Error {
     fn to_responses(components: &mut Components) -> Responses {
         StatusError::to_responses(components)
@@ -1160,6 +1220,45 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[cfg(feature = "rfc9457")]
+    #[test]
+    fn test_problem_schema_and_response_media_type() {
+        let mut components = Components::new();
+        let schema_ref = Problem::to_schema(&mut components);
+        let RefOr::Ref(schema_ref) = schema_ref else {
+            panic!("problem schema should use a component reference");
+        };
+        let name = schema_ref
+            .ref_location
+            .rsplit('/')
+            .next()
+            .expect("component reference should have a name");
+        let schema = components
+            .schemas
+            .get(name)
+            .expect("problem component should exist");
+        let schema = serde_json::to_value(schema).expect("schema should serialize");
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"]["type"]["format"], "uri-reference");
+        assert_eq!(schema["properties"]["instance"]["format"], "uri-reference");
+        assert_eq!(schema["properties"]["status"]["minimum"], 100);
+        assert_eq!(schema["properties"]["status"]["maximum"], 599);
+        assert_eq!(schema["additionalProperties"], true);
+        assert_eq!(schema["required"], json!(["type", "title", "status"]));
+
+        let responses = Problem::to_responses(&mut components);
+        let response = responses
+            .get("default")
+            .expect("problem should register a default response");
+        let response = serde_json::to_value(response).expect("response should serialize");
+        assert!(
+            response["content"]
+                .get("application/problem+json")
+                .is_some()
+        );
+    }
 
     #[test]
     fn test_primitive_schema() {

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -79,6 +79,7 @@ full = [
     "serve-static",
     "otel",
     "oapi",
+    "rfc9457",
     "aws-lc-rs",
     "matched-path",
     "tus",
@@ -129,6 +130,7 @@ session = ["dep:salvo-session"]
 serve-static = ["dep:salvo-serve-static"]
 otel = ["dep:salvo-otel"]
 oapi = ["dep:salvo-oapi"]
+rfc9457 = ["salvo_core/rfc9457", "salvo-oapi?/rfc9457"]
 aws-lc-rs = [
     "salvo_core/aws-lc-rs",
     "salvo-proxy?/aws-lc-rs",

--- a/crates/salvo/src/lib.rs
+++ b/crates/salvo/src/lib.rs
@@ -54,6 +54,7 @@
 //! | `otel` | OpenTelemetry integration | ❌ |
 //! | `proxy` | Reverse-proxy middleware | ❌ |
 //! | `rate-limiter` | Rate-limiting middleware | ❌ |
+//! | `rfc9457` | RFC 9457 Problem Details responses | ❌ |
 //! | `serve-static` | Static file / directory serving | ❌ |
 //! | `session` | Cookie-based session middleware | ❌ |
 //! | `tus` | [tus.io](https://tus.io) resumable upload protocol | ❌ |


### PR DESCRIPTION
## Summary

- add the feature-gated generic `Problem<Extensions = NoExtensions>` RFC 9457 response type, using Rust `kind` for the JSON `type` member
- provide `PlainProblem`, typed extensions via `with_extensions`, and a dynamic extension builder
- add `ProblemGoal` for opt-in catcher rendering and safe `StatusError` conversion
- compose typed extension schemas into Problem responses with `salvo-oapi`

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check --all --bins --examples --tests`
- `cargo check -p salvo --no-default-features --features rfc9457,oapi`
- `cargo test -p salvo_core --all-features --lib`
- `cargo test -p salvo-oapi --all-features --lib`
- `cargo test --workspace --doc`
- targeted no-default-feature checks and RFC 9457 unit/integration tests
- targeted Clippy checks for `salvo_core` and `salvo-oapi` with the `rfc9457` feature

Closes #1690