### PR TITLE
Stop serving XML-based files inline from static handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   when an application served attacker-supplied uploads. `image/svg+xml` and `text/xml` were
   classified as `inline` by their top-level `image`/`text` type, so an uploaded SVG carrying
   `<script>` — or an XML document naming an XSLT stylesheet through `<?xml-stylesheet ?>` —
-  executed script in the serving origin when opened. Any content type with an `xml` subtype or
-  an `+xml` suffix now defaults to `attachment`, matching how `application/xml` and
-  `application/xhtml+xml` already behaved. Reported by sl91994.
+  executed script in the serving origin when opened. XML-based content types now default to
+  `attachment`, matching how `application/xml` and `application/xhtml+xml` already behaved.
+  That covers the `+xml` suffix, an `xml` subtype, RFC 7303's `xml-dtd` and
+  `xml-external-parsed-entity`, and the legacy `text/xsl` that `<?xml-stylesheet ?>` itself
+  names. `text/html` still defaults to `inline`. Reported by sl91994.
 - `NamedFile` and `StaticEmbed` responses now carry `X-Content-Type-Options: nosniff`.
 
 ### Added
@@ -25,7 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `StaticFile::disposition_type`, `StaticFile::attached_name` and
   `StaticFile::use_content_type_options`, so applications serving trusted assets can opt back
   into inline rendering, which previously had no public API on either handler.
-
+- `NamedFileBuilder::disposition_name`, which sets the name `Content-Disposition` reports
+  without forcing the disposition to `attachment` the way `attached_name` does.
 - Changelog established for upcoming releases.
 - Opt-in RFC 9457 Problem Details responses with typed extension members and OpenAPI integration
   via the `rfc9457` feature.
@@ -88,6 +91,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `StaticDir` names a download after the file that was requested rather than the precompressed
+  sidecar it was served from, so a request for `logo.svg` answered out of `logo.svg.br` no
+  longer offers `Content-Disposition: attachment; filename="logo.svg.br"`.
 - `PathItem` no longer duplicates operations into `extensions` when deserialized, which
   previously made a parsed path item re-serialize with repeated keys.
 - OAuth2 flows are now resolved by their flow name instead of by shape, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Static file responses no longer serve XML-based documents inline, which allowed stored XSS
+  when an application served attacker-supplied uploads. `image/svg+xml` and `text/xml` were
+  classified as `inline` by their top-level `image`/`text` type, so an uploaded SVG carrying
+  `<script>` — or an XML document naming an XSLT stylesheet through `<?xml-stylesheet ?>` —
+  executed script in the serving origin when opened. Any content type with an `xml` subtype or
+  an `+xml` suffix now defaults to `attachment`, matching how `application/xml` and
+  `application/xhtml+xml` already behaved. Reported by sl91994.
+- `NamedFile` and `StaticEmbed` responses now carry `X-Content-Type-Options: nosniff`.
+
 ### Added
+
+- `NamedFileBuilder::use_content_type_options` and `NamedFile::use_content_type_options` to
+  control the `X-Content-Type-Options` header.
+- `StaticDir::disposition_type`, `StaticDir::use_content_type_options`,
+  `StaticFile::disposition_type`, `StaticFile::attached_name` and
+  `StaticFile::use_content_type_options`, so applications serving trusted assets can opt back
+  into inline rendering, which previously had no public API on either handler.
 
 - Changelog established for upcoming releases.
 - Opt-in RFC 9457 Problem Details responses with typed extension members and OpenAPI integration
@@ -51,6 +69,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is unchanged.
 - `OpenApi` still defaults to emitting OpenAPI 3.1; 3.2 remains opt-in via
   `OpenApi::openapi_version`.
+- **Behavior change.** Serving an SVG or XML file through `StaticDir`, `StaticFile` or
+  `NamedFile` now sends `Content-Disposition: attachment` by default, so following a link to
+  one downloads it instead of rendering it, and `<object>`/`<embed>`/`<iframe>` no longer
+  display it. Referencing the same file from `<img>`, CSS `url()` or `<use>` is unaffected,
+  because browsers ignore `Content-Disposition` on subresource loads. Directories holding only
+  trusted assets can restore the old behavior with
+  `StaticDir::new(..).disposition_type("inline")`. `text/html` still defaults to `inline`,
+  since serving HTML documents is the point of a static file server.
 
 ### Notes
 

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -1059,6 +1059,10 @@ mod tests {
             .build()
             .await
             .expect("build named file");
+        // The file must be recognised *as* an SVG, otherwise this test would also
+        // pass on an unidentified file falling back to `application/octet-stream`.
+        assert_eq!(named.content_type(), &mime::IMAGE_SVG);
+
         let mut res = Response::new();
         named.send(&HeaderMap::new(), &mut res).await;
 

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -21,6 +21,7 @@ use super::{ChunkedFile, ChunkedState};
 use crate::http::body::ResBody;
 use crate::http::header::{
     CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_TYPE, IF_NONE_MATCH, RANGE,
+    X_CONTENT_TYPE_OPTIONS,
 };
 use crate::http::mime::{detect_text_mime, fill_mime_charset_if_need, is_charset_required_mime};
 use crate::http::{HttpRange, Request, Response, StatusCode, StatusError};
@@ -51,13 +52,14 @@ const RFC5987_ATTR_CHAR_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'{')
     .add(b'}');
 
-#[bitflags(default = Etag | LastModified | ContentDisposition)]
+#[bitflags(default = Etag | LastModified | ContentDisposition | ContentTypeOptions)]
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Flag {
     Etag = 0b0001,
     LastModified = 0b0010,
     ContentDisposition = 0b0100,
+    ContentTypeOptions = 0b1000,
 }
 
 /// A file with an associated name and metadata for HTTP serving.
@@ -108,6 +110,19 @@ pub(crate) enum Flag {
 /// By default, text, images, video, and audio files are served with
 /// `Content-Disposition: inline`, while other files use `attachment`.
 /// Use [`NamedFileBuilder::attached_name`] to force a download with a specific filename.
+///
+/// XML-based documents — `image/svg+xml`, `text/xml`, and anything else with an
+/// `xml` subtype or `+xml` suffix — are the exception: they default to
+/// `attachment` even though their top-level type is `image` or `text`, because a
+/// browser rendering one as a document will run any script it contains in the
+/// serving origin. Pass [`NamedFileBuilder::disposition_type`] to override this
+/// for content you trust.
+///
+/// # Security Headers
+///
+/// Responses carry `X-Content-Type-Options: nosniff` by default so a browser
+/// cannot reinterpret a file as a more dangerous type than its `Content-Type`
+/// claims. See [`NamedFileBuilder::use_content_type_options`].
 ///
 /// # Caching Headers
 ///
@@ -260,6 +275,21 @@ impl NamedFileBuilder {
         self
     }
 
+    /// Specifies whether to send `X-Content-Type-Options: nosniff` or not.
+    ///
+    /// Default is true. Turn this off only when a client depends on MIME
+    /// sniffing to interpret a file whose extension does not describe it.
+    #[inline]
+    #[must_use]
+    pub fn use_content_type_options(mut self, value: bool) -> Self {
+        if value {
+            self.flags.insert(Flag::ContentTypeOptions);
+        } else {
+            self.flags.remove(Flag::ContentTypeOptions);
+        }
+        self
+    }
+
     /// Build a new `NamedFile` and send it.
     pub async fn send(self, req_headers: &HeaderMap, res: &mut Response) {
         if !self.path.exists() {
@@ -406,6 +436,21 @@ impl NamedFileBuilder {
         })
     }
 }
+/// Whether a browser rendering `content_type` as a document could run script in
+/// the serving origin.
+///
+/// An SVG carries `<script>` elements and event handler attributes, and any XML
+/// document can name an XSLT stylesheet through `<?xml-stylesheet ?>` and render
+/// scripted HTML from it. Both execute against the origin that served the file, so
+/// serving one inline turns an uploaded "image" into stored XSS.
+///
+/// `application/xml` and `application/xhtml+xml` already fell on the `attachment`
+/// side because their top-level type is not in the inline list; this covers the
+/// `image/svg+xml` and `text/xml` spellings that slipped past it.
+fn is_scriptable_xml(content_type: &Mime) -> bool {
+    content_type.subtype() == mime::XML || content_type.suffix() == Some(mime::XML)
+}
+
 fn build_content_disposition(
     file_path: impl AsRef<Path>,
     content_type: &Mime,
@@ -413,7 +458,7 @@ fn build_content_disposition(
     attached_name: Option<&str>,
 ) -> Result<HeaderValue> {
     let disposition_type = disposition_type.unwrap_or_else(|| {
-        if attached_name.is_some() {
+        if attached_name.is_some() || is_scriptable_xml(content_type) {
             "attachment"
         } else {
             match (content_type.type_(), content_type.subtype()) {
@@ -535,9 +580,9 @@ impl NamedFile {
     /// changing the inline/attachment disposition as well as the filename
     /// sent to the peer.
     ///
-    /// By default the disposition is `inline` for text,
-    /// image, and video content types, and `attachment` otherwise, and
-    /// the filename is taken from the path provided in the `open` method
+    /// By default the disposition is `inline` for text, image, video and audio
+    /// content types other than XML-based ones, and `attachment` for everything
+    /// else. The filename is taken from the path provided in the `open` method
     /// after converting it to UTF-8 using
     /// [to_string_lossy](https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy).
     #[inline]
@@ -552,6 +597,19 @@ impl NamedFile {
     #[inline]
     pub fn disable_content_disposition(&mut self) {
         self.flags.remove(Flag::ContentDisposition);
+    }
+
+    /// Specifies whether to send `X-Content-Type-Options: nosniff` or not.
+    ///
+    /// Default is true. Turn this off only when a client depends on MIME
+    /// sniffing to interpret a file whose extension does not describe it.
+    #[inline]
+    pub fn use_content_type_options(&mut self, value: bool) {
+        if value {
+            self.flags.insert(Flag::ContentTypeOptions);
+        } else {
+            self.flags.remove(Flag::ContentTypeOptions);
+        }
     }
 
     /// Get content encoding value reference.
@@ -719,6 +777,12 @@ impl NamedFile {
         if !res.headers().contains_key(CONTENT_TYPE) {
             res.headers_mut()
                 .typed_insert(ContentType::from(self.content_type.clone()));
+        }
+        if self.flags.contains(Flag::ContentTypeOptions)
+            && !res.headers().contains_key(X_CONTENT_TYPE_OPTIONS)
+        {
+            res.headers_mut()
+                .insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
         }
         if let Some(lm) = last_modified.and_then(|lm| self.encodable_last_modified(lm)) {
             res.headers_mut().typed_insert(LastModified::from(lm));
@@ -919,6 +983,100 @@ mod tests {
         assert_eq!(
             value.to_str().unwrap(),
             r#"attachment; filename="report\"\\__.txt"; filename*=UTF-8''report%22%5C%0D%0A.txt"#
+        );
+    }
+
+    fn default_disposition_for(content_type: &Mime) -> String {
+        build_content_disposition("upload.bin", content_type, None, None)
+            .expect("build content disposition")
+            .to_str()
+            .expect("header is ascii")
+            .to_owned()
+    }
+
+    #[test]
+    fn scriptable_xml_defaults_to_attachment() {
+        // An SVG can carry <script>/onload, and any XML document can pull in an
+        // XSLT stylesheet that renders scripted HTML. Serving either inline from
+        // the app's own origin turns an uploaded "image" into stored XSS.
+        for content_type in [
+            mime::IMAGE_SVG,
+            mime::TEXT_XML,
+            "application/xml".parse().expect("parse mime"),
+            "application/xhtml+xml".parse().expect("parse mime"),
+            "application/rss+xml".parse().expect("parse mime"),
+        ] {
+            assert!(
+                default_disposition_for(&content_type).starts_with("attachment"),
+                "{content_type} must not default to inline"
+            );
+        }
+    }
+
+    #[test]
+    fn non_xml_media_still_defaults_to_inline() {
+        // The XML carve-out must not pull ordinary media off the inline path.
+        for content_type in [
+            mime::IMAGE_PNG,
+            mime::TEXT_PLAIN,
+            // A static file server exists to serve HTML documents inline.
+            mime::TEXT_HTML,
+            "video/mp4".parse().expect("parse mime"),
+            "audio/mpeg".parse().expect("parse mime"),
+            "text/javascript".parse().expect("parse mime"),
+        ] {
+            assert_eq!(
+                default_disposition_for(&content_type),
+                "inline",
+                "{content_type} must stay inline"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_disposition_type_overrides_xml_default() {
+        // Serving trusted SVG assets inline stays possible.
+        let value = build_content_disposition("logo.svg", &mime::IMAGE_SVG, Some("inline"), None)
+            .expect("build content disposition");
+        assert_eq!(value.to_str().expect("header is ascii"), "inline");
+    }
+
+    #[tokio::test]
+    async fn svg_is_served_as_attachment_with_nosniff() {
+        use std::io::Write as _;
+
+        let mut file = tempfile::Builder::new()
+            .suffix(".svg")
+            .tempfile()
+            .expect("create temp file");
+        file.write_all(
+            br#"<svg xmlns="http://www.w3.org/2000/svg" onload="alert(document.domain)"/>"#,
+        )
+        .expect("write svg");
+        file.flush().expect("flush");
+
+        let named = NamedFile::builder(file.path())
+            .build()
+            .await
+            .expect("build named file");
+        let mut res = Response::new();
+        named.send(&HeaderMap::new(), &mut res).await;
+
+        let disposition = res
+            .headers()
+            .get(CONTENT_DISPOSITION)
+            .expect("content-disposition is set")
+            .to_str()
+            .expect("header is ascii");
+        assert!(
+            disposition.starts_with("attachment"),
+            "svg served with `{disposition}`"
+        );
+        assert_eq!(
+            res.headers()
+                .get(X_CONTENT_TYPE_OPTIONS)
+                .map(|v| v.to_str().expect("header is ascii")),
+            Some("nosniff")
         );
     }
 

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -111,8 +111,8 @@ pub(crate) enum Flag {
 /// `Content-Disposition: inline`, while other files use `attachment`.
 /// Use [`NamedFileBuilder::attached_name`] to force a download with a specific filename.
 ///
-/// XML-based documents — `image/svg+xml`, `text/xml`, and anything else with an
-/// `xml` subtype or `+xml` suffix — are the exception: they default to
+/// XML-based documents are the exception: `image/svg+xml`, `text/xml`, `text/xsl`
+/// and anything else carrying an `xml` subtype or a `+xml` suffix default to
 /// `attachment` even though their top-level type is `image` or `text`, because a
 /// browser rendering one as a document will run any script it contains in the
 /// serving origin. Pass [`NamedFileBuilder::disposition_type`] to override this
@@ -133,6 +133,9 @@ pub(crate) enum Flag {
 #[derive(Debug)]
 pub struct NamedFile {
     path: PathBuf,
+    /// Overrides the name `Content-Disposition` reports, when the bytes come from
+    /// a different path than the requested resource.
+    disposition_name: Option<String>,
     file: File,
     modified: Option<SystemTime>,
     buffer_size: u64,
@@ -174,6 +177,7 @@ pub struct NamedFile {
 pub struct NamedFileBuilder {
     path: PathBuf,
     attached_name: Option<String>,
+    disposition_name: Option<String>,
     disposition_type: Option<String>,
     content_type: Option<mime::Mime>,
     content_encoding: Option<String>,
@@ -188,6 +192,20 @@ impl NamedFileBuilder {
     pub fn attached_name<T: Into<String>>(mut self, attached_name: T) -> Self {
         self.attached_name = Some(attached_name.into());
         self.flags.insert(Flag::ContentDisposition);
+        self
+    }
+
+    /// Sets the file name used in `Content-Disposition` without forcing the
+    /// disposition to `attachment`, and returns `Self`.
+    ///
+    /// Use this when the bytes are read from a different path than the resource
+    /// the client asked for, so a download is saved under the requested name
+    /// rather than the name of the file on disk. [`Self::attached_name`] sets the
+    /// same name but also forces `attachment`.
+    #[inline]
+    #[must_use]
+    pub fn disposition_name<T: Into<String>>(mut self, disposition_name: T) -> Self {
+        self.disposition_name = Some(disposition_name.into());
         self
     }
 
@@ -312,6 +330,7 @@ impl NamedFileBuilder {
             preload_threshold,
             disposition_type,
             attached_name,
+            disposition_name,
             flags,
         } = self;
 
@@ -416,7 +435,7 @@ impl NamedFileBuilder {
         let mut content_disposition = None;
         if attached_name.is_some() || disposition_type.is_some() {
             content_disposition = Some(build_content_disposition(
-                &path,
+                disposition_name_source(disposition_name.as_deref(), &path),
                 &content_type,
                 disposition_type.as_deref(),
                 attached_name.as_deref(),
@@ -424,6 +443,7 @@ impl NamedFileBuilder {
         }
         Ok(NamedFile {
             path,
+            disposition_name,
             file,
             content_type,
             content_disposition,
@@ -444,11 +464,34 @@ impl NamedFileBuilder {
 /// scripted HTML from it. Both execute against the origin that served the file, so
 /// serving one inline turns an uploaded "image" into stored XSS.
 ///
-/// `application/xml` and `application/xhtml+xml` already fell on the `attachment`
-/// side because their top-level type is not in the inline list; this covers the
-/// `image/svg+xml` and `text/xml` spellings that slipped past it.
+/// `application/*` XML types already fell on the `attachment` side because their
+/// top-level type is not in the inline list. What slipped past were the `image`
+/// and `text` spellings, which is every case below.
 fn is_scriptable_xml(content_type: &Mime) -> bool {
-    content_type.subtype() == mime::XML || content_type.suffix() == Some(mime::XML)
+    let subtype = content_type.subtype().as_str();
+    // The `+xml` structured syntax suffix: `image/svg+xml`, `application/xslt+xml`.
+    content_type.suffix() == Some(mime::XML)
+        // `text/xml`, plus RFC 7303's `xml-dtd` and `xml-external-parsed-entity`,
+        // which are XML but carry no suffix. Compare only the segment before the
+        // first hyphen, so a subtype merely starting with those letters — say
+        // `xmlish` — is not swept along.
+        || subtype
+            .split_once('-')
+            .map_or(subtype, |(head, _)| head)
+            .eq_ignore_ascii_case("xml")
+        // `text/xsl` is the legacy type that `<?xml-stylesheet ?>` itself names,
+        // and browsers parse it as XML.
+        || subtype.eq_ignore_ascii_case("xsl")
+}
+
+/// The path whose file name names the file in `Content-Disposition`.
+///
+/// Normally that is the path on disk, but the two diverge when the bytes come
+/// from somewhere other than the resource that was requested: `StaticDir` serving
+/// the precompressed sidecar `logo.svg.br` for a request for `logo.svg` must
+/// still offer the download as `logo.svg`.
+fn disposition_name_source<'a>(disposition_name: Option<&'a str>, path: &'a Path) -> &'a Path {
+    disposition_name.map_or(path, Path::new)
 }
 
 fn build_content_disposition(
@@ -520,6 +563,7 @@ impl NamedFile {
         NamedFileBuilder {
             path: path.into(),
             attached_name: None,
+            disposition_name: None,
             disposition_type: None,
             content_type: None,
             content_encoding: None,
@@ -763,7 +807,12 @@ impl NamedFile {
                     .insert(CONTENT_DISPOSITION, content_disposition);
             } else if !res.headers().contains_key(CONTENT_DISPOSITION) {
                 // skip to set CONTENT_DISPOSITION header if it is already set.
-                match build_content_disposition(&self.path, &self.content_type, None, None) {
+                match build_content_disposition(
+                    disposition_name_source(self.disposition_name.as_deref(), &self.path),
+                    &self.content_type,
+                    None,
+                    None,
+                ) {
                     Ok(content_disposition) => {
                         res.headers_mut()
                             .insert(CONTENT_DISPOSITION, content_disposition);
@@ -1031,6 +1080,87 @@ mod tests {
                 "{content_type} must stay inline"
             );
         }
+    }
+
+    #[test]
+    fn xml_types_without_the_suffix_default_to_attachment() {
+        // These name XML without carrying an `xml` subtype or a `+xml` suffix, so
+        // the structural checks alone would let them through on `text`.
+        for content_type in [
+            // The type `<?xml-stylesheet type="text/xsl" ?>` itself names.
+            "text/xsl",
+            "text/xml-external-parsed-entity",
+            "text/xml-dtd",
+            // Matching is case-insensitive, as MIME comparisons are.
+            "TEXT/XSL",
+            "Text/XML",
+        ] {
+            let content_type = content_type.parse().expect("parse mime");
+            assert!(
+                default_disposition_for(&content_type).starts_with("attachment"),
+                "{content_type} must not default to inline"
+            );
+        }
+    }
+
+    #[test]
+    fn xml_lookalike_subtypes_stay_inline() {
+        // The XML carve-out keys on the type actually being XML; a subtype that
+        // merely starts with the same letters must not be dragged along.
+        for content_type in ["text/xmlish", "image/xslfoo", "text/xsl-but-not"] {
+            let content_type = content_type.parse().expect("parse mime");
+            assert_eq!(
+                default_disposition_for(&content_type),
+                "inline",
+                "{content_type} must stay inline"
+            );
+        }
+    }
+
+    #[test]
+    fn disposition_name_replaces_the_on_disk_file_name() {
+        // `StaticDir` reads `logo.svg.br` but the client asked for `logo.svg`.
+        let value = build_content_disposition(
+            disposition_name_source(Some("logo.svg"), Path::new("/srv/assets/logo.svg.br")),
+            &mime::IMAGE_SVG,
+            None,
+            None,
+        )
+        .expect("build content disposition");
+        assert_eq!(
+            value.to_str().expect("header is ascii"),
+            r#"attachment; filename="logo.svg""#
+        );
+    }
+
+    #[test]
+    fn attached_name_outranks_disposition_name() {
+        let value = build_content_disposition(
+            disposition_name_source(Some("logo.svg"), Path::new("logo.svg.br")),
+            &mime::IMAGE_SVG,
+            None,
+            Some("chosen.svg"),
+        )
+        .expect("build content disposition");
+        assert_eq!(
+            value.to_str().expect("header is ascii"),
+            r#"attachment; filename="chosen.svg""#
+        );
+    }
+
+    #[test]
+    fn disposition_name_falls_back_to_the_path() {
+        let value = build_content_disposition(
+            disposition_name_source(None, Path::new("/srv/assets/logo.svg")),
+            &mime::IMAGE_SVG,
+            None,
+            None,
+        )
+        .expect("build content disposition");
+        assert_eq!(
+            value.to_str().expect("header is ascii"),
+            r#"attachment; filename="logo.svg""#
+        );
     }
 
     #[test]

--- a/crates/core/src/fs/named_file.rs
+++ b/crates/core/src/fs/named_file.rs
@@ -801,6 +801,16 @@ impl NamedFile {
             false
         };
 
+        // A caller may have already chosen the response's Content-Type. Default
+        // the disposition from the type the client will actually receive, not
+        // necessarily the type detected for the file on disk. Treat an invalid
+        // pre-existing value conservatively as opaque binary data.
+        let effective_content_type = if res.headers().contains_key(CONTENT_TYPE) {
+            res.content_type().unwrap_or(mime::APPLICATION_OCTET_STREAM)
+        } else {
+            self.content_type.clone()
+        };
+
         if self.flags.contains(Flag::ContentDisposition) {
             if let Some(content_disposition) = self.content_disposition.take() {
                 res.headers_mut()
@@ -809,7 +819,7 @@ impl NamedFile {
                 // skip to set CONTENT_DISPOSITION header if it is already set.
                 match build_content_disposition(
                     disposition_name_source(self.disposition_name.as_deref(), &self.path),
-                    &self.content_type,
+                    &effective_content_type,
                     None,
                     None,
                 ) {
@@ -1211,6 +1221,74 @@ mod tests {
                 .get(X_CONTENT_TYPE_OPTIONS)
                 .map(|v| v.to_str().expect("header is ascii")),
             Some("nosniff")
+        );
+    }
+
+    #[tokio::test]
+    async fn response_content_type_controls_default_disposition() {
+        use std::io::Write as _;
+
+        let mut file = tempfile::Builder::new()
+            .suffix(".txt")
+            .tempfile()
+            .expect("create temp file");
+        file.write_all(b"plain text").expect("write text");
+        file.flush().expect("flush");
+
+        for content_type in ["image/svg+xml", "invalid"] {
+            let named = NamedFile::builder(file.path())
+                .build()
+                .await
+                .expect("build named file");
+            assert_eq!(named.content_type().type_(), mime::TEXT);
+            assert_eq!(named.content_type().subtype(), mime::PLAIN);
+
+            let mut res = Response::new();
+            res.headers_mut()
+                .insert(CONTENT_TYPE, content_type.parse().expect("header value"));
+            named.send(&HeaderMap::new(), &mut res).await;
+
+            let disposition = res
+                .headers()
+                .get(CONTENT_DISPOSITION)
+                .expect("content-disposition is set")
+                .to_str()
+                .expect("header is ascii");
+            assert!(
+                disposition.starts_with("attachment"),
+                "response type `{content_type}` produced `{disposition}`"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn safe_response_content_type_can_keep_default_disposition_inline() {
+        use std::io::Write as _;
+
+        let mut file = tempfile::Builder::new()
+            .suffix(".svg")
+            .tempfile()
+            .expect("create temp file");
+        file.write_all(br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#)
+            .expect("write svg");
+        file.flush().expect("flush");
+
+        let named = NamedFile::builder(file.path())
+            .build()
+            .await
+            .expect("build named file");
+        assert_eq!(named.content_type(), &mime::IMAGE_SVG);
+
+        let mut res = Response::new();
+        res.headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
+        named.send(&HeaderMap::new(), &mut res).await;
+
+        assert_eq!(
+            res.headers()
+                .get(CONTENT_DISPOSITION)
+                .expect("content-disposition is set"),
+            "inline"
         );
     }
 

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -190,6 +190,10 @@ pub struct StaticDir {
     pub defaults: Vec<String>,
     /// Fallback file to serve when requested file isn't found
     pub fallback: Option<String>,
+    /// Overrides the `Content-Disposition` type for every served file
+    pub disposition_type: Option<String>,
+    /// Whether to send `X-Content-Type-Options: nosniff`
+    pub use_content_type_options: bool,
 }
 impl Debug for StaticDir {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -202,6 +206,8 @@ impl Debug for StaticDir {
             .field("compressed_variations", &self.compressed_variations)
             .field("defaults", &self.defaults)
             .field("fallback", &self.fallback)
+            .field("disposition_type", &self.disposition_type)
+            .field("use_content_type_options", &self.use_content_type_options)
             .finish()
     }
 }
@@ -225,7 +231,37 @@ impl StaticDir {
             compressed_variations,
             defaults: vec![],
             fallback: None,
+            disposition_type: None,
+            use_content_type_options: true,
         }
+    }
+
+    /// Sets the `Content-Disposition` type used for every served file, e.g.
+    /// `inline` or `attachment`.
+    ///
+    /// By default the type is derived per file from its content type: `inline`
+    /// for text, image, video and audio, `attachment` for everything else
+    /// including XML-based documents such as `image/svg+xml` and `text/xml`.
+    ///
+    /// Forcing `inline` makes every file in the directory render in the browser,
+    /// so only do it for directories whose contents you control. An SVG served
+    /// inline runs its own `<script>` in the serving origin, which is stored XSS
+    /// when the directory holds user uploads.
+    #[inline]
+    #[must_use]
+    pub fn disposition_type(mut self, disposition_type: impl Into<String>) -> Self {
+        self.disposition_type = Some(disposition_type.into());
+        self
+    }
+
+    /// Specifies whether to send `X-Content-Type-Options: nosniff`.
+    ///
+    /// Default is true.
+    #[inline]
+    #[must_use]
+    pub fn use_content_type_options(mut self, value: bool) -> Self {
+        self.use_content_type_options = value;
+        self
     }
 
     /// Sets include_dot_files.
@@ -611,6 +647,10 @@ impl Handler for StaticDir {
                 if let Some(content_type) = content_type {
                     builder = builder.content_type(content_type);
                 }
+                if let Some(disposition_type) = &self.disposition_type {
+                    builder = builder.disposition_type(disposition_type.clone());
+                }
+                builder = builder.use_content_type_options(self.use_content_type_options);
                 (builder, varies_on_accept_encoding)
             };
             if let Ok(named_file) = builder.build().await {

--- a/crates/serve-static/src/dir.rs
+++ b/crates/serve-static/src/dir.rs
@@ -579,6 +579,12 @@ impl Handler for StaticDir {
             let mut content_encoding = None;
             let mut varies_on_accept_encoding = false;
             let content_type = mime_infer::from_path(&abs_path).first();
+            // Captured before the compressed-variant lookup may replace the path:
+            // a download must be named after the resource that was requested, not
+            // after the sidecar the bytes happen to be read from.
+            let requested_name = abs_path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned());
 
             let named_path = if !is_compressed_ext {
                 if !self.compressed_variations.is_empty() {
@@ -646,6 +652,9 @@ impl Handler for StaticDir {
                 }
                 if let Some(content_type) = content_type {
                     builder = builder.content_type(content_type);
+                }
+                if let Some(requested_name) = requested_name {
+                    builder = builder.disposition_name(requested_name);
                 }
                 if let Some(disposition_type) = &self.disposition_type {
                     builder = builder.disposition_type(disposition_type.clone());

--- a/crates/serve-static/src/embed.rs
+++ b/crates/serve-static/src/embed.rs
@@ -6,6 +6,7 @@ use rust_embed::{EmbeddedFile, Metadata, RustEmbed};
 use salvo_core::handler::Handler;
 use salvo_core::http::header::{
     ACCEPT_RANGES, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH, RANGE,
+    X_CONTENT_TYPE_OPTIONS,
 };
 use salvo_core::http::headers::{ContentLength, ContentRange, HeaderMapExt};
 use salvo_core::http::mime::fill_mime_charset_if_need;
@@ -121,6 +122,8 @@ fn render_embedded_data(
             .parse()
             .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
     );
+    res.headers_mut()
+        .insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
 
     // ETag generation and If-None-Match check.
     let hash = hex::encode(metadata.sha256_hash());

--- a/crates/serve-static/src/file.rs
+++ b/crates/serve-static/src/file.rs
@@ -58,6 +58,35 @@ impl StaticFile {
     pub fn preload_threshold(self, threshold: u64) -> Self {
         Self(self.0.preload_threshold(threshold))
     }
+
+    /// Set the `Content-Disposition` type, e.g. `inline` or `attachment`.
+    ///
+    /// By default the type is derived from the file's content type: `inline` for
+    /// text, image, video and audio, `attachment` for everything else including
+    /// XML-based documents such as `image/svg+xml`. Set this to `inline` only for
+    /// files you trust — an SVG rendered inline runs its own script in the
+    /// serving origin.
+    #[inline]
+    #[must_use]
+    pub fn disposition_type(self, disposition_type: impl Into<String>) -> Self {
+        Self(self.0.disposition_type(disposition_type))
+    }
+
+    /// Serve the file as a download under `name`, regardless of its content type.
+    #[inline]
+    #[must_use]
+    pub fn attached_name(self, name: impl Into<String>) -> Self {
+        Self(self.0.attached_name(name))
+    }
+
+    /// Specifies whether to send `X-Content-Type-Options: nosniff` or not.
+    ///
+    /// Default is true.
+    #[inline]
+    #[must_use]
+    pub fn use_content_type_options(self, value: bool) -> Self {
+        Self(self.0.use_content_type_options(value))
+    }
 }
 
 #[async_trait]

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -45,8 +45,8 @@ mod tests {
 
     use salvo_core::http::HeaderValue;
     use salvo_core::http::header::{
-        ACCEPT_RANGES, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, VARY,
-        X_CONTENT_TYPE_OPTIONS,
+        ACCEPT_RANGES, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE,
+        HeaderName, VARY, X_CONTENT_TYPE_OPTIONS,
     };
     use salvo_core::prelude::*;
     use salvo_core::routing::{Filter, filters};
@@ -209,30 +209,40 @@ mod tests {
             .get(StaticDir::new(root.path().to_path_buf()).auto_list(false));
         let service = Service::new(router);
 
-        async fn disposition(service: &Service, url: &str) -> String {
-            TestClient::get(url)
-                .send(service)
-                .await
-                .headers
-                .get(CONTENT_DISPOSITION)
-                .expect("content-disposition is set")
-                .to_str()
-                .expect("header is ascii")
-                .to_owned()
+        async fn headers_of(service: &Service, url: &str) -> (String, String) {
+            let response = TestClient::get(url).send(service).await;
+            let header = |name: HeaderName| {
+                response
+                    .headers
+                    .get(name)
+                    .expect("header is set")
+                    .to_str()
+                    .expect("header is ascii")
+                    .to_owned()
+            };
+            (header(CONTENT_DISPOSITION), header(CONTENT_TYPE))
         }
 
-        for name in ["poc.svg", "poc.xml"] {
-            let value = disposition(&service, &format!("http://127.0.0.1:5801/{name}")).await;
+        // The content type is asserted alongside the disposition: without it this
+        // test would also pass on a file that failed to be recognised at all and
+        // fell back to `application/octet-stream`.
+        for (name, expected_type) in [
+            ("poc.svg", "image/svg+xml"),
+            ("poc.xml", "text/xml; charset=utf-8"),
+        ] {
+            let (disposition, content_type) =
+                headers_of(&service, &format!("http://127.0.0.1:5801/{name}")).await;
+            assert_eq!(content_type, expected_type, "{name} content type");
             assert!(
-                value.starts_with("attachment"),
-                "{name} served with `{value}`"
+                disposition.starts_with("attachment"),
+                "{name} served with `{disposition}`"
             );
         }
         // Ordinary images keep rendering inline.
-        assert_eq!(
-            disposition(&service, "http://127.0.0.1:5801/logo.png").await,
-            "inline"
-        );
+        let (disposition, content_type) =
+            headers_of(&service, "http://127.0.0.1:5801/logo.png").await;
+        assert_eq!(content_type, "image/png");
+        assert_eq!(disposition, "inline");
 
         // Responses are also marked non-sniffable.
         let response = TestClient::get("http://127.0.0.1:5801/logo.png")

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -45,7 +45,8 @@ mod tests {
 
     use salvo_core::http::HeaderValue;
     use salvo_core::http::header::{
-        ACCEPT_RANGES, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, VARY,
+        ACCEPT_RANGES, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, VARY,
+        X_CONTENT_TYPE_OPTIONS,
     };
     use salvo_core::prelude::*;
     use salvo_core::routing::{Filter, filters};
@@ -184,6 +185,96 @@ mod tests {
             .send(&service)
             .await;
         assert_eq!(response.status_code.unwrap(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_static_dir_does_not_serve_uploaded_svg_inline() {
+        // A directory of user uploads is the common deployment. An SVG or XML
+        // document rendered inline runs its own script in the serving origin, so
+        // neither may come back with `Content-Disposition: inline`.
+        let root = tempfile::TempDir::new().unwrap();
+        fs::write(
+            root.path().join("poc.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg" onload="alert(document.domain)"/>"#,
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("poc.xml"),
+            r#"<?xml-stylesheet type="text/xsl" href="poc.xsl"?><root/>"#,
+        )
+        .unwrap();
+        fs::write(root.path().join("logo.png"), b"\x89PNG\r\n\x1a\n").unwrap();
+
+        let router = Router::with_path("{*path}")
+            .get(StaticDir::new(root.path().to_path_buf()).auto_list(false));
+        let service = Service::new(router);
+
+        async fn disposition(service: &Service, url: &str) -> String {
+            TestClient::get(url)
+                .send(service)
+                .await
+                .headers
+                .get(CONTENT_DISPOSITION)
+                .expect("content-disposition is set")
+                .to_str()
+                .expect("header is ascii")
+                .to_owned()
+        }
+
+        for name in ["poc.svg", "poc.xml"] {
+            let value = disposition(&service, &format!("http://127.0.0.1:5801/{name}")).await;
+            assert!(
+                value.starts_with("attachment"),
+                "{name} served with `{value}`"
+            );
+        }
+        // Ordinary images keep rendering inline.
+        assert_eq!(
+            disposition(&service, "http://127.0.0.1:5801/logo.png").await,
+            "inline"
+        );
+
+        // Responses are also marked non-sniffable.
+        let response = TestClient::get("http://127.0.0.1:5801/logo.png")
+            .send(&service)
+            .await;
+        assert_eq!(
+            response
+                .headers
+                .get(X_CONTENT_TYPE_OPTIONS)
+                .and_then(|v| v.to_str().ok()),
+            Some("nosniff")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_static_dir_disposition_type_can_restore_inline() {
+        // Directories holding only trusted assets can opt back into inline SVG.
+        let root = tempfile::TempDir::new().unwrap();
+        fs::write(
+            root.path().join("logo.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#,
+        )
+        .unwrap();
+
+        let router = Router::with_path("{*path}").get(
+            StaticDir::new(root.path().to_path_buf())
+                .disposition_type("inline")
+                .use_content_type_options(false),
+        );
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:5801/logo.svg")
+            .send(&service)
+            .await;
+        assert_eq!(
+            response
+                .headers
+                .get(CONTENT_DISPOSITION)
+                .and_then(|v| v.to_str().ok()),
+            Some("inline")
+        );
+        assert_eq!(response.headers.get(X_CONTENT_TYPE_OPTIONS), None);
     }
 
     #[tokio::test]

--- a/crates/serve-static/src/lib.rs
+++ b/crates/serve-static/src/lib.rs
@@ -258,6 +258,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_static_dir_names_download_after_the_requested_file() {
+        // Build tools routinely emit `logo.svg.br` next to `logo.svg`. When that
+        // sidecar is negotiated the bytes come from it, but the client asked for
+        // `logo.svg` and must be offered that name, not the sidecar's.
+        let root = tempfile::TempDir::new().unwrap();
+        fs::write(root.path().join("logo.svg"), "<svg/>").unwrap();
+        fs::write(root.path().join("logo.svg.br"), "brotli-bytes").unwrap();
+
+        let router = Router::with_path("{*path}")
+            .get(StaticDir::new(root.path().to_path_buf()).auto_list(false));
+        let service = Service::new(router);
+
+        let response = TestClient::get("http://127.0.0.1:5801/logo.svg")
+            .add_header("accept-encoding", "br", true)
+            .send(&service)
+            .await;
+        // The sidecar really was selected...
+        assert_eq!(
+            response
+                .headers
+                .get(CONTENT_ENCODING)
+                .and_then(|v| v.to_str().ok()),
+            Some("br")
+        );
+        // ...yet the download is named after the request.
+        assert_eq!(
+            response
+                .headers
+                .get(CONTENT_DISPOSITION)
+                .and_then(|v| v.to_str().ok()),
+            Some(r#"attachment; filename="logo.svg""#)
+        );
+    }
+
+    #[tokio::test]
     async fn test_static_dir_disposition_type_can_restore_inline() {
         // Directories holding only trusted assets can opt back into inline SVG.
         let root = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes a stored XSS reported by **sl91994** (CWE-79) affecting `StaticDir` / `StaticFile` and the underlying `salvo_core::fs::NamedFile`.

`build_content_disposition` classified files by their **top-level** media type:

```rust
match (content_type.type_(), content_type.subtype()) {
    (mime::IMAGE | mime::TEXT | mime::VIDEO | mime::AUDIO, _)
    | (_, mime::JAVASCRIPT | mime::JSON) => "inline",
    _ => "attachment",
}
```

So `image/svg+xml` matched on `image` and `text/xml` matched on `text`, and both were served `inline`. Both are *active* content:

- an SVG carries `<script>` elements and event-handler attributes;
- any XML document can name an XSLT stylesheet via `<?xml-stylesheet ?>` and render scripted HTML from it.

An app serving user uploads through `StaticDir` therefore turned an uploaded "image" into stored XSS in its own origin. Extension/content-type allowlists don't help — `.svg` with `Content-Type: image/svg+xml` *is* a legitimate image by every check an upload endpoint typically makes. And neither `StaticDir` nor `StaticFile` exposed any way to override the disposition (`grep -rn "disposition" crates/serve-static/src/` returned nothing).

## The fix

The classification was **already** fail-safe for `application/xml` and `application/xhtml+xml` — they reach `attachment` because their top-level type isn't in the inline list. The bug is that the same documents spelled `image/svg+xml` or `text/xml` slip past. This extends the existing behavior to any `xml` subtype or `+xml` suffix, so the XML family is handled consistently:

| Content-Type | before | after |
|---|---|---|
| `image/svg+xml` | `inline` | `attachment` |
| `text/xml`, `text/xsl` | `inline` | `attachment` |
| `application/xml`, `application/xhtml+xml` | `attachment` | `attachment` |
| `image/png`, `text/plain`, `video/mp4` | `inline` | `inline` |
| `text/html` | `inline` | `inline` |

`text/html` deliberately keeps defaulting to `inline` — serving HTML documents is what a static file server is for. The vector this closes is the one where a *non-HTML* type sneaks past upload validation.

Additionally:

- `NamedFile` and `StaticEmbed` responses now send `X-Content-Type-Options: nosniff` (the report noted no `nosniff` anywhere in the tree).
- `StaticDir` gains `disposition_type` and `use_content_type_options`; `StaticFile` gains `disposition_type`, `attached_name` and `use_content_type_options` — so directories of trusted assets can opt back into inline rendering, which previously had no public API at all.

## Compatibility

Serving an SVG or XML file now sends `Content-Disposition: attachment`, so **following a link to one downloads it** instead of rendering, and `<object>` / `<embed>` / `<iframe>` no longer display it. Referencing the same file from `<img>`, CSS `url()` or `<use>` is **unaffected** — browsers ignore `Content-Disposition` on subresource loads, so SVG icons and logos keep working.

Sites that intentionally serve trusted SVGs for direct viewing restore the old behavior with:

```rust
StaticDir::new(["assets"]).disposition_type("inline")
```

`StaticDir` is `#[non_exhaustive]`, so the two new public fields are not a breaking change.

## Verification

Six tests added. I confirmed they actually reproduce the vulnerability by stubbing `is_scriptable_xml` to `false` (restoring the old classification) and re-running:

```
thread 'tests::test_static_dir_does_not_serve_uploaded_svg_inline' panicked at
crates\serve-static\src\lib.rs:226:13:
poc.svg served with `inline`
```

With the fix in place: 345 tests pass across `salvo_core` and `salvo-serve-static`, `cargo check --workspace --all-features` is clean, `cargo fmt --check` is clean, and `cargo clippy` reports no new warnings (the 4 existing ones are all in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
