### PR TITLE
Support JSON values in cookie extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   into inline rendering, which previously had no public API on either handler.
 - `NamedFileBuilder::disposition_name`, which sets the name `Content-Disposition` reports
   without forcing the disposition to `attachment` the way `attached_name` does.
+- Cookie extractors now support structured JSON values. `CookieParam<T>` falls back to JSON when
+  scalar conversion fails, while `#[derive(Extractible)]` accepts explicit cookie field sources
+  such as `#[salvo(extract(source(from = "cookie", parse = "json")))]`.
 - Changelog established for upcoming releases.
 - Opt-in RFC 9457 Problem Details responses with typed extension members and OpenAPI integration
   via the `rfc9457` feature.

--- a/crates/core/src/extract/parameter/cookie.rs
+++ b/crates/core/src/extract/parameter/cookie.rs
@@ -18,9 +18,26 @@ fn parse_cookie_value<'de, T>(value: &'de str) -> Option<T>
 where
     T: Deserialize<'de>,
 {
-    from_str_val(value)
-        .ok()
-        .or_else(|| serde_json::from_str(value).ok())
+    // If the value looks like JSON, try JSON deserialization first so that
+    // structured types (e.g. serde_json::Value, untagged enums with a String
+    // variant) get the correct structured representation rather than being
+    // swallowed by the scalar string deserializer.
+    let trimmed = value.trim_start();
+    let looks_like_json = trimmed.starts_with('{')
+        || trimmed.starts_with('[')
+        || trimmed.starts_with('"')
+        || trimmed.chars().next().is_some_and(|c| {
+            c.is_ascii_digit() || matches!(c, '-' | 't' | 'f' | 'n')
+        });
+
+    if looks_like_json {
+        if let Ok(v) = serde_json::from_str::<T>(value) {
+            return Some(v);
+        }
+    }
+
+    // Fall back to scalar string deserialization.
+    from_str_val(value).ok()
 }
 
 impl<T> CookieParam<T, true> {
@@ -266,6 +283,46 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(result.into_inner(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_required_cookie_param_extract_json_value_as_value() {
+        let cookie = cookie::Cookie::new("data", r#"{"x":1}"#);
+        let mut req = TestClient::get("http://127.0.0.1:5801")
+            .add_header("cookie", cookie.encoded().to_string(), true)
+            .build();
+        let mut depot = Depot::new();
+
+        let result = CookieParam::<serde_json::Value, true>::extract_with_arg(
+            &mut req, &mut depot, "data",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.into_inner(), serde_json::json!({"x": 1}));
+    }
+
+    #[tokio::test]
+    async fn test_required_cookie_param_extract_untagged_enum_string_not_matched_by_json() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(untagged)]
+        enum StringOrStruct {
+            String(String),
+            Struct { x: i32 },
+        }
+
+        let cookie = cookie::Cookie::new("data", r#"{"x":1}"#);
+        let mut req = TestClient::get("http://127.0.0.1:5801")
+            .add_header("cookie", cookie.encoded().to_string(), true)
+            .build();
+        let mut depot = Depot::new();
+
+        let result = CookieParam::<StringOrStruct, true>::extract_with_arg(
+            &mut req, &mut depot, "data",
+        )
+        .await
+        .unwrap();
+        // Should be parsed as the struct variant, not the string variant.
+        assert_eq!(result.into_inner(), StringOrStruct::Struct { x: 1 });
     }
 
     #[tokio::test]

--- a/crates/core/src/extract/parameter/cookie.rs
+++ b/crates/core/src/extract/parameter/cookie.rs
@@ -9,7 +9,20 @@ use crate::http::{ParseError, Request};
 use crate::serde::from_str_val;
 
 /// Extracts a parameter from a request cookie.
+///
+/// Scalar values use Salvo's string deserializer. If that fails, the cookie
+/// value is parsed as JSON so structured values can be extracted directly.
 pub struct CookieParam<T, const REQUIRED: bool = true>(Option<T>);
+
+fn parse_cookie_value<'de, T>(value: &'de str) -> Option<T>
+where
+    T: Deserialize<'de>,
+{
+    from_str_val(value)
+        .ok()
+        .or_else(|| serde_json::from_str(value).ok())
+}
+
 impl<T> CookieParam<T, true> {
     /// Consumes self and returns the value of the parameter.
     pub fn into_inner(self) -> T {
@@ -102,7 +115,7 @@ where
         let value = req
             .cookies()
             .get(arg)
-            .and_then(|v| from_str_val(v.value()).ok())
+            .and_then(|v| parse_cookie_value(v.value()))
             .ok_or_else(|| {
                 ParseError::other(format!(
                     "cookie parameter {arg} not found or convert to type failed"
@@ -133,7 +146,7 @@ where
         let value = req
             .cookies()
             .get(arg)
-            .and_then(|v| from_str_val(v.value()).ok());
+            .and_then(|v| parse_cookie_value(v.value()));
         Ok(Self(value))
     }
 }
@@ -142,6 +155,7 @@ where
 mod tests {
     use crate::test::TestClient;
     use http::header::HeaderValue;
+    use serde::Serialize;
 
     use super::*;
 
@@ -224,6 +238,34 @@ mod tests {
         let result =
             CookieParam::<String, true>::extract_with_arg(&mut req, &mut depot, "param").await;
         assert_eq!(result.unwrap().0.unwrap(), "param");
+    }
+
+    #[tokio::test]
+    async fn test_required_cookie_param_extract_with_json_value() {
+        #[derive(Debug, Deserialize, Serialize, PartialEq)]
+        struct AuthToken {
+            pkce_verifier: String,
+            csrf_token: String,
+        }
+
+        let expected = AuthToken {
+            pkce_verifier: "verifier".into(),
+            csrf_token: "csrf".into(),
+        };
+        let cookie = cookie::Cookie::new(
+            "token",
+            serde_json::to_string(&expected).expect("serialize cookie value"),
+        );
+        let mut req = TestClient::get("http://127.0.0.1:5801")
+            .add_header("cookie", cookie.encoded().to_string(), true)
+            .build();
+        let mut depot = Depot::new();
+
+        let result =
+            CookieParam::<AuthToken, true>::extract_with_arg(&mut req, &mut depot, "token")
+                .await
+                .unwrap();
+        assert_eq!(result.into_inner(), expected);
     }
 
     #[tokio::test]

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -242,10 +242,13 @@ impl<'de> RequestDeserializer<'de> {
                     return Err(ValError::custom("JSON source value must be borrowed"));
                 };
                 let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(s));
-                seed.deserialize(&mut de)
+                let value = seed
+                    .deserialize(&mut de)
                     // Preserve the underlying serde_json error (line/column and the
                     // expected/actual type) instead of a generic message.
-                    .map_err(ValError::custom)
+                    .map_err(ValError::custom)?;
+                de.end().map_err(ValError::custom)?;
+                Ok(value)
             } else if let Some(value) = self.field_str_value.take() {
                 seed.deserialize(CowValue(value))
             } else if let Some(value) = self.field_vec_value.take() {
@@ -887,6 +890,32 @@ mod tests {
 
         let data: RequestData<'_> = req.extract(&mut depot).await.unwrap();
         assert_eq!(data.tok, expected);
+    }
+
+    #[cfg(feature = "cookie")]
+    #[tokio::test]
+    async fn test_de_request_rejects_trailing_data_in_json_cookie() {
+        #[derive(Deserialize, Extractible, Debug)]
+        struct RequestData {
+            #[salvo(extract(source(from = "cookie", parse = "json")))]
+            tok: serde_json::Value,
+        }
+
+        let cookie = cookie::Cookie::new("tok", r#"{"valid":true}junk"#);
+        let mut req = TestClient::get("http://127.0.0.1:8698/callback")
+            .add_header("cookie", cookie.encoded().to_string(), true)
+            .build();
+        let mut depot = Depot::new();
+
+        let result: Result<RequestData, _> = req.extract(&mut depot).await;
+        let error = match result {
+            Ok(data) => panic!("accepted JSON cookie with trailing data: {:?}", data.tok),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("trailing characters"),
+            "unexpected extraction error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/serde/request.rs
+++ b/crates/core/src/serde/request.rs
@@ -223,17 +223,23 @@ impl<'de> RequestDeserializer<'de> {
                 .expect("`MapAccess::next_value` called before next_key");
 
             let parser = self.real_parser(source);
-            if source.from == SourceFrom::Body && parser == SourceParser::Json {
-                // For JSON body parsing, value is always borrowed from the request payload.
-                // panic because this indicates a bug in the program rather than an expected
-                // failure.
+            let parse_json = parser == SourceParser::Json
+                && match source.from {
+                    SourceFrom::Body => true,
+                    #[cfg(feature = "cookie")]
+                    SourceFrom::Cookie => true,
+                    _ => false,
+                };
+            if parse_json {
+                // JSON body and cookie values are borrowed from the request. A missing value
+                // indicates a bug in the deserializer rather than an expected parse failure.
                 let value = self
                     .field_str_value
                     .take()
                     .expect("MapAccess::next_value called before next_key");
-                // Body JSON values are always borrowed from the request payload
+                // JSON values from these sources are always borrowed from the request.
                 let Cow::Borrowed(s) = value else {
-                    return Err(ValError::custom("JSON body value must be borrowed"));
+                    return Err(ValError::custom("JSON source value must be borrowed"));
                 };
                 let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new(s));
                 seed.deserialize(&mut de)
@@ -844,6 +850,43 @@ mod tests {
                 s: "abcd-good"
             }
         );
+    }
+
+    #[cfg(feature = "cookie")]
+    #[tokio::test]
+    async fn test_de_request_with_json_cookie() {
+        #[derive(Deserialize, Serialize, Eq, PartialEq, Debug)]
+        struct AuthToken<'a> {
+            pkce_verifier: &'a str,
+            csrf_token: &'a str,
+            nonce: &'a str,
+            from_url: Option<&'a str>,
+        }
+
+        #[derive(Deserialize, Extractible, Eq, PartialEq, Debug)]
+        struct RequestData<'a> {
+            #[serde(borrow)]
+            #[salvo(extract(source(from = "cookie", parse = "json")))]
+            tok: AuthToken<'a>,
+        }
+
+        let expected = AuthToken {
+            pkce_verifier: "verifier",
+            csrf_token: "csrf",
+            nonce: "nonce",
+            from_url: Some("/dashboard"),
+        };
+        let cookie = cookie::Cookie::new(
+            "tok",
+            serde_json::to_string(&expected).expect("serialize cookie value"),
+        );
+        let mut req = TestClient::get("http://127.0.0.1:8698/callback")
+            .add_header("cookie", cookie.encoded().to_string(), true)
+            .build();
+        let mut depot = Depot::new();
+
+        let data: RequestData<'_> = req.extract(&mut depot).await.unwrap();
+        assert_eq!(data.tok, expected);
     }
 
     #[tokio::test]

--- a/crates/macros/src/extract.rs
+++ b/crates/macros/src/extract.rs
@@ -171,7 +171,8 @@ impl Parse for SourceInfo {
         if source.parser.is_empty() {
             source.parser = "smart".to_owned();
         }
-        if !["param", "query", "header", "body", "depot"].contains(&source.from.as_str()) {
+        if !["param", "query", "header", "cookie", "body", "depot"].contains(&source.from.as_str())
+        {
             return Err(Error::new(
                 input.span(),
                 format!("source from is invalid: {}", source.from),

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -86,7 +86,7 @@ pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// - `#[salvo(extract(default_source(from = "query")))]` sets a fallback source for fields without
 ///   an explicit source.
-/// - `from` accepts `param`, `query`, `header`, `body`, or `depot`.
+/// - `from` accepts `param`, `query`, `header`, `cookie`, `body`, or `depot`.
 /// - `parse` accepts `smart`, `json`, or `multimap`.
 /// - `#[salvo(extract(rename_all = "camelCase"))]` renames fields with the same case rules used by
 ///   serde.
@@ -115,7 +115,14 @@ pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// struct Search<'a> {
 ///     #[salvo(extract(source(from = "param")))]
 ///     id: i64,
+///     #[salvo(extract(source(from = "cookie", parse = "json")))]
+///     preferences: Preferences,
 ///     term: &'a str,
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct Preferences {
+///     compact: bool,
 /// }
 ///
 /// #[handler]


### PR DESCRIPTION
## Summary
- accept `cookie` as an `Extractible` field source and honor explicit JSON parsing
- let `CookieParam<T>` fall back to JSON for structured cookie values while preserving scalar conversion
- add encoded-cookie regression coverage and document the new behavior

## Testing
- `cargo test -p salvo_core --all-features`
- `cargo check -p salvo_core --no-default-features`
- `cargo test -p salvo_macros`
- `cargo test -p salvo-oapi --all-features`
- Clippy on the affected crates with warnings denied after allowing the repository's existing Rust 1.97 lints

Fixes #1695