### PR TITLE
fix(tls): pass the rustls CryptoProvider explicitly instead of relying on crate features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `examples/oapi-3-2` demonstrates emitting a 3.2 document with a `QUERY` route.
 - `salvo_core::fs::extension_content_encoding`, which reports the content coding a file
   extension implies, so a handler choosing a file to serve can tell that it already carries one.
+- `salvo_core::conn::rustls::default_crypto_provider`, which reports the rustls `CryptoProvider`
+  Salvo builds its TLS configurations with. Pass it to other rustls based libraries so the whole
+  application agrees on one backend.
 
 ### Changed
 
@@ -96,6 +99,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- TLS setup no longer panics with *"Could not automatically determine the process-level
+  `CryptoProvider` from Rustls crate features"*. rustls can only pick a backend by itself when
+  exactly one of its `aws-lc-rs` and `ring` features is enabled across the whole dependency
+  graph, so pulling in any crate that enables the other one made `RustlsListener`,
+  `QuinnListener`, `AcmeListener` and the proxy's default `HyperClient` panic. Salvo now selects
+  the provider from its own features and passes it to rustls explicitly. An application that
+  installed a process level provider through `CryptoProvider::install_default` still has that
+  one used; Salvo itself never installs one, so applications keep full control over the
+  process level default.
 - `StaticDir` names a download after the file that was requested rather than the precompressed
   sidecar it was served from, so a request for `logo.svg` answered out of `logo.svg.br` no
   longer offers `Content-Disposition: attachment; filename="logo.svg.br"`.

--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -39,7 +39,7 @@ const ACME_TLS_ALPN_NAME: &[u8] = b"acme-tls/1";
 /// Reuses the process level provider when the application installed one, otherwise builds one
 /// from this crate's `aws-lc-rs` / `ring` features without installing it globally. Passing the
 /// provider explicitly keeps rustls from panicking when feature unification makes both backends
-/// available at once.
+/// available at once. `ring` wins when both are on, matching this crate's default.
 fn default_crypto_provider() -> Arc<CryptoProvider> {
     if let Some(provider) = CryptoProvider::get_default() {
         return Arc::clone(provider);

--- a/crates/acme/src/listener.rs
+++ b/crates/acme/src/listener.rs
@@ -17,6 +17,7 @@ use salvo_core::http::uri::Scheme;
 use salvo_core::{Result as CoreResult, Router, cfg_feature};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::TlsAcceptor;
+use tokio_rustls::rustls::crypto::CryptoProvider;
 use tokio_rustls::rustls::server::ServerConfig;
 use tokio_rustls::server::TlsStream;
 
@@ -32,6 +33,27 @@ cfg_feature! {
 
 /// ACME TLS-ALPN-01 protocol name.
 const ACME_TLS_ALPN_NAME: &[u8] = b"acme-tls/1";
+
+/// Returns the [`CryptoProvider`] used to build the ACME `ServerConfig`.
+///
+/// Reuses the process level provider when the application installed one, otherwise builds one
+/// from this crate's `aws-lc-rs` / `ring` features without installing it globally. Passing the
+/// provider explicitly keeps rustls from panicking when feature unification makes both backends
+/// available at once.
+fn default_crypto_provider() -> Arc<CryptoProvider> {
+    if let Some(provider) = CryptoProvider::get_default() {
+        return Arc::clone(provider);
+    }
+
+    #[cfg(any(feature = "ring", not(feature = "aws-lc-rs")))]
+    {
+        Arc::new(tokio_rustls::rustls::crypto::ring::default_provider())
+    }
+    #[cfg(all(not(feature = "ring"), feature = "aws-lc-rs"))]
+    {
+        Arc::new(tokio_rustls::rustls::crypto::aws_lc_rs::default_provider())
+    }
+}
 
 /// A wrapper around an underlying listener which implements ACME.
 pub struct AcmeListenerBuilder<T> {
@@ -367,7 +389,9 @@ impl<T> AcmeListenerBuilder<T> {
         };
         let cert_resolver = Arc::new(cert_resolver);
 
-        let mut server_config = ServerConfig::builder()
+        let mut server_config = ServerConfig::builder_with_provider(default_crypto_provider())
+            .with_safe_default_protocol_versions()
+            .map_err(salvo_core::Error::other)?
             .with_no_client_auth()
             .with_cert_resolver(cert_resolver.clone());
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -152,7 +152,9 @@ nix = { workspace = true, optional = true, features = ["fs", "user"] }
 [dev-dependencies]
 criterion = { workspace = true }
 fastrand = { workspace = true }
-rustls = { workspace = true, features = ["aws-lc-rs"] }
+# Both backends on purpose: this makes rustls unable to pick a provider from crate features,
+# which is exactly the situation that used to panic. See `conn::rustls::default_crypto_provider`.
+rustls = { workspace = true, features = ["aws-lc-rs", "ring"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/core/src/conn/rustls.rs
+++ b/crates/core/src/conn/rustls.rs
@@ -1,7 +1,9 @@
 //! `RustlsListener` and utils.
 use std::io::{Error as IoError, Result as IoResult};
+use std::sync::Arc;
 
 use tokio_rustls::rustls::RootCertStore;
+use tokio_rustls::rustls::crypto::CryptoProvider;
 use tokio_rustls::rustls::pki_types::{CertificateDer, pem::PemObject};
 
 pub(crate) mod config;
@@ -9,6 +11,41 @@ pub use config::{Keycert, RustlsConfig, ServerConfig};
 
 mod listener;
 pub use listener::{RustlsAcceptor, RustlsListener};
+
+/// Returns the [`CryptoProvider`] used to build rustls configurations.
+///
+/// rustls needs to know which cryptographic backend to use. It can pick one on its own only
+/// when exactly one of its `aws-lc-rs` and `ring` features is enabled in the whole dependency
+/// graph. As soon as another crate pulls in the other backend, cargo feature unification makes
+/// the choice ambiguous and rustls panics with *"Could not automatically determine the
+/// process-level `CryptoProvider` from Rustls crate features"*.
+///
+/// To stay panic free, Salvo never relies on that automatic selection:
+///
+/// - If the application already installed a process level provider through
+///   [`CryptoProvider::install_default`] (a FIPS or HSM backed one, for instance), it is reused
+///   as is.
+/// - Otherwise a provider is built from Salvo's own `aws-lc-rs` / `ring` features and passed
+///   explicitly to rustls. It is **not** installed as the process default, so the application
+///   remains free to install whichever provider it wants, whenever it wants.
+///
+/// This is also the provider to pass to other rustls based libraries used alongside Salvo, so
+/// that the whole application agrees on a single backend.
+#[must_use]
+pub fn default_crypto_provider() -> Arc<CryptoProvider> {
+    if let Some(provider) = CryptoProvider::get_default() {
+        return Arc::clone(provider);
+    }
+
+    #[cfg(any(feature = "aws-lc-rs", not(feature = "ring")))]
+    {
+        Arc::new(tokio_rustls::rustls::crypto::aws_lc_rs::default_provider())
+    }
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    {
+        Arc::new(tokio_rustls::rustls::crypto::ring::default_provider())
+    }
+}
 
 pub(crate) fn read_trust_anchor(trust_anchor: &[u8]) -> IoResult<RootCertStore> {
     let certs = CertificateDer::pem_slice_iter(trust_anchor)
@@ -37,7 +74,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_rustls_listener() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        // No `CryptoProvider::install_default()` call here on purpose: both the listener and the
+        // client below must work without a process level provider being installed.
         let mut acceptor = TcpListener::new("127.0.0.1:0")
             .rustls(RustlsConfig::new(
                 Keycert::new()
@@ -57,7 +95,9 @@ mod tests {
         tokio::spawn(async move {
             let stream = TcpStream::connect(addr).await.unwrap();
             let trust_anchor = include_bytes!("../../certs/chain.pem");
-            let client_config = ClientConfig::builder()
+            let client_config = ClientConfig::builder_with_provider(default_crypto_provider())
+                .with_safe_default_protocol_versions()
+                .unwrap()
                 .with_root_certificates(read_trust_anchor(trust_anchor.as_slice()).unwrap())
                 .with_no_client_auth();
             let connector = TlsConnector::from(Arc::new(client_config));

--- a/crates/core/src/conn/rustls.rs
+++ b/crates/core/src/conn/rustls.rs
@@ -29,6 +29,9 @@ pub use listener::{RustlsAcceptor, RustlsListener};
 ///   explicitly to rustls. It is **not** installed as the process default, so the application
 ///   remains free to install whichever provider it wants, whenever it wants.
 ///
+/// `aws-lc-rs` wins when both features are on, matching Salvo's own default and the backend the
+/// certified keys are already signed with in [`RustlsConfig`].
+///
 /// This is also the provider to pass to other rustls based libraries used alongside Salvo, so
 /// that the whole application agrees on a single backend.
 #[must_use]

--- a/crates/core/src/conn/rustls/config.rs
+++ b/crates/core/src/conn/rustls/config.rs
@@ -21,7 +21,7 @@ pub use tokio_rustls::rustls::server::ServerConfig;
 
 use crate::{IntoVecString, conn::IntoConfigStream};
 
-use super::read_trust_anchor;
+use super::{default_crypto_provider, read_trust_anchor};
 
 /// Private key and certificate
 #[derive(Clone, Debug)]
@@ -291,7 +291,9 @@ impl RustlsConfig {
             }
         };
 
-        let mut config = ServerConfig::builder_with_protocol_versions(self.tls_versions)
+        let mut config = ServerConfig::builder_with_provider(default_crypto_provider())
+            .with_protocol_versions(self.tls_versions)
+            .map_err(|e| IoError::other(format!("failed to build server config: {e}")))?
             .with_client_cert_verifier(client_auth)
             .with_cert_resolver(Arc::new(CertResolver {
                 literal_certified_keys,

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["aws-lc-rs", "hyper-client", "unix-sock-client"]
 full = ["aws-lc-rs", "hyper-client", "reqwest-client", "unix-sock-client"]
-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "reqwest?/rustls"]
+aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "reqwest?/rustls", "rustls", "rustls/aws-lc-rs"]
 ring = ["hyper-rustls?/ring", "reqwest?/rustls-no-provider", "rustls", "rustls/ring"]
 hyper-client = ["dep:hyper-util", "dep:hyper-rustls"]
 reqwest-client = ["dep:reqwest"]
@@ -58,7 +58,9 @@ tracing = { workspace = true }
 [dev-dependencies]
 futures-util = { workspace = true, features = ["sink"] }
 salvo_core = { workspace = true, features = ["http1", "server", "test"] }
-rustls ={ workspace = true, features = ["aws-lc-rs"]}
+# Both backends on purpose: this makes rustls unable to pick a provider from crate features,
+# which is exactly the situation that used to panic when building the default HTTPS connector.
+rustls = { workspace = true, features = ["aws-lc-rs", "ring"] }
 salvo_extra = { workspace = true, features = ["websocket"] }
 tokio-tungstenite = { workspace = true }
 

--- a/crates/proxy/src/hyper_client.rs
+++ b/crates/proxy/src/hyper_client.rs
@@ -1,10 +1,12 @@
 use std::io;
+use std::sync::Arc;
 
 use hyper::upgrade::OnUpgrade;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::Client as HyperUtilClient;
 use hyper_util::client::legacy::connect::{Connect, HttpConnector};
 use hyper_util::rt::TokioExecutor;
+use rustls::crypto::CryptoProvider;
 use salvo_core::Error;
 use salvo_core::http::{ReqBody, ResBody, StatusCode};
 use salvo_core::rt::tokio::TokioIo;
@@ -21,12 +23,33 @@ pub struct HyperClient<C> {
     inner: HyperUtilClient<C, ReqBody>,
 }
 
+/// Returns the [`CryptoProvider`] used to build the default HTTPS connector.
+///
+/// Reuses the process level provider when the application installed one, otherwise builds one
+/// from this crate's `aws-lc-rs` / `ring` features without installing it globally. Passing the
+/// provider explicitly keeps rustls from panicking when feature unification makes both backends
+/// available at once.
+fn default_crypto_provider() -> Arc<CryptoProvider> {
+    if let Some(provider) = CryptoProvider::get_default() {
+        return Arc::clone(provider);
+    }
+
+    #[cfg(any(feature = "aws-lc-rs", not(feature = "ring")))]
+    {
+        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+    }
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    {
+        Arc::new(rustls::crypto::ring::default_provider())
+    }
+}
+
 fn build_default_https_connector_with(
     native_roots: impl FnOnce() -> io::Result<HttpsConnector<HttpConnector>>,
-    webpki_roots: impl FnOnce() -> HttpsConnector<HttpConnector>,
-) -> HttpsConnector<HttpConnector> {
+    webpki_roots: impl FnOnce() -> io::Result<HttpsConnector<HttpConnector>>,
+) -> io::Result<HttpsConnector<HttpConnector>> {
     match native_roots() {
-        Ok(connector) => connector,
+        Ok(connector) => Ok(connector),
         Err(error) => {
             tracing::warn!(
                 error = ?error,
@@ -39,24 +62,24 @@ fn build_default_https_connector_with(
 
 impl Default for HyperClient<HttpsConnector<HttpConnector>> {
     fn default() -> Self {
-        #[cfg(feature = "ring")]
-        let _ = rustls::crypto::ring::default_provider().install_default();
         let https = build_default_https_connector_with(
             || {
                 Ok(HttpsConnectorBuilder::new()
-                    .with_native_roots()?
+                    .with_provider_and_native_roots(default_crypto_provider())?
                     .https_or_http()
                     .enable_all_versions()
                     .build())
             },
             || {
-                HttpsConnectorBuilder::new()
-                    .with_webpki_roots()
+                Ok(HttpsConnectorBuilder::new()
+                    .with_provider_and_webpki_roots(default_crypto_provider())
+                    .map_err(io::Error::other)?
                     .https_or_http()
                     .enable_all_versions()
-                    .build()
+                    .build())
             },
-        );
+        )
+        .expect("failed to build the default https connector for proxy hyper client");
         Self {
             inner: HyperUtilClient::builder(TokioExecutor::new()).build(https),
         }
@@ -154,27 +177,24 @@ mod tests {
 
     #[test]
     fn test_default_connector_falls_back_to_webpki_roots() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider()
-            .install_default();
-
         let connector = build_default_https_connector_with(
             || Err(io::Error::other("missing native roots")),
             || {
-                HttpsConnectorBuilder::new()
-                    .with_webpki_roots()
+                Ok(HttpsConnectorBuilder::new()
+                    .with_provider_and_webpki_roots(default_crypto_provider())
+                    .map_err(io::Error::other)?
                     .https_or_http()
                     .enable_all_versions()
-                    .build()
+                    .build())
             },
-        );
+        )
+        .expect("webpki roots fallback should succeed");
 
         let _client = HyperClient::new(HyperUtilClient::builder(TokioExecutor::new()).build(connector));
     }
 
     #[tokio::test]
     async fn test_upstreams_elect() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider()
-            .install_default();
         let upstreams = vec!["https://www.example.com", "https://www.example2.com"];
         let proxy = Proxy::new(upstreams.clone(), HyperClient::default());
         let request = Request::new();
@@ -185,8 +205,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_hyper_client() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider()
-            .install_default();
         let router = Router::new().push(
             Router::with_path("rust/{**rest}")
                 .goal(Proxy::new(vec!["https://salvo.rs"], HyperClient::default())),
@@ -203,8 +221,6 @@ mod tests {
 
     #[test]
     fn test_others() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider()
-            .install_default();
         let mut handler = Proxy::new(["https://www.bing.com"], HyperClient::default());
         assert_eq!(handler.upstreams().len(), 1);
         assert_eq!(handler.upstreams_mut().len(), 1);

--- a/crates/proxy/src/hyper_client.rs
+++ b/crates/proxy/src/hyper_client.rs
@@ -29,18 +29,25 @@ pub struct HyperClient<C> {
 /// from this crate's `aws-lc-rs` / `ring` features without installing it globally. Passing the
 /// provider explicitly keeps rustls from panicking when feature unification makes both backends
 /// available at once.
+///
+/// `ring` wins when both features are on. `aws-lc-rs` is what `default` and `full` select, and
+/// the `salvo` crate always pulls this one in through `salvo-proxy/full`, so `ring` can only be
+/// there because it was asked for. It also keeps this in step with `ReqwestClient::default`,
+/// which still has to install ring as the process default for `reqwest`'s sake: were the two to
+/// disagree, which provider this function returns would depend on whether a `ReqwestClient` had
+/// been built first.
 fn default_crypto_provider() -> Arc<CryptoProvider> {
     if let Some(provider) = CryptoProvider::get_default() {
         return Arc::clone(provider);
     }
 
-    #[cfg(any(feature = "aws-lc-rs", not(feature = "ring")))]
-    {
-        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
-    }
-    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    #[cfg(feature = "ring")]
     {
         Arc::new(rustls::crypto::ring::default_provider())
+    }
+    #[cfg(not(feature = "ring"))]
+    {
+        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
     }
 }
 

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -888,7 +888,6 @@ mod tests {
 
     #[test]
     fn test_host_header_handling() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let uri = Uri::from_str("http://host.tld/test").unwrap();
         let mut req = Request::new();
         let depot = Depot::new();
@@ -937,7 +936,6 @@ mod tests {
 
     #[test]
     fn test_proxy_default_host_header_getter_includes_port() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         // `Proxy::new` now defaults to the standards-compliant getter, which keeps
         // a non-default upstream port in the forwarded `Host`.
         let proxy = Proxy::new(vec!["http://host.tld:8080"], HyperClient::default());
@@ -1107,8 +1105,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_proxy_websocket_connection_with_split_connection_headers() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
         let upstream_router = Router::with_path("ws").goal(websocket_echo);
         let (upstream_addr, upstream_server) = spawn_server(upstream_router).await;
 


### PR DESCRIPTION
Alternative to #1474, which fixes the same panic but by installing a process level `CryptoProvider` from inside the library.

## The problem

`rustls` can only pick a cryptographic backend on its own when exactly one of its `aws-lc-rs` and `ring` features is enabled **across the whole dependency graph** ([`get_default_or_install_from_crate_features`](https://docs.rs/rustls/0.23.40/src/rustls/crypto/mod.rs.html#243)). As soon as another crate pulls in the other backend, cargo feature unification makes the choice ambiguous and rustls panics:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make
sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

Salvo itself is careful (`tokio-rustls` is pulled with `default-features = false`), but the user has no say in what their other dependencies enable — see #1335, where a `k8s` client dragged in the second backend.

Every entry point that lets rustls choose for itself is affected: `RustlsListener`, `QuinnListener` (it goes through `RustlsConfig::build_server_config`), `AcmeListener` and the proxy's default `HyperClient`.

## Why not #1474

#1474 calls `CryptoProvider::install_default()` inside `build_server_config()`. That fixes the symptom, but:

1. **It writes process global state from a library.** Whoever installs first wins, so a library that installs preempts the application: a later `CryptoProvider::install_default()` in `main()` returns `Err`, and an application that wrote `.expect()` there now panics. It also defeats `rustls/custom-provider`, whose whole point is to force the application to choose.
2. **`get_default().is_none()` followed by `install_default().expect(..)` is a TOCTOU.** Two listeners built concurrently race, the loser gets `Err` and the `.expect()` turns it into a panic — in a function that returns `IoResult` and should not panic at all. rustls' own comment at that exact spot is *"Ignore the error resulting from us losing a race, and accept the outcome."*
3. **It does not cover the reported failure.** The panic in #1335 happened on a `tokio-runtime-worker` in an outbound client path, not in `build_server_config()`. `AcmeListener` and `HyperClient::default()` stay broken.
4. **The repo already has the right pattern.** `default_rustls_crypto_provider()` in `crates/jwt-auth/src/oidc.rs` (#1667) reuses an installed provider if there is one, otherwise builds one from crate features *without installing it*, and passes it explicitly.

## What this PR does

Applies the `jwt-auth` pattern everywhere rustls was left to guess:

- **`salvo_core`** — new `pub fn conn::rustls::default_crypto_provider() -> Arc<CryptoProvider>`, and `build_server_config()` switches from `ServerConfig::builder_with_protocol_versions(..)` to `builder_with_provider(default_crypto_provider()).with_protocol_versions(..)?`. The version-selection error is now returned as an `IoError` instead of `unwrap()`ed inside rustls. `QuinnListener` is fixed through the same function.
- **`salvo-acme`** — same treatment for `AcmeListener`'s `ServerConfig::builder()`.
- **`salvo-proxy`** — `HyperClient::default()` uses `with_provider_and_native_roots` / `with_provider_and_webpki_roots`, and the `let _ = ring::default_provider().install_default();` line is gone. `aws-lc-rs` now enables the `rustls` dependency, mirroring what `ring` already did.

Semantics:

- an application that installed a process level provider (FIPS, HSM, or just `install_default()` in `main()`) keeps it — `default_crypto_provider()` returns that one;
- otherwise the provider comes from the crate's own `aws-lc-rs` / `ring` feature and is passed to rustls **without** being installed, so the application keeps full control over the process level default;
- the server now uses one backend for both the handshake and `any_supported_type`, which previously could come from different providers.

No API is removed and no behaviour changes for applications that already work. `default_crypto_provider()` is public so an application can pass the same provider to other rustls based libraries it uses next to Salvo.

## Testing

The `rustls` dev-dependency of `salvo_core` and `salvo-proxy` now enables **both** backends on purpose, so the test suites run in exactly the ambiguous configuration that used to panic. `crates/core/src/conn/rustls.rs`'s listener test also lost its `install_default()` call, on both the server and the client side.

Verified with that setup:

- `cargo test -p salvo_core --features rustls --lib` — 344 passed. Reverting just the `build_server_config` change makes `conn::rustls::tests::test_rustls_listener` panic with the message above, so the test really does cover the regression.
- `cargo test -p salvo-proxy --lib` — 29 passed, including `test_hyper_client`, which makes a real HTTPS request through the default connector.
- `cargo check` over the feature matrix: `salvo_core` with `rustls`/`quinn` and with `ring` instead of `aws-lc-rs`; `salvo-acme` with `ring` (default), `aws-lc-rs` and `quinn`; `salvo-proxy` with `aws-lc-rs` (default) and `ring`.
- `cargo fmt --all -- --check` clean, `cargo clippy` reports no new warnings in the touched crates.

## Left for a follow-up

`ReqwestClient::default()` still calls `install_default()` under the `ring` feature, because `reqwest`'s `rustls-no-provider` backend reads the process level default and the only alternative is `use_preconfigured_tls`. Worth doing, but it is a bigger change than this one.

Closes #1335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
