### PR TITLE
feat(otel)!: follow the OpenTelemetry HTTP semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `xml-external-parsed-entity`, and the legacy `text/xsl` that `<?xml-stylesheet ?>` itself
   names. `text/html` still defaults to `inline`. Reported by sl91994.
 - `NamedFile` and `StaticEmbed` responses now carry `X-Content-Type-Options: nosniff`.
-- `salvo-otel` no longer records the request URI, so query strings holding access tokens,
-  signed-URL signatures or session identifiers stop being copied into metric dimensions and
-  span attributes. `Metrics` dropped `url.full` entirely, and `Tracing` replaced it with
-  `url.path` plus a `url.query` whose `sig`, `Signature`, `AWSAccessKeyId` and
-  `X-Goog-Signature` values are redacted, as the semantic conventions require.
+- `salvo-otel` no longer records the full request URI. `Metrics` dropped `url.full` entirely,
+  so query strings no longer become metric dimensions. `Tracing` replaced it with `url.path`
+  plus a `url.query` whose `sig`, `Signature`, `AWSAccessKeyId` and `X-Goog-Signature` values
+  are redacted, as the semantic conventions require.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `xml-external-parsed-entity`, and the legacy `text/xsl` that `<?xml-stylesheet ?>` itself
   names. `text/html` still defaults to `inline`. Reported by sl91994.
 - `NamedFile` and `StaticEmbed` responses now carry `X-Content-Type-Options: nosniff`.
+- `salvo-otel` no longer records the request URI, so query strings holding access tokens,
+  signed-URL signatures or session identifiers stop being copied into metric dimensions and
+  span attributes. `Metrics` dropped `url.full` entirely, and `Tracing` replaced it with
+  `url.path` plus a `url.query` whose `sig`, `Signature`, `AWSAccessKeyId` and
+  `X-Goog-Signature` values are redacted, as the semantic conventions require.
 
 ### Added
 
@@ -66,6 +71,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `salvo_core::conn::rustls::default_crypto_provider`, which reports the rustls `CryptoProvider`
   Salvo builds its TLS configurations with. Pass it to other rustls based libraries so the whole
   application agrees on one backend.
+- `salvo-otel` records `http.server.active_requests`, `http.server.request.body.size` and
+  `http.server.response.body.size`, which its documentation already described. The in-flight
+  gauge is decremented from a drop guard, so a cancelled request — a client disconnect or a
+  timeout — does not leave it drifting upwards.
+- `Metrics::with_known_methods` and `Tracing::with_known_methods` widen the set of request
+  methods reported verbatim in `http.request.method`, for applications serving methods beyond
+  RFC 9110 and RFC 5789 (WebDAV's `PROPFIND`, say).
+- `salvo-otel` gained a `matched-path` feature, on by default, which supplies `http.route`.
+  Through the `salvo` crate it follows that crate's own `matched-path` feature.
 
 ### Changed
 
@@ -80,6 +94,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is unchanged.
 - `OpenApi` still defaults to emitting OpenAPI 3.1; 3.2 remains opt-in via
   `OpenApi::openapi_version`.
+- **Breaking.** `salvo-otel`'s `Metrics` middleware now emits the instruments the
+  OpenTelemetry HTTP semantic conventions define, replacing names it had invented. Dashboards
+  and alerts built on the old names have to be repointed:
+  - `salvo_request_duration_ms` became `http.server.request.duration`, and it measures
+    **seconds** rather than milliseconds, with the bucket boundaries the conventions
+    recommend. A Prometheus exporter renders it as `http_server_request_duration_seconds`.
+  - `salvo_request_count` and `salvo_error_count` are gone. The conventions define no such
+    instruments: the duration histogram already carries the request count
+    (`http_server_request_duration_seconds_count`), and failures are selected by filtering on
+    `error.type` or `http.response.status_code`.
+  - The instruments are registered under the `salvo-otel` instrumentation scope, versioned
+    and carrying the semantic conventions' schema URL, instead of a bare `salvo` meter.
+- **Breaking.** `salvo-otel`'s metric dimensions changed to the ones the conventions list, so
+  the number of time series is now proportional to the number of routes instead of growing
+  with traffic:
+  - `url.full` — one series per distinct URI, query string included — was replaced by
+    `http.route`, the matched route template (`/users/{id}`). Requests that matched no route
+    carry no `http.route` at all rather than a fallback, except a request for `/`, which is
+    reported as the root route because salvo reports a root-mounted goal and a request that
+    matched nothing with the same empty matched path.
+  - `exception.message` was replaced by `error.type`, which carries the status code of a
+    server error. The old attribute was unbounded, and it was appended to the labels of
+    `salvo_request_count` and `salvo_request_duration_ms` but not of `salvo_error_count`, so
+    a failed request produced a different label set than a successful one on the same metric.
+  - A request method outside RFC 9110 and RFC 5789 is now reported as `_OTHER`, so a client
+    cannot open a time series per made-up method name. See `Metrics::with_known_methods`.
+  - `url.scheme` and `network.protocol.version` were added. A request target given in absolute
+    form lets the client choose the scheme, so a scheme other than `http` or `https` is
+    reported as `_OTHER` for the same reason an unknown method is; spans still record it.
+- **Breaking.** `salvo-otel`'s `Tracing` middleware follows the same conventions:
+  - Spans are named `{method} {route}` — `GET /users/{id}` — instead of `{method} {uri}`,
+    which made every distinct URI its own span name.
+  - `url.full` gave way to `url.path`, a redacted `url.query` and `url.scheme`, and
+    `http.route` was added.
+  - `network.protocol.version` reports `1.1` and `2` rather than the `HTTP/1.1` form
+    `Version`'s `Debug` output produces.
+  - An unknown request method is reported as `_OTHER`, with the value the client sent kept in
+    `http.request.method_original`.
+  - A `5xx` response now sets `error.type` and an error span status. A `4xx` does not: it is a
+    valid outcome for a server span.
+  - `http.response.header.content-length`, which was not an attribute the conventions define,
+    became `http.response.body.size`, and it is left out for a response whose body the
+    catcher fills in after middleware returns rather than reported as zero.
+  - `client.address` reports the peer's IP (`198.51.100.4`) with the port split out into
+    `client.port`, instead of salvo's `socket://198.51.100.4:54321` display form.
+  - The `telemetry.sdk.name`, `telemetry.sdk.version` and `telemetry.sdk.language` attributes
+    were removed from every span. They describe the resource, and the SDK already reports them
+    there.
 - **Behavior change.** Serving an SVG or XML file through `StaticDir`, `StaticFile` or
   `NamedFile` now sends `Content-Disposition: attachment` by default, so following a link to
   one downloads it instead of rendering it, and `<object>`/`<embed>`/`<iframe>` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the number of time series is now proportional to the number of routes instead of growing
   with traffic:
   - `url.full` — one series per distinct URI, query string included — was replaced by
-    `http.route`, the matched route template (`/users/{id}`). Requests that matched no route
-    carry no `http.route` at all rather than a fallback, except a request for `/`, which is
-    reported as the root route because salvo reports a root-mounted goal and a request that
-    matched nothing with the same empty matched path.
+    `http.route`, the matched route template (`/users/{id}`). A request that matched no route
+    carries no `http.route` at all rather than a fallback, and a goal mounted at the router
+    root is reported as `/`.
   - `exception.message` was replaced by `error.type`, which carries the status code of a
     server error. The old attribute was unbounded, and it was appended to the labels of
     `salvo_request_count` and `salvo_request_duration_ms` but not of `salvo_error_count`, so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ openssl = { version = "0.10" }
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry-http = { version = "0.32", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32", default-features = false }
+opentelemetry_sdk = { version = "0.32", default-features = false }
 parking_lot = "0.12"
 path-slash = "0.2"
 percent-encoding = "2"

--- a/crates/otel/Cargo.toml
+++ b/crates/otel/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry-semantic-conventions = { workspace = true, features = [
     "semconv_experimental",
 ] }
 opentelemetry = { workspace = true, features = ["metrics"] }
+percent-encoding = { workspace = true }
 salvo_core = { workspace = true, default-features = false }
 tracing = { workspace = true }
 

--- a/crates/otel/Cargo.toml
+++ b/crates/otel/Cargo.toml
@@ -19,16 +19,20 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["matched-path"]
+matched-path = ["salvo_core/matched-path"]
 
 [dependencies]
 opentelemetry-http = { workspace = true }
-opentelemetry-semantic-conventions = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true, features = [
+    "semconv_experimental",
+] }
 opentelemetry = { workspace = true, features = ["metrics"] }
 salvo_core = { workspace = true, default-features = false }
 tracing = { workspace = true }
 
 [dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["metrics", "testing"] }
 salvo_core = { workspace = true, features = ["test"] }
 tokio = { workspace = true }
 

--- a/crates/otel/README.md
+++ b/crates/otel/README.md
@@ -52,24 +52,42 @@ OpenTelemetry integration for the Salvo web framework. This crate provides middl
 
 | Middleware | Purpose |
 |------------|---------|
-| `Metrics` | Collects HTTP request metrics (latency, status codes, etc.) |
+| `Metrics` | Records the HTTP server metrics of the semantic conventions |
 | `Tracing` | Adds distributed tracing spans to requests |
 
 ## Collected Metrics
 
-The `Metrics` middleware collects:
-- `http.server.request.duration` - Request duration histogram
-- `http.server.active_requests` - Number of in-flight requests
-- `http.server.request.body.size` - Request body size
-- `http.server.response.body.size` - Response body size
+The `Metrics` middleware records:
 
-## Trace Attributes
+| Name | Instrument | Unit |
+|------|------------|------|
+| `http.server.request.duration` | histogram | `s` |
+| `http.server.active_requests` | up-down counter | `{request}` |
+| `http.server.request.body.size` | histogram | `By` |
+| `http.server.response.body.size` | histogram | `By` |
 
-The `Tracing` middleware adds standard HTTP semantic conventions:
-- `http.method` - HTTP method
-- `http.route` - Matched route pattern
-- `http.status_code` - Response status code
-- `http.url` - Request URL
+There is no request or error counter: the duration histogram already carries the
+request count — a Prometheus exporter renders it as
+`http_server_request_duration_seconds_count` — and failures are selected by
+filtering on `error.type` or `http.response.status_code`.
+
+## Attributes
+
+Both middlewares follow the [HTTP semantic conventions][semconv] for attribute
+names and values: `http.request.method`, `http.route`,
+`http.response.status_code`, `url.scheme`, `url.path`, `url.query`,
+`network.protocol.version` and `error.type`.
+
+The request target is reported as the matched route template (`/users/{id}`)
+rather than the requested URI, so the number of metric time series stays
+proportional to the number of routes rather than growing with traffic. Requests
+with a method the conventions do not name are reported as `_OTHER`; list your
+own with `Metrics::with_known_methods`.
+
+`http.route` needs the `matched-path` feature, which is enabled by default —
+through the `salvo` crate, by its own `matched-path` feature.
+
+[semconv]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
 
 ## Installation
 

--- a/crates/otel/src/lib.rs
+++ b/crates/otel/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! | Middleware | Purpose |
 //! |------------|---------|
-//! | [`Metrics`] | Collects HTTP request metrics (latency, status codes, etc.) |
+//! | [`Metrics`] | Collects HTTP server metrics (duration, in-flight requests, body sizes) |
 //! | [`Tracing`] | Adds distributed tracing spans to requests |
 //!
 //! # Metrics Example
@@ -41,25 +41,38 @@
 //! global::set_tracer_provider(provider);
 //!
 //! let router = Router::new()
-//!     .hoop(Tracing::new())
+//!     .hoop(Tracing::new(provider.tracer("my-service")))
 //!     .get(my_handler);
 //! ```
 //!
 //! # Collected Metrics
 //!
-//! The `Metrics` middleware collects:
-//! - `http.server.request.duration` - Request duration histogram
-//! - `http.server.active_requests` - Number of in-flight requests
-//! - `http.server.request.body.size` - Request body size
-//! - `http.server.response.body.size` - Response body size
+//! The [`Metrics`] middleware records the HTTP server instruments defined by the
+//! [HTTP metric conventions]:
 //!
-//! # Trace Attributes
+//! - `http.server.request.duration` — request duration histogram, in seconds
+//! - `http.server.active_requests` — number of in-flight requests
+//! - `http.server.request.body.size` — request body size, in bytes
+//! - `http.server.response.body.size` — response body size, in bytes
 //!
-//! The `Tracing` middleware adds standard HTTP semantic conventions:
-//! - `http.method` - HTTP method
-//! - `http.route` - Matched route pattern
-//! - `http.status_code` - Response status code
-//! - `http.url` - Request URL
+//! There is no request or error counter: the duration histogram already carries
+//! the request count, and failures are selected by filtering on `error.type` or
+//! `http.response.status_code`.
+//!
+//! # Attributes
+//!
+//! Both middlewares follow the [HTTP span conventions] for attribute names and
+//! values: `http.request.method`, `http.route`, `http.response.status_code`,
+//! `url.scheme`, `url.path`, `url.query`, `network.protocol.version` and
+//! `error.type`.
+//!
+//! The request target is reported as the matched route template (`/users/{id}`)
+//! rather than the requested URI, so the number of metric time series stays
+//! proportional to the number of routes. That attribute needs the `matched-path`
+//! feature, which is enabled by default.
+//!
+//! [HTTP metric conventions]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+//! [HTTP span conventions]: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 //!
 //! Read more: <https://salvo.rs>
 #![doc(html_favicon_url = "https://salvo.rs/favicon-32x32.png")]
@@ -67,6 +80,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod metrics;
+mod semconv;
 mod tracing;
 
 pub use metrics::Metrics;

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -1,17 +1,90 @@
 use std::time::Instant;
 
-use opentelemetry::metrics::{Counter, Histogram};
-use opentelemetry::{KeyValue, global};
-use opentelemetry_semantic_conventions::trace;
-use salvo_core::http::ResBody;
+use opentelemetry::metrics::{Histogram, UpDownCounter};
+use opentelemetry::{InstrumentationScope, KeyValue, global};
+use opentelemetry_semantic_conventions::{SCHEMA_URL, attribute, metric};
+use salvo_core::http::headers::{self, HeaderMapExt};
 use salvo_core::prelude::*;
 
-/// Middleware for metrics with OpenTelemetry.
+use crate::semconv::{self, KnownMethods, OTHER};
+
+/// Bucket boundaries, in seconds, the HTTP semantic conventions recommend for
+/// `http.server.request.duration`.
+const DURATION_BOUNDARIES: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
+/// Middleware recording the HTTP server metrics defined by the OpenTelemetry
+/// [HTTP semantic conventions].
+///
+/// # Instruments
+///
+/// | Name | Instrument | Unit |
+/// |------|------------|------|
+/// | `http.server.request.duration` | histogram | `s` |
+/// | `http.server.active_requests` | up-down counter | `{request}` |
+/// | `http.server.request.body.size` | histogram | `By` |
+/// | `http.server.response.body.size` | histogram | `By` |
+///
+/// There is deliberately no request or error counter: the duration histogram
+/// already carries the request count (a Prometheus exporter renders it as
+/// `http_server_request_duration_seconds_count`), and failures are selected by
+/// filtering on `error.type` or `http.response.status_code`.
+///
+/// # Attributes
+///
+/// `http.server.active_requests` carries `http.request.method` and `url.scheme`.
+/// The other three carry, additionally, `network.protocol.version`,
+/// `http.response.status_code`, `http.route` when a route matched, and
+/// `error.type` when the response status is a server error.
+///
+/// Every attribute is drawn from a bounded set, so the number of time series
+/// stays proportional to the number of routes rather than growing with traffic.
+/// In particular the request target is reported as the matched route template
+/// (`/users/{id}`) rather than the requested URI, and the two values a client
+/// can otherwise choose — the request method and, through an absolute-form
+/// request target, the scheme — collapse to `_OTHER` when they fall outside the
+/// known set. See [`Metrics::with_known_methods`].
+///
+/// [HTTP semantic conventions]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+///
+/// # Route attribute
+///
+/// `http.route` requires the `matched-path` feature, which is enabled by
+/// default. Through the `salvo` crate, enable its own `matched-path` feature
+/// (also on by default) to turn this one on.
+///
+/// A request that matched no route carries no `http.route`, as the conventions
+/// ask, rather than one built from the path it asked for. The exception is a
+/// request for `/`, which is reported as the root route: salvo reports a goal
+/// mounted at the router root and a request that matched nothing with the same
+/// empty matched path, and an application that has no root route has no root
+/// traffic for its `/` misses to be confused with.
+///
+/// # Body sizes
+///
+/// The body size histograms only record a measurement when the size is known
+/// before the response is written: `http.server.request.body.size` comes from
+/// the request's `Content-Length`, and `http.server.response.body.size` from a
+/// buffered response body. Streamed bodies, `HEAD` responses and error
+/// responses whose body the catcher fills in after middleware returns are
+/// skipped rather than recorded as zero.
+///
+/// # Example
+///
+/// ```ignore
+/// use salvo_core::prelude::*;
+/// use salvo_otel::Metrics;
+///
+/// let router = Router::new().hoop(Metrics::new()).get(handler);
+/// ```
 #[derive(Debug)]
 pub struct Metrics {
-    request_count: Counter<u64>,
-    error_count: Counter<u64>,
     duration: Histogram<f64>,
+    active_requests: UpDownCounter<i64>,
+    request_body_size: Histogram<u64>,
+    response_body_size: Histogram<u64>,
+    known_methods: Option<KnownMethods>,
 }
 
 impl Default for Metrics {
@@ -21,27 +94,95 @@ impl Default for Metrics {
 }
 
 impl Metrics {
-    /// Create `Metrics` middleware with `meter`.
+    /// Creates `Metrics` middleware, registering its instruments on the global
+    /// meter provider.
+    ///
+    /// The instruments bind to whichever provider is installed at this moment,
+    /// so call [`global::set_meter_provider`] first. Built before the
+    /// application's provider is installed, the middleware binds to the no-op
+    /// provider and records nothing.
     #[must_use]
     pub fn new() -> Self {
-        let meter = global::meter("salvo");
+        let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .with_schema_url(SCHEMA_URL)
+            .build();
+        let meter = global::meter_with_scope(scope);
         Self {
-            request_count: meter
-                .u64_counter("salvo_request_count")
-                .with_description("total request count (since start of service)")
-                .build(),
-            error_count: meter
-                .u64_counter("salvo_error_count")
-                .with_description("failed request count (since start of service)")
-                .build(),
             duration: meter
-                .f64_histogram("salvo_request_duration_ms")
-                .with_unit("milliseconds")
-                .with_description(
-                    "request duration histogram (in milliseconds, since start of service)",
-                )
+                .f64_histogram(metric::HTTP_SERVER_REQUEST_DURATION)
+                .with_unit("s")
+                .with_description("Duration of HTTP server requests.")
+                .with_boundaries(DURATION_BOUNDARIES.to_vec())
                 .build(),
+            active_requests: meter
+                .i64_up_down_counter(metric::HTTP_SERVER_ACTIVE_REQUESTS)
+                .with_unit("{request}")
+                .with_description("Number of active HTTP server requests.")
+                .build(),
+            request_body_size: meter
+                .u64_histogram(metric::HTTP_SERVER_REQUEST_BODY_SIZE)
+                .with_unit("By")
+                .with_description("Size of HTTP server request bodies.")
+                .build(),
+            response_body_size: meter
+                .u64_histogram(metric::HTTP_SERVER_RESPONSE_BODY_SIZE)
+                .with_unit("By")
+                .with_description("Size of HTTP server response bodies.")
+                .build(),
+            known_methods: None,
         }
+    }
+
+    /// Replaces the set of methods reported verbatim in `http.request.method`.
+    ///
+    /// By default only the methods RFC 9110 defines, plus `PATCH` from RFC 5789,
+    /// are reported as themselves; any other method becomes `_OTHER` so a client
+    /// cannot create a time series per made-up method name. An application that
+    /// serves further methods — WebDAV's `PROPFIND`, say — can list them here.
+    ///
+    /// The set replaces the default rather than extending it, matching how the
+    /// conventions define `OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS`, so include
+    /// every method that should be reported verbatim. Names are matched
+    /// case-sensitively.
+    ///
+    /// ```ignore
+    /// use salvo_otel::Metrics;
+    ///
+    /// let metrics = Metrics::new().with_known_methods(["GET", "POST", "PROPFIND"]);
+    /// ```
+    #[must_use]
+    pub fn with_known_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.known_methods = Some(semconv::known_methods(methods));
+        self
+    }
+}
+
+/// Keeps `http.server.active_requests` balanced.
+///
+/// The decrement happens on drop so it also runs when the request future is
+/// cancelled — a client disconnect or a timeout drops the future mid-await, and
+/// decrementing only after `call_next` returned would leak the increment and
+/// leave the gauge drifting upwards for the life of the process.
+struct ActiveRequestGuard<'a> {
+    counter: &'a UpDownCounter<i64>,
+    attrs: Vec<KeyValue>,
+}
+
+impl<'a> ActiveRequestGuard<'a> {
+    fn new(counter: &'a UpDownCounter<i64>, attrs: Vec<KeyValue>) -> Self {
+        counter.add(1, &attrs);
+        Self { counter, attrs }
+    }
+}
+
+impl Drop for ActiveRequestGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.add(-1, &self.attrs);
     }
 }
 
@@ -54,47 +195,74 @@ impl Handler for Metrics {
         res: &mut Response,
         ctrl: &mut FlowCtrl,
     ) {
-        let mut labels = Vec::with_capacity(3);
-        labels.push(KeyValue::new(
-            trace::HTTP_REQUEST_METHOD,
-            req.method().to_string(),
-        ));
-        labels.push(KeyValue::new(trace::URL_FULL, req.uri().to_string()));
+        let method = KeyValue::new(
+            attribute::HTTP_REQUEST_METHOD,
+            semconv::known_method_value(req.method(), self.known_methods.as_ref())
+                .unwrap_or_else(|| OTHER.into()),
+        );
+        let scheme = KeyValue::new(
+            attribute::URL_SCHEME,
+            semconv::bounded_scheme_value(req.scheme()),
+        );
 
-        let s = Instant::now();
+        // Held for the whole request, including the `call_next` await below.
+        let _active =
+            ActiveRequestGuard::new(&self.active_requests, vec![method.clone(), scheme.clone()]);
+
+        let mut labels = Vec::with_capacity(6);
+        labels.push(method);
+        labels.push(scheme);
+        if let Some(version) = semconv::protocol_version(req.version()) {
+            labels.push(KeyValue::new(attribute::NETWORK_PROTOCOL_VERSION, version));
+        }
+        // Read before the body is consumed downstream.
+        let request_body_size = req
+            .headers()
+            .typed_get::<headers::ContentLength>()
+            .map(|length| length.0);
+
+        let started = Instant::now();
         ctrl.call_next(req, depot, res).await;
-        let elapsed = s.elapsed();
+        let elapsed = started.elapsed();
+
+        #[cfg(feature = "matched-path")]
+        if let Some(route) = semconv::route_value(req) {
+            labels.push(KeyValue::new(attribute::HTTP_ROUTE, route));
+        }
 
         let status = res.status_code.unwrap_or_else(|| {
             tracing::info!("[otel::Metrics] Treat status_code=none as 200(OK)");
             StatusCode::OK
         });
         labels.push(KeyValue::new(
-            trace::HTTP_RESPONSE_STATUS_CODE,
-            status.as_u16() as i64,
+            attribute::HTTP_RESPONSE_STATUS_CODE,
+            i64::from(status.as_u16()),
         ));
-        if status.is_client_error() || status.is_server_error() {
-            self.error_count.add(1, &labels);
-            let msg = if let ResBody::Error(body) = &res.body {
-                body.to_string()
-            } else {
-                format!("ErrorCode: {}", status.as_u16())
-            };
-            labels.push(KeyValue::new(trace::EXCEPTION_MESSAGE, msg));
+        // Only a server error counts as a failed request, and the conventions
+        // use the status code as the low-cardinality class of that error.
+        if status.is_server_error() {
+            labels.push(KeyValue::new(
+                attribute::ERROR_TYPE,
+                status.as_str().to_owned(),
+            ));
         }
 
-        self.request_count.add(1, &labels);
-        self.duration
-            .record(elapsed.as_secs_f64() * 1000.0, &labels);
+        self.duration.record(elapsed.as_secs_f64(), &labels);
+        if let Some(size) = request_body_size {
+            self.request_body_size.record(size, &labels);
+        }
+        if let Some(size) = semconv::final_body_size(req, res, status) {
+            self.response_body_size.record(size, &labels);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use salvo_core::prelude::*;
     use salvo_core::test::{ResponseExt, TestClient};
 
     use super::*;
+
     #[tokio::test]
     async fn test_metrics_default() {
         let metrics = Metrics::default();
@@ -109,6 +277,39 @@ mod tests {
     #[tokio::test]
     async fn test_metrics_handle() {
         let metrics = Metrics::default();
+
+        let router = Router::new().hoop(metrics).goal(hello);
+        let service = Service::new(router);
+
+        let content = TestClient::get("http://127.0.0.1:8698")
+            .send(&service)
+            .await
+            .take_string()
+            .await
+            .unwrap();
+        assert_eq!(content, "Hello");
+    }
+
+    #[tokio::test]
+    async fn test_metrics_handle_error() {
+        #[handler]
+        async fn boom() -> Result<(), StatusError> {
+            Err(StatusError::internal_server_error())
+        }
+
+        let router = Router::new().hoop(Metrics::new()).goal(boom);
+        let service = Service::new(router);
+
+        let res = TestClient::get("http://127.0.0.1:8698")
+            .send(&service)
+            .await;
+        assert_eq!(res.status_code, Some(StatusCode::INTERNAL_SERVER_ERROR));
+    }
+
+    #[tokio::test]
+    async fn test_metrics_with_known_methods() {
+        let metrics = Metrics::new().with_known_methods(["GET", "PROPFIND"]);
+        assert!(metrics.known_methods.is_some());
 
         let router = Router::new().hoop(metrics).goal(hello);
         let service = Service::new(router);

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -55,11 +55,11 @@ const DURATION_BOUNDARIES: &[f64] = &[
 /// (also on by default) to turn this one on.
 ///
 /// A request that matched no route carries no `http.route`, as the conventions
-/// ask, rather than one built from the path it asked for. The exception is a
-/// request for `/`, which is reported as the root route: salvo reports a goal
-/// mounted at the router root and a request that matched nothing with the same
-/// empty matched path, and an application that has no root route has no root
-/// traffic for its `/` misses to be confused with.
+/// ask, rather than one built from the path it asked for. A goal mounted at the
+/// router root is reported as `/`, which salvo itself does not distinguish from
+/// an unmatched request — both leave the matched path empty — so the two are
+/// told apart by whether the service had already answered the request when the
+/// middleware was entered.
 ///
 /// # Body sizes
 ///
@@ -221,14 +221,17 @@ impl Handler for Metrics {
             .typed_get::<headers::ContentLength>()
             .map(|length| length.0);
 
+        // The service resolves the route, and settles whether there was one at
+        // all, before middleware runs — so this has to be read before handing
+        // the request on.
+        #[cfg(feature = "matched-path")]
+        if let Some(route) = semconv::route_value(req, res) {
+            labels.push(KeyValue::new(attribute::HTTP_ROUTE, route));
+        }
+
         let started = Instant::now();
         ctrl.call_next(req, depot, res).await;
         let elapsed = started.elapsed();
-
-        #[cfg(feature = "matched-path")]
-        if let Some(route) = semconv::route_value(req) {
-            labels.push(KeyValue::new(attribute::HTTP_ROUTE, route));
-        }
 
         let status = res.status_code.unwrap_or_else(|| {
             tracing::info!("[otel::Metrics] Treat status_code=none as 200(OK)");

--- a/crates/otel/src/metrics.rs
+++ b/crates/otel/src/metrics.rs
@@ -14,6 +14,20 @@ const DURATION_BOUNDARIES: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
 
+/// Byte-oriented defaults from 1 KiB to 64 MiB. The HTTP conventions do not
+/// prescribe body-size boundaries; SDK views can override these defaults.
+const BODY_SIZE_BOUNDARIES: &[f64] = &[
+    1_024.0,
+    4_096.0,
+    16_384.0,
+    65_536.0,
+    262_144.0,
+    1_048_576.0,
+    4_194_304.0,
+    16_777_216.0,
+    67_108_864.0,
+];
+
 /// Middleware recording the HTTP server metrics defined by the OpenTelemetry
 /// [HTTP semantic conventions].
 ///
@@ -124,11 +138,13 @@ impl Metrics {
                 .u64_histogram(metric::HTTP_SERVER_REQUEST_BODY_SIZE)
                 .with_unit("By")
                 .with_description("Size of HTTP server request bodies.")
+                .with_boundaries(BODY_SIZE_BOUNDARIES.to_vec())
                 .build(),
             response_body_size: meter
                 .u64_histogram(metric::HTTP_SERVER_RESPONSE_BODY_SIZE)
                 .with_unit("By")
                 .with_description("Size of HTTP server response bodies.")
+                .with_boundaries(BODY_SIZE_BOUNDARIES.to_vec())
                 .build(),
             known_methods: None,
         }

--- a/crates/otel/src/semconv.rs
+++ b/crates/otel/src/semconv.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use opentelemetry::Value;
+use percent_encoding::percent_decode_str;
 use salvo_core::http::uri::Scheme;
 use salvo_core::http::{Method, StatusCode, Version};
 use salvo_core::{Request, Response};
@@ -177,7 +178,7 @@ pub(crate) fn redact_query(query: &str) -> Cow<'_, str> {
             redacted.push('&');
         }
         match pair.split_once('=') {
-            Some((key, _)) if REDACTED_QUERY_KEYS.contains(&key) => {
+            Some((key, _)) if is_redacted_query_key(key) => {
                 redacted.push_str(key);
                 redacted.push('=');
                 redacted.push_str(REDACTED_VALUE);
@@ -193,8 +194,20 @@ pub(crate) fn redact_query(query: &str) -> Cow<'_, str> {
 fn needs_redaction(query: &str) -> bool {
     query.split('&').any(|pair| {
         pair.split_once('=')
-            .is_some_and(|(key, _)| REDACTED_QUERY_KEYS.contains(&key))
+            .is_some_and(|(key, _)| is_redacted_query_key(key))
     })
+}
+
+/// Returns whether a query key identifies a value that must be redacted.
+///
+/// Query parsers percent-decode names before exposing them to applications, so
+/// the comparison must do the same. The original spelling is still emitted by
+/// [`redact_query`], preventing an encoded name from changing unexpectedly.
+fn is_redacted_query_key(key: &str) -> bool {
+    REDACTED_QUERY_KEYS.contains(&key)
+        || percent_decode_str(key)
+            .decode_utf8()
+            .is_ok_and(|decoded| REDACTED_QUERY_KEYS.contains(&decoded.as_ref()))
 }
 
 #[cfg(test)]
@@ -345,6 +358,14 @@ mod tests {
         assert_eq!(
             redact_query("AWSAccessKeyId=AKIA&Signature=xyz&X-Goog-Signature=zzz"),
             "AWSAccessKeyId=REDACTED&Signature=REDACTED&X-Goog-Signature=REDACTED"
+        );
+    }
+
+    #[test]
+    fn test_redact_query_redacts_percent_encoded_keys() {
+        assert_eq!(
+            redact_query("s%69g=secret&%53ignature=xyz&X-Goog-%53ignature=zzz"),
+            "s%69g=REDACTED&%53ignature=REDACTED&X-Goog-%53ignature=REDACTED"
         );
     }
 

--- a/crates/otel/src/semconv.rs
+++ b/crates/otel/src/semconv.rs
@@ -1,0 +1,361 @@
+//! Helpers shared by the [`Metrics`](crate::Metrics) and
+//! [`Tracing`](crate::Tracing) middlewares for producing attribute values that
+//! follow the OpenTelemetry semantic conventions.
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use opentelemetry::Value;
+use salvo_core::http::uri::Scheme;
+use salvo_core::http::{Method, StatusCode, Version};
+use salvo_core::{Request, Response};
+
+/// Sentinel the conventions define for an `http.request.method` outside the
+/// known set. This crate also uses it for a `url.scheme` outside its own known
+/// set, for the same reason: keeping a client from choosing the value.
+pub(crate) const OTHER: &str = "_OTHER";
+
+/// Value substituted for a redacted query-string value.
+const REDACTED_VALUE: &str = "REDACTED";
+
+/// Query-string keys whose values the HTTP semantic conventions require to be
+/// redacted before `url.query` is recorded.
+const REDACTED_QUERY_KEYS: [&str; 4] = ["AWSAccessKeyId", "Signature", "sig", "X-Goog-Signature"];
+
+/// A set of method names an application declared known, overriding the default.
+pub(crate) type KnownMethods = HashSet<Arc<str>>;
+
+/// Collects `methods` into the set accepted by [`known_method_value`].
+pub(crate) fn known_methods<I, S>(methods: I) -> KnownMethods
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    methods
+        .into_iter()
+        .map(|method| Arc::from(method.as_ref()))
+        .collect()
+}
+
+/// Returns the `http.request.method` value for `method`, or `None` when the
+/// method is not known and has to be reported as [`OTHER`].
+///
+/// `known` overrides the default set, which is the methods RFC 9110 defines
+/// plus `PATCH` from RFC 5789. Method names are matched case-sensitively, as
+/// the conventions require.
+pub(crate) fn known_method_value(method: &Method, known: Option<&KnownMethods>) -> Option<Value> {
+    match known {
+        Some(known) => known
+            .get(method.as_str())
+            .map(|method| Value::from(Arc::clone(method))),
+        None => default_known_method(method.as_str()).map(Value::from),
+    }
+}
+
+/// Returns `method` itself when it is one of the methods defined by RFC 9110 or
+/// RFC 5789, so the value can be recorded without allocating.
+fn default_known_method(method: &str) -> Option<&'static str> {
+    Some(match method {
+        "GET" => "GET",
+        "HEAD" => "HEAD",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "CONNECT" => "CONNECT",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "PATCH" => "PATCH",
+        _ => return None,
+    })
+}
+
+/// Returns the `url.scheme` value for `scheme`.
+pub(crate) fn scheme_value(scheme: &Scheme) -> Cow<'static, str> {
+    match known_scheme(scheme) {
+        Some(scheme) => Cow::Borrowed(scheme),
+        None => Cow::Owned(scheme.as_str().to_owned()),
+    }
+}
+
+/// Returns the `url.scheme` value for `scheme`, drawn from a bounded set.
+///
+/// A request target may be given in absolute form, and salvo takes the scheme
+/// from it in preference to the one the connection was accepted on, so the
+/// value is client-controlled. Recording it verbatim would let a client open a
+/// time series per scheme it invents, so a scheme a salvo server cannot
+/// actually have spoken is reported as [`OTHER`], the way an unknown method is.
+/// Spans, which are not aggregated by attribute value, keep the scheme sent.
+pub(crate) fn bounded_scheme_value(scheme: &Scheme) -> &'static str {
+    known_scheme(scheme).unwrap_or(OTHER)
+}
+
+/// Returns the schemes a salvo server speaks, so they can be recorded without
+/// allocating.
+fn known_scheme(scheme: &Scheme) -> Option<&'static str> {
+    if scheme == &Scheme::HTTP {
+        Some("http")
+    } else if scheme == &Scheme::HTTPS {
+        Some("https")
+    } else {
+        None
+    }
+}
+
+/// Returns the `network.protocol.version` value for `version`.
+///
+/// The conventions spell the version out as `1.1` or `2`, not in the `HTTP/1.1`
+/// form that [`Version`]'s `Debug` output uses. Versions the conventions do not
+/// name return `None`, so the attribute is left out instead of guessed.
+pub(crate) fn protocol_version(version: Version) -> Option<&'static str> {
+    if version == Version::HTTP_11 {
+        Some("1.1")
+    } else if version == Version::HTTP_2 {
+        Some("2")
+    } else if version == Version::HTTP_3 {
+        Some("3")
+    } else if version == Version::HTTP_10 {
+        Some("1.0")
+    } else if version == Version::HTTP_09 {
+        Some("0.9")
+    } else {
+        None
+    }
+}
+
+/// Returns the `http.route` value for `req`, or `None` when no route matched
+/// and the conventions ask for the attribute to be left out.
+///
+/// Salvo reports a matched route without the leading separator the conventions
+/// expect (`users/{id}`), and reports a goal mounted at the router root as an
+/// empty string — the same value a request that matched nothing carries. The
+/// requested path tells the two apart: `/` reached the root route, and any
+/// other path with nothing matched reached no route at all.
+///
+/// The two cases overlap only for a request to `/` that matched nothing, which
+/// happens when the application has no root route — and then there is no root
+/// traffic for it to be confused with.
+#[cfg(feature = "matched-path")]
+pub(crate) fn route_value(req: &Request) -> Option<String> {
+    let matched_path = req.matched_path();
+    if matched_path.is_empty() {
+        return (req.uri().path() == "/").then(|| "/".to_owned());
+    }
+    let mut route = String::with_capacity(matched_path.len() + 1);
+    route.push('/');
+    route.push_str(matched_path);
+    Some(route)
+}
+
+/// Returns the `http.response.body.size` value when middleware can already tell
+/// what will be sent.
+///
+/// The service finishes a response after middleware returns: a `4xx`/`5xx` with
+/// no body yet is handed to the catcher, and a `HEAD` response has its body
+/// stripped. In both cases the body observable here is not the one that goes on
+/// the wire, so nothing is reported rather than a wrong size.
+pub(crate) fn final_body_size(req: &Request, res: &Response, status: StatusCode) -> Option<u64> {
+    if *req.method() == Method::HEAD {
+        return None;
+    }
+    if (status.is_client_error() || status.is_server_error()) && res.body.is_none() {
+        return None;
+    }
+    res.body.size()
+}
+
+/// Replaces the values of well-known credential-bearing query keys with
+/// `REDACTED`, keeping their keys, as the conventions require before
+/// `url.query` is recorded.
+pub(crate) fn redact_query(query: &str) -> Cow<'_, str> {
+    if !needs_redaction(query) {
+        return Cow::Borrowed(query);
+    }
+    let mut redacted = String::with_capacity(query.len());
+    for (idx, pair) in query.split('&').enumerate() {
+        if idx > 0 {
+            redacted.push('&');
+        }
+        match pair.split_once('=') {
+            Some((key, _)) if REDACTED_QUERY_KEYS.contains(&key) => {
+                redacted.push_str(key);
+                redacted.push('=');
+                redacted.push_str(REDACTED_VALUE);
+            }
+            _ => redacted.push_str(pair),
+        }
+    }
+    Cow::Owned(redacted)
+}
+
+/// Returns whether `query` carries any key whose value has to be redacted, so
+/// the common case can borrow the query instead of rebuilding it.
+fn needs_redaction(query: &str) -> bool {
+    query.split('&').any(|pair| {
+        pair.split_once('=')
+            .is_some_and(|(key, _)| REDACTED_QUERY_KEYS.contains(&key))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo_core::http::ResBody;
+
+    use super::*;
+
+    #[test]
+    fn test_known_method_value_defaults() {
+        for name in [
+            "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
+        ] {
+            let method = Method::from_bytes(name.as_bytes()).expect("valid method");
+            assert_eq!(known_method_value(&method, None), Some(Value::from(name)));
+        }
+    }
+
+    #[test]
+    fn test_known_method_value_is_case_sensitive() {
+        let method = Method::from_bytes(b"get").expect("valid method");
+        assert_eq!(known_method_value(&method, None), None);
+    }
+
+    #[test]
+    fn test_known_method_value_unknown() {
+        let method = Method::from_bytes(b"PROPFIND").expect("valid method");
+        assert_eq!(known_method_value(&method, None), None);
+    }
+
+    #[test]
+    fn test_known_method_value_override() {
+        let known = known_methods(["GET", "PROPFIND"]);
+        let propfind = Method::from_bytes(b"PROPFIND").expect("valid method");
+        assert_eq!(
+            known_method_value(&propfind, Some(&known)),
+            Some(Value::from("PROPFIND"))
+        );
+        // The override replaces the default set instead of extending it.
+        assert_eq!(known_method_value(&Method::POST, Some(&known)), None);
+    }
+
+    #[test]
+    fn test_scheme_value() {
+        assert_eq!(scheme_value(&Scheme::HTTP), "http");
+        assert_eq!(scheme_value(&Scheme::HTTPS), "https");
+        let ws: Scheme = "ws".parse().expect("valid scheme");
+        assert_eq!(scheme_value(&ws), "ws");
+    }
+
+    #[test]
+    fn test_bounded_scheme_value() {
+        assert_eq!(bounded_scheme_value(&Scheme::HTTP), "http");
+        assert_eq!(bounded_scheme_value(&Scheme::HTTPS), "https");
+        // An absolute-form request target lets a client pick the scheme, so it
+        // must not reach a metric dimension verbatim.
+        let invented: Scheme = "salvo-is-great".parse().expect("valid scheme");
+        assert_eq!(bounded_scheme_value(&invented), "_OTHER");
+    }
+
+    #[test]
+    fn test_protocol_version() {
+        assert_eq!(protocol_version(Version::HTTP_09), Some("0.9"));
+        assert_eq!(protocol_version(Version::HTTP_10), Some("1.0"));
+        assert_eq!(protocol_version(Version::HTTP_11), Some("1.1"));
+        assert_eq!(protocol_version(Version::HTTP_2), Some("2"));
+        assert_eq!(protocol_version(Version::HTTP_3), Some("3"));
+    }
+
+    #[cfg(feature = "matched-path")]
+    #[test]
+    fn test_route_value() {
+        let mut req = Request::new();
+        *req.uri_mut() = "/users/42".parse().expect("valid uri");
+        *req.matched_path_mut() = "users/{id}".to_owned();
+        assert_eq!(route_value(&req).as_deref(), Some("/users/{id}"));
+    }
+
+    #[cfg(feature = "matched-path")]
+    #[test]
+    fn test_route_value_root_goal() {
+        let mut req = Request::new();
+        *req.uri_mut() = "/".parse().expect("valid uri");
+        // Salvo reports a goal mounted at the router root with no matched parts.
+        assert_eq!(route_value(&req).as_deref(), Some("/"));
+    }
+
+    #[cfg(feature = "matched-path")]
+    #[test]
+    fn test_route_value_unmatched() {
+        let mut req = Request::new();
+        *req.uri_mut() = "/nowhere".parse().expect("valid uri");
+        assert_eq!(
+            route_value(&req),
+            None,
+            "an unmatched request carries no route rather than its raw path"
+        );
+    }
+
+    #[test]
+    fn test_final_body_size_skips_head() {
+        let mut req = Request::new();
+        *req.method_mut() = Method::HEAD;
+        let mut res = Response::new();
+        res.body = ResBody::Once("Hello".into());
+        assert_eq!(final_body_size(&req, &res, StatusCode::OK), None);
+    }
+
+    #[test]
+    fn test_final_body_size_skips_body_left_to_catcher() {
+        let req = Request::new();
+        let res = Response::new();
+        assert_eq!(
+            final_body_size(&req, &res, StatusCode::NOT_FOUND),
+            None,
+            "an empty error response is filled in after middleware returns"
+        );
+    }
+
+    #[test]
+    fn test_final_body_size_reports_buffered_body() {
+        let req = Request::new();
+        let mut res = Response::new();
+        res.body = ResBody::Once("Hello".into());
+        assert_eq!(final_body_size(&req, &res, StatusCode::OK), Some(5));
+    }
+
+    #[test]
+    fn test_final_body_size_reports_empty_success() {
+        let req = Request::new();
+        let res = Response::new();
+        assert_eq!(final_body_size(&req, &res, StatusCode::NO_CONTENT), Some(0));
+    }
+
+    #[test]
+    fn test_redact_query_keeps_untouched_query_borrowed() {
+        let query = "q=OpenTelemetry&page=2";
+        assert!(matches!(redact_query(query), Cow::Borrowed(_)));
+        assert_eq!(redact_query(query), query);
+    }
+
+    #[test]
+    fn test_redact_query_redacts_known_keys() {
+        assert_eq!(
+            redact_query("q=OpenTelemetry&sig=abc123"),
+            "q=OpenTelemetry&sig=REDACTED"
+        );
+        assert_eq!(
+            redact_query("AWSAccessKeyId=AKIA&Signature=xyz&X-Goog-Signature=zzz"),
+            "AWSAccessKeyId=REDACTED&Signature=REDACTED&X-Goog-Signature=REDACTED"
+        );
+    }
+
+    #[test]
+    fn test_redact_query_leaves_similar_keys_alone() {
+        // `sig` matches exactly; `signal` and `design` only contain it.
+        assert_eq!(redact_query("signal=1&design=2"), "signal=1&design=2");
+    }
+
+    #[test]
+    fn test_redact_query_keeps_valueless_pairs() {
+        assert_eq!(redact_query("sig=a&flag&b=2"), "sig=REDACTED&flag&b=2");
+    }
+}

--- a/crates/otel/src/semconv.rs
+++ b/crates/otel/src/semconv.rs
@@ -127,20 +127,25 @@ pub(crate) fn protocol_version(version: Version) -> Option<&'static str> {
 /// Returns the `http.route` value for `req`, or `None` when no route matched
 /// and the conventions ask for the attribute to be left out.
 ///
+/// Must be called before the middleware hands the request on, because it reads
+/// `res` to tell whether the request was routed at all.
+///
 /// Salvo reports a matched route without the leading separator the conventions
 /// expect (`users/{id}`), and reports a goal mounted at the router root as an
 /// empty string — the same value a request that matched nothing carries. The
-/// requested path tells the two apart: `/` reached the root route, and any
-/// other path with nothing matched reached no route at all.
+/// service settles which one it is before middleware runs: it answers a request
+/// that matched no route by pre-setting `404`/`405`, and leaves the status unset
+/// when it did find one. So an untouched status means the request reached a
+/// route, and `/` with nothing matched is the root route rather than a miss.
 ///
-/// The two cases overlap only for a request to `/` that matched nothing, which
-/// happens when the application has no root route — and then there is no root
-/// traffic for it to be confused with.
+/// A hoop placed behind one that already set a status loses that signal and
+/// reports no route for `/`, leaving the attribute out rather than filling it
+/// with a route the request may not have taken.
 #[cfg(feature = "matched-path")]
-pub(crate) fn route_value(req: &Request) -> Option<String> {
+pub(crate) fn route_value(req: &Request, res: &Response) -> Option<String> {
     let matched_path = req.matched_path();
     if matched_path.is_empty() {
-        return (req.uri().path() == "/").then(|| "/".to_owned());
+        return (res.status_code.is_none() && req.uri().path() == "/").then(|| "/".to_owned());
     }
     let mut route = String::with_capacity(matched_path.len() + 1);
     route.push('/');
@@ -283,7 +288,10 @@ mod tests {
         let mut req = Request::new();
         *req.uri_mut() = "/users/42".parse().expect("valid uri");
         *req.matched_path_mut() = "users/{id}".to_owned();
-        assert_eq!(route_value(&req).as_deref(), Some("/users/{id}"));
+        assert_eq!(
+            route_value(&req, &Response::new()).as_deref(),
+            Some("/users/{id}")
+        );
     }
 
     #[cfg(feature = "matched-path")]
@@ -291,8 +299,25 @@ mod tests {
     fn test_route_value_root_goal() {
         let mut req = Request::new();
         *req.uri_mut() = "/".parse().expect("valid uri");
-        // Salvo reports a goal mounted at the router root with no matched parts.
-        assert_eq!(route_value(&req).as_deref(), Some("/"));
+        // Salvo reports a goal mounted at the router root with no matched parts,
+        // and leaves the status unset for a request it did route.
+        assert_eq!(route_value(&req, &Response::new()).as_deref(), Some("/"));
+    }
+
+    #[cfg(feature = "matched-path")]
+    #[test]
+    fn test_route_value_unmatched_root() {
+        let mut req = Request::new();
+        *req.uri_mut() = "/".parse().expect("valid uri");
+        // The service answers a request that matched nothing by pre-setting the
+        // status before middleware runs.
+        let mut res = Response::new();
+        res.status_code = Some(StatusCode::NOT_FOUND);
+        assert_eq!(
+            route_value(&req, &res),
+            None,
+            "an unmatched request for `/` is not the root route"
+        );
     }
 
     #[cfg(feature = "matched-path")]
@@ -301,7 +326,7 @@ mod tests {
         let mut req = Request::new();
         *req.uri_mut() = "/nowhere".parse().expect("valid uri");
         assert_eq!(
-            route_value(&req),
+            route_value(&req, &Response::new()),
             None,
             "an unmatched request carries no route rather than its raw path"
         );

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -1,23 +1,73 @@
 use std::fmt::{self, Debug, Formatter};
 
-use opentelemetry::trace::{FutureExt, Span, SpanKind, TraceContextExt, Tracer};
+use opentelemetry::trace::{FutureExt, Span, SpanKind, Status, TraceContextExt, Tracer};
 use opentelemetry::{Context, KeyValue, global};
 use opentelemetry_http::HeaderExtractor;
-use opentelemetry_semantic_conventions::{resource, trace};
-use salvo_core::http::headers::{self, HeaderMap, HeaderMapExt, HeaderName, HeaderValue};
+use opentelemetry_semantic_conventions::attribute;
+use salvo_core::http::headers::{HeaderMap, HeaderName, HeaderValue};
 use salvo_core::prelude::*;
 
-/// Middleware for tracing with OpenTelemetry.
+use crate::semconv::{self, KnownMethods, OTHER};
+
+/// Span name used in place of the method when the method is not a known one.
+const OTHER_METHOD_SPAN_NAME: &str = "HTTP";
+
+/// Middleware creating a server span per request, with the attributes the
+/// OpenTelemetry [HTTP semantic conventions] define.
+///
+/// The span is named `{method} {route}` — `GET /users/{id}` — falling back to
+/// the method alone when no route matched, and carries `http.request.method`,
+/// `url.path`, `url.query`, `url.scheme`, `http.route`, `client.address`,
+/// `client.port`, `network.protocol.version`, `http.response.status_code`,
+/// `http.response.body.size` and, for a server error, `error.type`.
+///
+/// The request target is reported split into `url.path` and `url.query` rather
+/// than as one `url.full`, and the query has the values of well-known
+/// credential-bearing keys (`sig`, `Signature`, `AWSAccessKeyId`,
+/// `X-Goog-Signature`) replaced with `REDACTED`, as the conventions require.
+///
+/// `http.route` requires the `matched-path` feature, which is enabled by
+/// default. Through the `salvo` crate, enable its own `matched-path` feature
+/// (also on by default) to turn this one on. A request that matched no route
+/// carries no `http.route` and is named for its method alone.
+///
+/// [HTTP semantic conventions]: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 pub struct Tracing<T> {
     tracer: T,
+    known_methods: Option<KnownMethods>,
 }
 
 impl<T> Tracing<T> {
     /// Create `Tracing` middleware with `tracer`.
     pub fn new(tracer: T) -> Self {
-        Self { tracer }
+        Self {
+            tracer,
+            known_methods: None,
+        }
+    }
+
+    /// Replaces the set of methods reported verbatim in `http.request.method`.
+    ///
+    /// By default only the methods RFC 9110 defines, plus `PATCH` from RFC 5789,
+    /// are reported as themselves; any other method becomes `_OTHER`, with the
+    /// value the client sent recorded in `http.request.method_original`. An
+    /// application that serves further methods — WebDAV's `PROPFIND`, say — can
+    /// list them here.
+    ///
+    /// The set replaces the default rather than extending it, so include every
+    /// method that should be reported verbatim. Names are matched
+    /// case-sensitively.
+    #[must_use]
+    pub fn with_known_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.known_methods = Some(semconv::known_methods(methods));
+        self
     }
 }
+
 impl<T> Debug for Tracing<T>
 where
     T: Debug,
@@ -25,7 +75,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Tracing")
             .field("tracer", &self.tracer)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -42,8 +92,6 @@ where
         res: &mut Response,
         ctrl: &mut FlowCtrl,
     ) {
-        let remote_addr = req.remote_addr().to_string();
-
         // TODO: Will remove after opentelemetry_http updated
         let mut headers = HeaderMap::with_capacity(req.headers().len());
         for (name, value) in req.headers() {
@@ -67,29 +115,69 @@ where
             propagator.extract(&HeaderExtractor(&headers))
         });
 
-        let mut attributes = Vec::new();
+        let mut attributes = Vec::with_capacity(10);
+
+        // A method the instrumentation does not know is reported as `_OTHER`, so
+        // it cannot widen the value space of derived metrics; the value sent is
+        // kept in `http.request.method_original`.
+        let span_method = if let Some(method) =
+            semconv::known_method_value(req.method(), self.known_methods.as_ref())
+        {
+            let span_method = req.method().as_str().to_owned();
+            attributes.push(KeyValue::new(attribute::HTTP_REQUEST_METHOD, method));
+            span_method
+        } else {
+            attributes.push(KeyValue::new(attribute::HTTP_REQUEST_METHOD, OTHER));
+            attributes.push(KeyValue::new(
+                attribute::HTTP_REQUEST_METHOD_ORIGINAL,
+                req.method().as_str().to_owned(),
+            ));
+            OTHER_METHOD_SPAN_NAME.to_owned()
+        };
+
         attributes.push(KeyValue::new(
-            resource::TELEMETRY_SDK_NAME,
-            env!("CARGO_CRATE_NAME"),
+            attribute::URL_PATH,
+            req.uri().path().to_owned(),
         ));
+        if let Some(query) = req.uri().query() {
+            attributes.push(KeyValue::new(
+                attribute::URL_QUERY,
+                semconv::redact_query(query).into_owned(),
+            ));
+        }
         attributes.push(KeyValue::new(
-            resource::TELEMETRY_SDK_VERSION,
-            env!("CARGO_PKG_VERSION"),
+            attribute::URL_SCHEME,
+            semconv::scheme_value(req.scheme()),
         ));
-        attributes.push(KeyValue::new(resource::TELEMETRY_SDK_LANGUAGE, "rust"));
-        attributes.push(KeyValue::new(
-            trace::HTTP_REQUEST_METHOD,
-            req.method().to_string(),
-        ));
-        attributes.push(KeyValue::new(trace::URL_FULL, req.uri().to_string()));
-        attributes.push(KeyValue::new(trace::CLIENT_ADDRESS, remote_addr));
-        attributes.push(KeyValue::new(
-            trace::NETWORK_PROTOCOL_VERSION,
-            format!("{:?}", req.version()),
-        ));
+
+        // The service resolves the route before running middleware, so the span
+        // can be named after it.
+        #[cfg(feature = "matched-path")]
+        let route = semconv::route_value(req);
+        #[cfg(not(feature = "matched-path"))]
+        let route: Option<String> = None;
+        let span_name = match &route {
+            Some(route) => format!("{span_method} {route}"),
+            None => span_method,
+        };
+        if let Some(route) = route {
+            attributes.push(KeyValue::new(attribute::HTTP_ROUTE, route));
+        }
+
+        let remote_addr = req.remote_addr();
+        if let Some(addr) = remote_addr.ip() {
+            attributes.push(KeyValue::new(attribute::CLIENT_ADDRESS, addr.to_string()));
+        }
+        if let Some(port) = remote_addr.port() {
+            attributes.push(KeyValue::new(attribute::CLIENT_PORT, i64::from(port)));
+        }
+        if let Some(version) = semconv::protocol_version(req.version()) {
+            attributes.push(KeyValue::new(attribute::NETWORK_PROTOCOL_VERSION, version));
+        }
+
         let mut span = self
             .tracer
-            .span_builder(format!("{} {}", req.method(), req.uri()))
+            .span_builder(span_name)
             .with_kind(SpanKind::Server)
             .with_attributes(attributes)
             .start_with_context(&self.tracer, &parent_cx);
@@ -112,13 +200,24 @@ where
             };
             span.add_event(event.to_owned(), vec![]);
             span.set_attribute(KeyValue::new(
-                trace::HTTP_RESPONSE_STATUS_CODE,
-                status.as_u16() as i64,
+                attribute::HTTP_RESPONSE_STATUS_CODE,
+                i64::from(status.as_u16()),
             ));
-            if let Some(content_length) = res.headers().typed_get::<headers::ContentLength>() {
+            if let Some(size) = semconv::final_body_size(req, res, status) {
                 span.set_attribute(KeyValue::new(
-                    "http.response.header.content-length",
-                    content_length.0 as i64,
+                    attribute::HTTP_RESPONSE_BODY_SIZE,
+                    size as i64,
+                ));
+            }
+            // Only a server error makes a server span a failure: a `4xx` is a
+            // valid outcome the caller asked for.
+            if status.is_server_error() {
+                span.set_attribute(KeyValue::new(
+                    attribute::ERROR_TYPE,
+                    status.as_str().to_owned(),
+                ));
+                span.set_status(Status::error(
+                    status.canonical_reason().unwrap_or_default().to_owned(),
                 ));
             }
         }
@@ -131,6 +230,7 @@ where
 mod tests {
     use opentelemetry::trace::TracerProvider;
     use opentelemetry::trace::noop::NoopTracerProvider;
+    use salvo_core::test::{ResponseExt, TestClient};
     use salvo_core::{Depot, FlowCtrl, Request, Response};
 
     use super::*;
@@ -148,5 +248,34 @@ mod tests {
         handler
             .handle(&mut req, &mut depot, &mut res, &mut ctrl)
             .await;
+    }
+
+    #[tokio::test]
+    async fn test_tracing_routed_request() {
+        #[handler]
+        async fn hello() -> &'static str {
+            "Hello"
+        }
+
+        let tracer = NoopTracerProvider::new().tracer("test");
+        let router = Router::new()
+            .hoop(Tracing::new(tracer).with_known_methods(["GET"]))
+            .push(Router::with_path("users/{id}").goal(hello));
+        let service = Service::new(router);
+
+        let content = TestClient::get("http://127.0.0.1:8698/users/42?sig=secret")
+            .send(&service)
+            .await
+            .take_string()
+            .await
+            .unwrap();
+        assert_eq!(content, "Hello");
+    }
+
+    #[test]
+    fn test_tracing_debug() {
+        let tracer = NoopTracerProvider::new().tracer("test");
+        let handler = Tracing::new(tracer);
+        assert!(format!("{handler:?}").contains("Tracing"));
     }
 }

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -153,7 +153,7 @@ where
         // The service resolves the route before running middleware, so the span
         // can be named after it.
         #[cfg(feature = "matched-path")]
-        let route = semconv::route_value(req);
+        let route = semconv::route_value(req, res);
         #[cfg(not(feature = "matched-path"))]
         let route: Option<String> = None;
         let span_name = match &route {

--- a/crates/otel/src/tracing.rs
+++ b/crates/otel/src/tracing.rs
@@ -216,9 +216,8 @@ where
                     attribute::ERROR_TYPE,
                     status.as_str().to_owned(),
                 ));
-                span.set_status(Status::error(
-                    status.canonical_reason().unwrap_or_default().to_owned(),
-                ));
+                // The HTTP status code already describes the failure.
+                span.set_status(Status::error(""));
             }
         }
         .with_context(Context::current_with_span(span))

--- a/crates/otel/tests/metrics.rs
+++ b/crates/otel/tests/metrics.rs
@@ -1,0 +1,246 @@
+//! End-to-end check that [`Metrics`] emits what the OpenTelemetry HTTP
+//! semantic conventions define.
+//!
+//! The middleware registers its instruments on the process-global meter
+//! provider, so everything lives in one test function: a second test in this
+//! binary would observe the same provider and the same exported measurements.
+
+use std::collections::BTreeMap;
+
+use opentelemetry::global;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+use salvo_core::http::Method;
+use salvo_core::prelude::*;
+use salvo_core::test::{RequestBuilder, TestClient};
+use salvo_otel::Metrics;
+
+/// Bucket boundaries the conventions recommend for the duration histogram.
+const DURATION_BOUNDARIES: [f64; 14] = [
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
+/// One exported measurement, flattened into what the assertions care about.
+#[derive(Debug)]
+struct Point {
+    attrs: BTreeMap<String, String>,
+    /// `None` for a histogram, whose value is not asserted on.
+    value: Option<i64>,
+}
+
+impl Point {
+    fn attr(&self, key: &str) -> Option<&str> {
+        self.attrs.get(key).map(String::as_str)
+    }
+}
+
+/// One exported instrument.
+#[derive(Debug, Default)]
+struct Instrument {
+    unit: String,
+    bounds: Vec<f64>,
+    points: Vec<Point>,
+}
+
+fn attrs<'a>(pairs: impl Iterator<Item = &'a opentelemetry::KeyValue>) -> BTreeMap<String, String> {
+    pairs
+        .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+        .collect()
+}
+
+fn collect(exporter: &InMemoryMetricExporter) -> BTreeMap<String, Instrument> {
+    let mut collected: BTreeMap<String, Instrument> = BTreeMap::new();
+    for resource_metrics in exporter.get_finished_metrics().expect("exported metrics") {
+        for scope_metrics in resource_metrics.scope_metrics() {
+            assert_eq!(
+                scope_metrics.scope().name(),
+                "salvo-otel",
+                "instruments are reported under the crate's own scope"
+            );
+            for metric in scope_metrics.metrics() {
+                let entry = collected.entry(metric.name().to_owned()).or_default();
+                entry.unit = metric.unit().to_owned();
+                match metric.data() {
+                    AggregatedMetrics::F64(MetricData::Histogram(histogram)) => {
+                        for point in histogram.data_points() {
+                            entry.bounds = point.bounds().collect();
+                            entry.points.push(Point {
+                                attrs: attrs(point.attributes()),
+                                value: None,
+                            });
+                        }
+                    }
+                    AggregatedMetrics::U64(MetricData::Histogram(histogram)) => {
+                        for point in histogram.data_points() {
+                            entry.points.push(Point {
+                                attrs: attrs(point.attributes()),
+                                value: Some(point.sum() as i64),
+                            });
+                        }
+                    }
+                    AggregatedMetrics::I64(MetricData::Sum(sum)) => {
+                        for point in sum.data_points() {
+                            entry.points.push(Point {
+                                attrs: attrs(point.attributes()),
+                                value: Some(point.value()),
+                            });
+                        }
+                    }
+                    other => panic!("unexpected aggregation for {}: {other:?}", metric.name()),
+                }
+            }
+        }
+    }
+    collected
+}
+
+#[handler]
+async fn hello() -> &'static str {
+    "Hello"
+}
+
+#[handler]
+async fn boom() -> Result<(), StatusError> {
+    Err(StatusError::internal_server_error())
+}
+
+#[tokio::test]
+async fn test_metrics_follow_semantic_conventions() {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    global::set_meter_provider(provider.clone());
+
+    let router = Router::new()
+        .hoop(Metrics::new())
+        .push(Router::with_path("users/{id}").goal(hello))
+        .push(Router::with_path("boom").goal(boom));
+    let service = Service::new(router);
+
+    TestClient::get("http://127.0.0.1:8698/users/42?sig=secret&token=abc")
+        .send(&service)
+        .await;
+    TestClient::get("http://127.0.0.1:8698/boom")
+        .send(&service)
+        .await;
+    // An absolute-form request target lets the client pick the scheme, so it
+    // must not reach a metric dimension verbatim.
+    RequestBuilder::new("salvo-is-great://127.0.0.1:8698/users/42", Method::GET)
+        .send(&service)
+        .await;
+
+    provider.force_flush().expect("flush");
+    let collected = collect(&exporter);
+
+    assert_eq!(
+        collected.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec![
+            "http.server.active_requests",
+            "http.server.request.duration",
+            "http.server.response.body.size",
+        ],
+        "only the conventions' instruments are emitted, and no request or error counter"
+    );
+
+    let duration = &collected["http.server.request.duration"];
+    assert_eq!(
+        duration.unit, "s",
+        "the conventions measure duration in seconds"
+    );
+    assert_eq!(
+        duration.bounds, DURATION_BOUNDARIES,
+        "the histogram uses the conventions' recommended buckets"
+    );
+
+    for point in &duration.points {
+        assert!(
+            !point.attrs.contains_key("url.full"),
+            "the request URI must not become a metric dimension: {:?}",
+            point.attrs
+        );
+        assert!(
+            !point.attrs.contains_key("exception.message"),
+            "an error message must not become a metric dimension: {:?}",
+            point.attrs
+        );
+        assert_eq!(point.attr("http.request.method"), Some("GET"));
+        assert_eq!(point.attr("network.protocol.version"), Some("1.1"));
+        assert!(
+            matches!(point.attr("url.scheme"), Some("http" | "_OTHER")),
+            "a scheme a salvo server cannot have spoken is reported as _OTHER, got {:?}",
+            point.attr("url.scheme")
+        );
+    }
+    assert!(
+        duration
+            .points
+            .iter()
+            .any(|point| point.attr("url.scheme") == Some("_OTHER")),
+        "the invented scheme was collapsed, not dropped"
+    );
+
+    let ok = duration
+        .points
+        .iter()
+        .find(|point| {
+            point.attr("http.route") == Some("/users/{id}")
+                && point.attr("url.scheme") == Some("http")
+        })
+        .expect("the matched route template is reported, not the requested path");
+    assert_eq!(ok.attr("http.response.status_code"), Some("200"));
+    assert_eq!(
+        ok.attr("error.type"),
+        None,
+        "a successful request carries no error class"
+    );
+
+    let failed = duration
+        .points
+        .iter()
+        .find(|point| point.attr("http.route") == Some("/boom"))
+        .expect("the failing route is reported");
+    assert_eq!(failed.attr("http.response.status_code"), Some("500"));
+    assert_eq!(
+        failed.attr("error.type"),
+        Some("500"),
+        "the conventions use the status code as the error class"
+    );
+
+    let active = &collected["http.server.active_requests"];
+    assert_eq!(active.unit, "{request}");
+    assert!(!active.points.is_empty(), "the gauge was actually recorded");
+    assert_eq!(
+        active
+            .points
+            .iter()
+            .map(|point| point.value)
+            .sum::<Option<i64>>(),
+        Some(0),
+        "every increment is matched by a decrement once the request finishes"
+    );
+    for point in &active.points {
+        assert_eq!(
+            point.attrs.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["http.request.method", "url.scheme"],
+            "the gauge carries only the attributes the conventions list for it"
+        );
+    }
+
+    let body = &collected["http.server.response.body.size"];
+    assert_eq!(body.unit, "By");
+    assert!(
+        body.points
+            .iter()
+            .all(|point| point.attr("http.route") == Some("/users/{id}")),
+        "the error response body is written after middleware returns, so it is not measured"
+    );
+    assert_eq!(
+        body.points
+            .iter()
+            .map(|point| point.value)
+            .sum::<Option<i64>>(),
+        Some(10),
+        "two responses of \"Hello\", five bytes each"
+    );
+}

--- a/crates/otel/tests/metrics.rs
+++ b/crates/otel/tests/metrics.rs
@@ -184,10 +184,15 @@ async fn test_metrics_follow_semantic_conventions() {
         .points
         .iter()
         .find(|point| {
-            point.attr("http.route") == Some("/users/{id}")
+            point.attr("http.route")
+                == if cfg!(feature = "matched-path") {
+                    Some("/users/{id}")
+                } else {
+                    None
+                }
                 && point.attr("url.scheme") == Some("http")
         })
-        .expect("the matched route template is reported, not the requested path");
+        .expect("the successful HTTP request is reported with the configured route behavior");
     assert_eq!(ok.attr("http.response.status_code"), Some("200"));
     assert_eq!(
         ok.attr("error.type"),
@@ -198,8 +203,16 @@ async fn test_metrics_follow_semantic_conventions() {
     let failed = duration
         .points
         .iter()
-        .find(|point| point.attr("http.route") == Some("/boom"))
-        .expect("the failing route is reported");
+        .find(|point| {
+            point.attr("http.response.status_code") == Some("500")
+                && point.attr("http.route")
+                    == if cfg!(feature = "matched-path") {
+                        Some("/boom")
+                    } else {
+                        None
+                    }
+        })
+        .expect("the failed request is reported with the configured route behavior");
     assert_eq!(failed.attr("http.response.status_code"), Some("500"));
     assert_eq!(
         failed.attr("error.type"),
@@ -230,9 +243,14 @@ async fn test_metrics_follow_semantic_conventions() {
     let body = &collected["http.server.response.body.size"];
     assert_eq!(body.unit, "By");
     assert!(
-        body.points
-            .iter()
-            .all(|point| point.attr("http.route") == Some("/users/{id}")),
+        body.points.iter().all(|point| {
+            point.attr("http.route")
+                == if cfg!(feature = "matched-path") {
+                    Some("/users/{id}")
+                } else {
+                    None
+                }
+        }),
         "the error response body is written after middleware returns, so it is not measured"
     );
     assert_eq!(

--- a/crates/otel/tests/metrics.rs
+++ b/crates/otel/tests/metrics.rs
@@ -133,6 +133,11 @@ async fn test_metrics_follow_semantic_conventions() {
     provider.force_flush().expect("flush");
     let collected = collect(&exporter);
 
+    // `http.route` needs the `matched-path` feature, so the routes the
+    // assertions expect depend on how the crate was built.
+    let users_route = cfg!(feature = "matched-path").then_some("/users/{id}");
+    let boom_route = cfg!(feature = "matched-path").then_some("/boom");
+
     assert_eq!(
         collected.keys().map(String::as_str).collect::<Vec<_>>(),
         vec![
@@ -180,20 +185,22 @@ async fn test_metrics_follow_semantic_conventions() {
         "the invented scheme was collapsed, not dropped"
     );
 
+    // Each point is looked up by something that identifies it on its own in
+    // either feature configuration, so that what is under test — the route — is
+    // asserted rather than assumed.
     let ok = duration
         .points
         .iter()
         .find(|point| {
-            point.attr("http.route")
-                == if cfg!(feature = "matched-path") {
-                    Some("/users/{id}")
-                } else {
-                    None
-                }
+            point.attr("http.response.status_code") == Some("200")
                 && point.attr("url.scheme") == Some("http")
         })
-        .expect("the successful HTTP request is reported with the configured route behavior");
-    assert_eq!(ok.attr("http.response.status_code"), Some("200"));
+        .expect("the successful HTTP request is reported");
+    assert_eq!(
+        ok.attr("http.route"),
+        users_route,
+        "the matched route template is reported, not the requested path"
+    );
     assert_eq!(
         ok.attr("error.type"),
         None,
@@ -203,17 +210,9 @@ async fn test_metrics_follow_semantic_conventions() {
     let failed = duration
         .points
         .iter()
-        .find(|point| {
-            point.attr("http.response.status_code") == Some("500")
-                && point.attr("http.route")
-                    == if cfg!(feature = "matched-path") {
-                        Some("/boom")
-                    } else {
-                        None
-                    }
-        })
-        .expect("the failed request is reported with the configured route behavior");
-    assert_eq!(failed.attr("http.response.status_code"), Some("500"));
+        .find(|point| point.attr("http.response.status_code") == Some("500"))
+        .expect("the failed request is reported");
+    assert_eq!(failed.attr("http.route"), boom_route);
     assert_eq!(
         failed.attr("error.type"),
         Some("500"),
@@ -242,16 +241,16 @@ async fn test_metrics_follow_semantic_conventions() {
 
     let body = &collected["http.server.response.body.size"];
     assert_eq!(body.unit, "By");
+    assert_eq!(
+        body.points.len(),
+        2,
+        "only the two successful responses are measured: the error body is written          after middleware returns"
+    );
     assert!(
-        body.points.iter().all(|point| {
-            point.attr("http.route")
-                == if cfg!(feature = "matched-path") {
-                    Some("/users/{id}")
-                } else {
-                    None
-                }
-        }),
-        "the error response body is written after middleware returns, so it is not measured"
+        body.points
+            .iter()
+            .all(|point| point.attr("http.route") == users_route),
+        "both measured responses came from the same route"
     );
     assert_eq!(
         body.points

--- a/crates/otel/tests/metrics.rs
+++ b/crates/otel/tests/metrics.rs
@@ -26,6 +26,7 @@ struct Point {
     attrs: BTreeMap<String, String>,
     /// `None` for a histogram, whose value is not asserted on.
     value: Option<i64>,
+    bucket_counts: Vec<u64>,
 }
 
 impl Point {
@@ -67,14 +68,17 @@ fn collect(exporter: &InMemoryMetricExporter) -> BTreeMap<String, Instrument> {
                             entry.points.push(Point {
                                 attrs: attrs(point.attributes()),
                                 value: None,
+                                bucket_counts: Vec::new(),
                             });
                         }
                     }
                     AggregatedMetrics::U64(MetricData::Histogram(histogram)) => {
                         for point in histogram.data_points() {
+                            entry.bounds = point.bounds().collect();
                             entry.points.push(Point {
                                 attrs: attrs(point.attributes()),
                                 value: Some(point.sum() as i64),
+                                bucket_counts: point.bucket_counts().collect(),
                             });
                         }
                     }
@@ -83,6 +87,7 @@ fn collect(exporter: &InMemoryMetricExporter) -> BTreeMap<String, Instrument> {
                             entry.points.push(Point {
                                 attrs: attrs(point.attributes()),
                                 value: Some(point.value()),
+                                bucket_counts: Vec::new(),
                             });
                         }
                     }
@@ -260,4 +265,57 @@ async fn test_metrics_follow_semantic_conventions() {
         Some(10),
         "two responses of \"Hello\", five bytes each"
     );
+
+    #[handler]
+    async fn echo(req: &mut Request, res: &mut Response) {
+        let body = req
+            .payload_with_max_size(1_048_576)
+            .await
+            .expect("request body")
+            .clone();
+        res.write_body(body).expect("response body");
+    }
+
+    let service = Service::new(Router::new().hoop(Metrics::new()).goal(echo));
+    for size in [16_384, 65_536, 1_048_576] {
+        TestClient::put("http://127.0.0.1:8698/")
+            .add_header("content-length", size.to_string(), true)
+            .body(vec![b'x'; size])
+            .send(&service)
+            .await;
+    }
+    provider.force_flush().expect("flush body sizes");
+    let collected = collect(&exporter);
+    for name in [
+        "http.server.request.body.size",
+        "http.server.response.body.size",
+    ] {
+        let instrument = &collected[name];
+        assert_eq!(instrument.unit, "By");
+        assert_eq!(
+            instrument.bounds,
+            vec![
+                1_024.0,
+                4_096.0,
+                16_384.0,
+                65_536.0,
+                262_144.0,
+                1_048_576.0,
+                4_194_304.0,
+                16_777_216.0,
+                67_108_864.0,
+            ]
+        );
+        let point = instrument
+            .points
+            .iter()
+            .find(|point| point.attr("http.request.method") == Some("PUT"))
+            .expect("body sizes for the PUT requests");
+        assert_eq!(point.value, Some(16_384 + 65_536 + 1_048_576));
+        assert_eq!(
+            point.bucket_counts,
+            vec![0, 0, 1, 1, 0, 1, 0, 0, 0, 0],
+            "large bodies occupy distinct finite buckets for {name}"
+        );
+    }
 }

--- a/crates/otel/tests/tracing.rs
+++ b/crates/otel/tests/tracing.rs
@@ -75,21 +75,33 @@ fn routed(provider: &SdkTracerProvider) -> Service {
 #[tokio::test]
 async fn test_span_reports_route_and_split_url() {
     let span = trace_request(
-        TestClient::get("http://127.0.0.1:8698/users/42?sig=secret&token=abc"),
+        TestClient::get("http://127.0.0.1:8698/users/42?s%69g=secret&token=abc"),
         routed,
     )
     .await;
 
     assert_eq!(
-        span.name, "GET /users/{id}",
-        "the span is named after the route template, not the requested path"
+        span.name,
+        if cfg!(feature = "matched-path") {
+            "GET /users/{id}"
+        } else {
+            "GET"
+        },
+        "the span name follows the configured route behavior"
     );
     assert_eq!(span.attr("http.request.method"), Some("GET"));
-    assert_eq!(span.attr("http.route"), Some("/users/{id}"));
+    assert_eq!(
+        span.attr("http.route"),
+        if cfg!(feature = "matched-path") {
+            Some("/users/{id}")
+        } else {
+            None
+        }
+    );
     assert_eq!(span.attr("url.path"), Some("/users/42"));
     assert_eq!(
         span.attr("url.query"),
-        Some("sig=REDACTED&token=abc"),
+        Some("s%69g=REDACTED&token=abc"),
         "credential-bearing query values are redacted, other keys are kept"
     );
     assert_eq!(span.attr("url.scheme"), Some("http"));
@@ -132,7 +144,14 @@ async fn test_span_normalizes_unknown_method() {
         Some("PROPFIND"),
         "the value the client sent is kept alongside the normalized one"
     );
-    assert_eq!(span.name, "HTTP /users/{id}");
+    assert_eq!(
+        span.name,
+        if cfg!(feature = "matched-path") {
+            "HTTP /users/{id}"
+        } else {
+            "HTTP"
+        }
+    );
 }
 
 #[tokio::test]
@@ -202,7 +221,21 @@ async fn test_span_names_root_route() {
     })
     .await;
 
-    assert_eq!(span.attr("http.route"), Some("/"));
-    assert_eq!(span.name, "GET /");
+    assert_eq!(
+        span.attr("http.route"),
+        if cfg!(feature = "matched-path") {
+            Some("/")
+        } else {
+            None
+        }
+    );
+    assert_eq!(
+        span.name,
+        if cfg!(feature = "matched-path") {
+            "GET /"
+        } else {
+            "GET"
+        }
+    );
     assert_eq!(span.attr("http.response.status_code"), Some("200"));
 }

--- a/crates/otel/tests/tracing.rs
+++ b/crates/otel/tests/tracing.rs
@@ -1,0 +1,208 @@
+//! End-to-end checks that [`Tracing`] produces the span names and attributes
+//! the OpenTelemetry HTTP semantic conventions define.
+
+use std::collections::BTreeMap;
+
+use opentelemetry::trace::{Status, TracerProvider as _};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SimpleSpanProcessor};
+use salvo_core::http::Method;
+use salvo_core::prelude::*;
+use salvo_core::test::{RequestBuilder, TestClient};
+use salvo_otel::Tracing;
+
+/// One exported span, flattened into what the assertions care about.
+struct Span {
+    name: String,
+    attrs: BTreeMap<String, String>,
+    status: Status,
+}
+
+impl Span {
+    fn attr(&self, key: &str) -> Option<&str> {
+        self.attrs.get(key).map(String::as_str)
+    }
+}
+
+#[handler]
+async fn hello() -> &'static str {
+    "Hello"
+}
+
+#[handler]
+async fn boom() -> Result<(), StatusError> {
+    Err(StatusError::internal_server_error())
+}
+
+/// Runs `request` through the service `build_service` assembles around a
+/// tracer, and returns the single span it produced.
+async fn trace_request<F>(request: RequestBuilder, build_service: F) -> Span
+where
+    F: FnOnce(&SdkTracerProvider) -> Service,
+{
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+        .build();
+    let service = build_service(&provider);
+
+    request.send(&service).await;
+    provider.force_flush().expect("flush");
+
+    let mut spans = exporter.get_finished_spans().expect("exported spans");
+    assert_eq!(spans.len(), 1, "one server span per request");
+    let span = spans.remove(0);
+    Span {
+        name: span.name.into_owned(),
+        attrs: span
+            .attributes
+            .iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect(),
+        status: span.status,
+    }
+}
+
+/// The service most of these tests run against: routed, tracing on the router.
+fn routed(provider: &SdkTracerProvider) -> Service {
+    Service::new(
+        Router::new()
+            .hoop(Tracing::new(provider.tracer("test")))
+            .push(Router::with_path("users/{id}").goal(hello))
+            .push(Router::with_path("boom").goal(boom)),
+    )
+}
+
+#[tokio::test]
+async fn test_span_reports_route_and_split_url() {
+    let span = trace_request(
+        TestClient::get("http://127.0.0.1:8698/users/42?sig=secret&token=abc"),
+        routed,
+    )
+    .await;
+
+    assert_eq!(
+        span.name, "GET /users/{id}",
+        "the span is named after the route template, not the requested path"
+    );
+    assert_eq!(span.attr("http.request.method"), Some("GET"));
+    assert_eq!(span.attr("http.route"), Some("/users/{id}"));
+    assert_eq!(span.attr("url.path"), Some("/users/42"));
+    assert_eq!(
+        span.attr("url.query"),
+        Some("sig=REDACTED&token=abc"),
+        "credential-bearing query values are redacted, other keys are kept"
+    );
+    assert_eq!(span.attr("url.scheme"), Some("http"));
+    assert_eq!(span.attr("network.protocol.version"), Some("1.1"));
+    assert_eq!(span.attr("http.response.status_code"), Some("200"));
+    assert_eq!(span.attr("http.response.body.size"), Some("5"));
+    assert_eq!(span.attr("error.type"), None);
+    assert_eq!(span.status, Status::Unset);
+
+    assert_eq!(
+        span.attr("url.full"),
+        None,
+        "the full URI is no longer recorded"
+    );
+    for key in [
+        "telemetry.sdk.name",
+        "telemetry.sdk.version",
+        "telemetry.sdk.language",
+    ] {
+        assert_eq!(
+            span.attr(key),
+            None,
+            "{key} describes the resource, not a span"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_span_normalizes_unknown_method() {
+    let propfind = Method::from_bytes(b"PROPFIND").expect("valid method");
+    let span = trace_request(
+        RequestBuilder::new("http://127.0.0.1:8698/users/42", propfind),
+        routed,
+    )
+    .await;
+
+    assert_eq!(span.attr("http.request.method"), Some("_OTHER"));
+    assert_eq!(
+        span.attr("http.request.method_original"),
+        Some("PROPFIND"),
+        "the value the client sent is kept alongside the normalized one"
+    );
+    assert_eq!(span.name, "HTTP /users/{id}");
+}
+
+#[tokio::test]
+async fn test_span_marks_server_error() {
+    let span = trace_request(TestClient::get("http://127.0.0.1:8698/boom"), routed).await;
+
+    assert_eq!(span.attr("http.response.status_code"), Some("500"));
+    assert_eq!(span.attr("error.type"), Some("500"));
+    assert_eq!(
+        span.attr("http.response.body.size"),
+        None,
+        "the error body is written after middleware returns, so its size is unknown here"
+    );
+    assert!(
+        matches!(span.status, Status::Error { .. }),
+        "a server error fails the span, got {:?}",
+        span.status
+    );
+}
+
+#[tokio::test]
+async fn test_span_without_matched_route() {
+    let span = trace_request(
+        TestClient::get("http://127.0.0.1:8698/nowhere"),
+        |provider| {
+            // The router hoop never runs when nothing matches, so trace from the service.
+            Service::new(Router::new().push(Router::with_path("users/{id}").goal(hello)))
+                .hoop(Tracing::new(provider.tracer("test")))
+        },
+    )
+    .await;
+
+    assert_eq!(
+        span.name, "GET",
+        "with no route to name it after, the span is named for the method alone"
+    );
+    assert_eq!(
+        span.attr("http.route"),
+        None,
+        "the conventions leave the attribute out rather than filling it with the path"
+    );
+    assert_eq!(span.attr("url.path"), Some("/nowhere"));
+    assert_eq!(span.attr("http.response.status_code"), Some("404"));
+    assert_eq!(
+        span.attr("error.type"),
+        None,
+        "a client error is a valid outcome for a server span"
+    );
+    assert_eq!(
+        span.attr("http.response.body.size"),
+        None,
+        "the 404 body is written after middleware returns, so its size is unknown here"
+    );
+    assert_eq!(span.status, Status::Unset);
+}
+
+#[tokio::test]
+async fn test_span_names_root_route() {
+    let span = trace_request(TestClient::get("http://127.0.0.1:8698/"), |provider| {
+        // A goal mounted at the router root matches with no path parts, which
+        // salvo reports the same way it reports a request that matched nothing.
+        Service::new(
+            Router::new()
+                .hoop(Tracing::new(provider.tracer("test")))
+                .goal(hello),
+        )
+    })
+    .await;
+
+    assert_eq!(span.attr("http.route"), Some("/"));
+    assert_eq!(span.name, "GET /");
+    assert_eq!(span.attr("http.response.status_code"), Some("200"));
+}

--- a/crates/otel/tests/tracing.rs
+++ b/crates/otel/tests/tracing.rs
@@ -239,3 +239,26 @@ async fn test_span_names_root_route() {
     );
     assert_eq!(span.attr("http.response.status_code"), Some("200"));
 }
+
+#[tokio::test]
+async fn test_span_without_root_route() {
+    let span = trace_request(TestClient::get("http://127.0.0.1:8698/"), |provider| {
+        // No root goal, so `/` matches nothing — and salvo reports that with the
+        // same empty matched path a root goal would have produced.
+        Service::new(Router::new().push(Router::with_path("users/{id}").goal(hello)))
+            .hoop(Tracing::new(provider.tracer("test")))
+    })
+    .await;
+
+    assert_eq!(
+        span.attr("http.route"),
+        None,
+        "an unmatched request for `/` is not the root route"
+    );
+    assert_eq!(span.name, "GET");
+    assert_eq!(
+        span.attr("http.response.status_code"),
+        Some("405"),
+        "the root router consumed the path but had no goal for it"
+    );
+}

--- a/crates/otel/tests/tracing.rs
+++ b/crates/otel/tests/tracing.rs
@@ -165,10 +165,10 @@ async fn test_span_marks_server_error() {
         None,
         "the error body is written after middleware returns, so its size is unknown here"
     );
-    assert!(
-        matches!(span.status, Status::Error { .. }),
-        "a server error fails the span, got {:?}",
-        span.status
+    assert_eq!(
+        span.status,
+        Status::error(""),
+        "an HTTP server error fails the span without a redundant status description"
     );
 }
 

--- a/crates/salvo/Cargo.toml
+++ b/crates/salvo/Cargo.toml
@@ -136,7 +136,7 @@ aws-lc-rs = [
     "salvo-proxy?/aws-lc-rs",
 ]
 ring = ["salvo_core/ring", "salvo-proxy?/ring"]
-matched-path = ["salvo_core/matched-path"]
+matched-path = ["salvo_core/matched-path", "salvo-otel?/matched-path"]
 tls12 = ["salvo_core/tls12"]
 tus = ["dep:salvo-tus"]
 


### PR DESCRIPTION
## What

`salvo-otel` invented its own metric names and used the request URI as a metric
dimension. This makes both middlewares follow the OpenTelemetry [HTTP semantic
conventions][semconv]. It is a **breaking change** for anyone with dashboards or
alerts on the old names.

## Why

Three problems, in increasing order of severity:

1. **Non-standard names.** `salvo_request_count`, `salvo_error_count` and
   `salvo_request_duration_ms` match nothing a backend, dashboard or exporter
   expects, and the histogram measured milliseconds where the conventions and
   Prometheus both use seconds.

2. **Unbounded metric dimensions.** `url.full` put the whole URI — query string
   included — into a label. Every distinct URI opened its own time series, and
   query parameters holding access tokens, signed-URL signatures or session
   identifiers were copied into metric storage. `exception.message` was a label
   too, and error messages are unbounded strings.

3. **A label-set bug.** `exception.message` was appended to `labels` *before*
   `request_count.add` and `duration.record` but *after* `error_count.add`, so a
   failed request produced a four-label point on two metrics and a three-label
   point on the third. On the same metric, failures and successes carried
   different label sets.

## What changed

### `Metrics`

| Was | Is |
|-----|-----|
| `salvo_request_duration_ms` (ms) | `http.server.request.duration` (**seconds**, with the conventions' bucket advice) |
| `salvo_request_count` | *gone* — the histogram's count already carries it (`http_server_request_duration_seconds_count`) |
| `salvo_error_count` | *gone* — filter on `error.type` / `http.response.status_code` |
| — | `http.server.active_requests` |
| — | `http.server.request.body.size`, `http.server.response.body.size` |

The last three were already promised by the crate's own documentation but never
implemented.

Attributes are now `http.request.method`, `url.scheme`, `http.route`,
`http.response.status_code`, `network.protocol.version` and `error.type`. Every
one is drawn from a bounded set, so the series count is proportional to the
number of routes rather than to traffic:

- the **matched route template** (`/users/{id}`) replaces the requested URI;
- **`error.type`** carries the status code of a server error, replacing the
  error message;
- an unknown **request method** collapses to `_OTHER` (widen the set with
  `Metrics::with_known_methods`, which the conventions require instrumentations
  to offer);
- an unknown **scheme** collapses to `_OTHER` as well. A request target may be
  given in absolute form and salvo prefers its scheme over the connection's, so
  this value is client-controlled too. Spans still record what was sent.

`http.server.active_requests` is decremented from a drop guard, so a client
disconnect or a timeout — which drops the request future mid-await — does not
leak the increment and leave the gauge drifting upwards for the life of the
process.

### `Tracing`

- Spans are named `{method} {route}` (`GET /users/{id}`) instead of
  `{method} {uri}`, which made every distinct URI its own span name.
- `url.full` → `url.path` + `url.query` + `url.scheme`, with the query's `sig`,
  `Signature`, `AWSAccessKeyId` and `X-Goog-Signature` values replaced by
  `REDACTED`, as the conventions require.
- `http.route` added.
- `network.protocol.version` reports `1.1`/`2` rather than the `HTTP/1.1` form
  that `Version`'s `Debug` produces.
- An unknown method is `_OTHER`, with what the client sent kept in
  `http.request.method_original`.
- A `5xx` sets `error.type` and an error span status; a `4xx` does not, since it
  is a valid outcome for a server span.
- `http.response.header.content-length` → `http.response.body.size`.
- `client.address` reports the peer IP with the port split into `client.port`,
  instead of salvo's `socket://198.51.100.4:54321` display form.
- The `telemetry.sdk.*` attributes are gone from every span: they describe the
  resource, and the SDK already reports them there.

### Feature wiring

`http.route` comes from `Request::matched_path`, so `salvo-otel` gained a
`matched-path` feature, on by default, that enables `salvo_core/matched-path`.
Through the `salvo` crate it follows that crate's own `matched-path` feature,
which is already in `default` and `full`.

## Notes

Two behaviours worth a second look from reviewers:

- **Root route.** Salvo reports a goal mounted at the router root and a request
  that matched nothing with the same empty `matched_path`. Rather than leave the
  most common route in most applications without an `http.route`, a request for
  `/` is reported as the root route. The two cases overlap only when an
  application has no root route at all — and then there is no root traffic for
  its `/` misses to be confused with.
- **Body sizes** are recorded only when the size is known before the response is
  written. A streamed body, a `HEAD` response, and an error response whose body
  the catcher fills in *after* middleware returns are skipped rather than
  recorded as zero.

## Testing

`cargo test -p salvo-otel` — 31 tests, including two new integration suites that
drive real requests through an SDK meter/tracer provider with in-memory
exporters and assert on what actually comes out: instrument names, units, bucket
boundaries, the exact attribute sets, the absence of `url.full` and
`exception.message`, that `active_requests` balances to zero, and that an
invented absolute-form scheme is collapsed rather than recorded.

`cargo clippy` is clean with and without default features; `cargo +nightly fmt`
and `cargo doc` are clean.

[semconv]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
